### PR TITLE
Fixed #55 Disabled body scrollwing while modal open

### DIFF
--- a/src/css/core/_modal.styl
+++ b/src/css/core/_modal.styl
@@ -1,0 +1,2 @@
+body.-modal
+    overflow: hidden

--- a/src/css/core/index.styl
+++ b/src/css/core/index.styl
@@ -4,6 +4,7 @@
 
 @require '_normalize'
 @require '_print'
+@require '_modal'
 @require '_icons'
 @require 'code'
 @require 'images'

--- a/src/factories/PopupManager.js
+++ b/src/factories/PopupManager.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { isKey } from '@inkline/inkline/src/helpers/index';
+import { addClass, isKey, removeClass } from '@inkline/inkline/src/helpers/index';
 
 export class PopupManager {
     instances = {};
@@ -48,12 +48,16 @@ export class PopupManager {
         } else {
             this.modalStack.push({ id: id });
         }
+
+        addClass(window.document.body, '-modal');
     }
 
     closeModal(id) {
         const modalIndex = this.modalStack.findIndex((m) => m.id === id);
 
         this.modalStack.splice(modalIndex, 1);
+
+        removeClass(window.document.body, '-modal');
     }
 
     getTopPopup() {

--- a/tests/unit/factories/PopupManager.spec.js
+++ b/tests/unit/factories/PopupManager.spec.js
@@ -158,6 +158,12 @@ describe('Factories', () => {
                 expect(popupManager.modalStack.length).toEqual(1);
                 expect(popupManager.modalStack[0].$el.style.zIndex).toEqual(1000);
             });
+
+            it('should add ".-modal" modifier class to document body', () => {
+                popupManager.openModal('abc');
+
+                expect(window.document.body.classList.contains('-modal')).toEqual(true);
+            });
         });
 
         describe('closeModal()', () => {
@@ -166,6 +172,13 @@ describe('Factories', () => {
                 popupManager.closeModal('abc');
 
                 expect(popupManager.modalStack.length).toEqual(0);
+            });
+
+            it('should remove ".-modal" modifier class from document body', () => {
+                popupManager.openModal('abc');
+                popupManager.closeModal('abc');
+
+                expect(window.document.body.classList.contains('-modal')).toEqual(false);
             });
         });
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for #55 

* **What is the current behavior?** (You can also link to an open issue here)

Document body is scrolling behind the open modal.

* **What is the new behavior?** (If this is a feature change)

Document body now has `overflow: hidden` to prevent scrolling. Also, a new `.-modal` modifier class is being added to it.