### PR TITLE
#84 input append prepend improvement

### DIFF
--- a/src/components/Input/css/_sizes.scss
+++ b/src/components/Input/css/_sizes.scss
@@ -20,27 +20,23 @@
         > .form-input-append {
             font-size: $_font-size;
 
-            @if $border-radius-enabled {
-                border-radius: $_border-radius;
-            }
-
-            > * {
+            > span {
                 padding: $_padding;
             }
         }
 
-        > .form-input-prepend,
-        > .form-input-prepend > *,
-        > .form-input-append > * + * {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-        }
+        @if $border-radius-enabled {
+            > .form-input-prepend,
+            > .form-input-prepend > *:first-child {
+                border-top-left-radius: $_border-radius;
+                border-bottom-left-radius: $_border-radius;
+            }
 
-        > .form-input-append,
-        > .form-input-append > *,
-        > .form-input-prepend > * + * {
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
+            > .form-input-append,
+            > .form-input-append > *:last-child {
+                border-top-right-radius: $_border-radius;
+                border-bottom-right-radius: $_border-radius;
+            }
         }
     }
 }

--- a/src/components/Input/style.scss
+++ b/src/components/Input/style.scss
@@ -169,7 +169,6 @@
 
     &.-prepended .form-input {
         @include form-input-selector() {
-            display: block;
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
         }
@@ -183,15 +182,15 @@
     }
 
     > .form-input-prepend,
-    > .form-input-prepend > * {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-    }
+    > .form-input-append {
+        display: flex;
+        flex-flow: row nowrap;
+        align-items: stretch;
 
-    > .form-input-append,
-    > .form-input-append > * {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        > * {
+            flex: auto 1 0;
+            border-radius: 0;
+        }
     }
 
     @extend .form-input-group.-md;

--- a/src/components/Navbar/style.scss
+++ b/src/components/Navbar/style.scss
@@ -41,7 +41,6 @@
 
                             > .item {
                                 width: 100%;
-                                display: block;
                             }
                         }
                     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Changed append and prepend to use flexbox
- Input append and prepend only has border radius for first, and respectively, last item.
- No longer changing display style for collapsed nav item.


* **What is the current behavior?** (You can also link to an open issue here)
- Only one input append and prepend is supported properly. 
- Append and prepend elements have incorrect height. 
- Append and prepend elements have incorrect border-radius

* **What is the new behavior?** (If this is a feature change)
- Input append and prepend now properly supports multiple elements.


