### PR TITLE
Navbar collapse on click outside

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ install:
 - npm install
 - lerna exec npm install
 - lerna link
+- lerna run build
 script:
-- lerna run lint --stream
-- lerna run build --stream
-after_script:
+- lerna run lint
 - lerna run test
 - lerna run coveralls --scope @inkline/inkline
 env:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna exec npm install && lerna link",
+    "test": "lerna run test --parallel",
     "dev": "lerna run dev --parallel",
     "generate": "lerna run generate --scope @inkline/docs"
   },

--- a/packages/docs/jest.config.js
+++ b/packages/docs/jest.config.js
@@ -22,6 +22,7 @@ module.exports = {
         '^@components/(.*)$': '<rootDir>/components/$1',
         '^@/(.*)$': '<rootDir>/$1',
         '^~/(.*)$': '<rootDir>/$1',
+        '^@inkline/inkline/(.*)$': '<rootDir>/node_modules/@inkline/inkline/$1',
         '^vue$': 'vue/dist/vue.common.js'
     },
     snapshotSerializers: ["jest-serializer-vue"],

--- a/packages/docs/package-lock.json
+++ b/packages/docs/package-lock.json
@@ -1129,11 +1129,10 @@
       }
     },
     "@inkline/inkline": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@inkline/inkline/-/inkline-1.20.2.tgz",
-      "integrity": "sha512-F/nDoC+Eq4YZ7C06aAIq7I+lQfsitYJyrGftwOVO93ZXvvhjjt47kZ+yIlUomdC9ipWS4rW3Zv3QRZZ5gKPOJg==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/@inkline/inkline/-/inkline-1.20.3.tgz",
+      "integrity": "sha512-ghN9c3qEUls0gWVytKdnM0fdXzNSLEBki1e03BNBLTyPzNCUySGgfJdLuge4hJoYVUysMAAzMYANymNg/fvUzw==",
       "requires": {
-        "core-js": "^3.6.4",
         "fuse.js": "^3.4.6",
         "popper.js": "^1.16.1"
       }
@@ -6848,7 +6847,8 @@
     "core-js": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.6.4",

--- a/packages/docs/pages/docs/components/navbar.md
+++ b/packages/docs/pages/docs/components/navbar.md
@@ -430,7 +430,7 @@ Sometimes, it's necessary to control whether the Navbar is collapsed or not prog
 <i-button v-on:click="collapsed = !collapsed">
     Toggle Collapsed
 </i-button>
-<i-navbar :collapse="true" v-model="collapsed">
+<i-navbar :collapse="true" v-model="collapsed" :collapse-on-click-outside="false">
     <i-navbar-brand href="https://inkline.io" onclick="return false;">Navbar</i-navbar-brand>
     <i-navbar-items>
         <i-nav>
@@ -445,7 +445,7 @@ Sometimes, it's necessary to control whether the Navbar is collapsed or not prog
 ~~~html
 <i-button @click="collapsed = !collapsed">Toggle Collapsed</i-button>
 
-<i-navbar :collapse="true">
+<i-navbar :collapse="true" v-model="collapsed" :collapse-on-click-outside="false">
     <i-navbar-brand :to="{ name: 'index' }">Navbar</i-navbar-brand>
     <i-navbar-items>
         <i-nav>
@@ -484,7 +484,14 @@ Sometimes, it's necessary to control whether the Navbar is collapsed or not prog
                 </tr>
                 <tr>
                     <td>collapseOnClick</td>
-                    <td>Collapses the navbar when clicking a navbar item.</td>
+                    <td>Toggles collapsing the navbar when clicking a navbar item if collapsed.</td>
+                    <td><code>Boolean</code></td>
+                    <td><code>true</code>, <code>false</code></td>
+                    <td><code>true</code></td>
+                </tr>
+                <tr>
+                    <td>collapseOnClickOutside</td>
+                    <td>Toggles collapsing the navbar when clicking outside the navbar if collapsed.</td>
                     <td><code>Boolean</code></td>
                     <td><code>true</code>, <code>false</code></td>
                     <td><code>true</code></td>

--- a/packages/inkline/package.json
+++ b/packages/inkline/package.json
@@ -7,7 +7,7 @@
     "build": "npm run build:inkline && npm run dist",
     "build:inkline": "vue-cli-service build --target lib --name Inkline src/main.js",
     "lint": "npm run lint:script && npm run lint:style",
-    "coveralls": "cat ../../coverage/lcov.info | coveralls",
+    "coveralls": "cat coverage/lcov.info | coveralls",
     "dev": "vue-cli-service serve",
     "dist": "node ./scripts/dist.js",
     "lint:script": "vue-cli-service lint",

--- a/packages/inkline/src/components/Navbar/script.js
+++ b/packages/inkline/src/components/Navbar/script.js
@@ -7,6 +7,8 @@ import AttributesProviderMixin from '@inkline/inkline/src/mixins/components/prov
 import ClassesProviderMixin from '@inkline/inkline/src/mixins/components/providers/ClassesProviderMixin';
 import CollapsibleProviderMixin from '@inkline/inkline/src/mixins/components/providers/CollapsibleProviderMixin';
 
+import ClickOutside from '@inkline/inkline/src/directives/click-outside';
+
 import SizePropertyMixin from '@inkline/inkline/src/mixins/components/properties/SizePropertyMixin';
 import VariantPropertyMixin from '@inkline/inkline/src/mixins/components/properties/VariantPropertyMixin';
 
@@ -27,8 +29,15 @@ export default {
         IColumn,
         IHamburgerMenu
     },
+    directives: {
+        ClickOutside
+    },
     props: {
         collapseOnClick: {
+            type: Boolean,
+            default: true
+        },
+        collapseOnClickOutside: {
             type: Boolean,
             default: true
         },
@@ -42,16 +51,21 @@ export default {
         }
     },
     methods: {
-        onItemClick() {
+        onClickItem() {
             if (this.collapseOnClick && this.collapsed) {
+                this.setCollapse(false);
+            }
+        },
+        onClickOutside() {
+            if (this.collapseOnClickOutside && this.collapsed) {
                 this.setCollapse(false);
             }
         }
     },
     created() {
-        this.$on('item-click', this.onItemClick);
+        this.$on('item-click', this.onClickItem);
     },
     beforeDestroy() {
-        this.$off('item-click', this.onItemClick);
+        this.$off('item-click', this.onClickItem);
     }
 };

--- a/packages/inkline/src/components/Navbar/template.html
+++ b/packages/inkline/src/components/Navbar/template.html
@@ -1,6 +1,7 @@
 <div class="navbar"
      :class="classes['root']"
-     v-bind="attributes">
+     v-bind="attributes"
+     v-click-outside="onClickOutside">
     <i-container :fluid="fluid">
         <i-row>
             <i-column :xs="true">

--- a/packages/inkline/tests/unit/components/Navbar.spec.js
+++ b/packages/inkline/tests/unit/components/Navbar.spec.js
@@ -30,6 +30,13 @@ describe('Components', () => {
                 });
             });
 
+            describe('collapseOnClickOutside', () => {
+                it('should be defined', () => {
+                    expect(wrapper.vm.collapseOnClickOutside).toBeDefined();
+                    expect(wrapper.vm.collapseOnClickOutside).toEqual(true);
+                });
+            });
+
             describe('fluid', () => {
                 it('should be defined', () => {
                     expect(wrapper.vm.fluid).toBeDefined();
@@ -46,9 +53,9 @@ describe('Components', () => {
         });
 
         describe('methods', () => {
-            describe('onItemClick()', () => {
+            describe('onClickItem()', () => {
                 it('should be defined', () => {
-                    expect(wrapper.vm.onItemClick).toBeDefined();
+                    expect(wrapper.vm.onClickItem).toBeDefined();
                 });
 
                 it('should not set collapsed to false if not collapseOnClick and collapsed', () => {
@@ -57,7 +64,7 @@ describe('Components', () => {
                     wrapper.setProps({ collapseOnClick: false });
                     wrapper.setData({ collapsed: false });
 
-                    wrapper.vm.onItemClick();
+                    wrapper.vm.onClickItem();
 
                     expect(spy).not.toHaveBeenCalled();
                 });
@@ -68,7 +75,36 @@ describe('Components', () => {
                     wrapper.setProps({ collapseOnClick: true });
                     wrapper.setData({ collapsed: true });
 
-                    wrapper.vm.onItemClick();
+                    wrapper.vm.onClickItem();
+
+                    expect(spy).toHaveBeenCalled();
+                    expect(spy).toHaveBeenCalledWith(false);
+                });
+            });
+
+            describe('onClickOutside()', () => {
+                it('should be defined', () => {
+                    expect(wrapper.vm.onClickOutside).toBeDefined();
+                });
+
+                it('should not set collapsed to false if not collapseOnClick and collapsed', () => {
+                    const spy = jest.spyOn(wrapper.vm, 'setCollapse');
+
+                    wrapper.setProps({ collapseOnClickOutside: false });
+                    wrapper.setData({ collapsed: false });
+
+                    wrapper.vm.onClickOutside();
+
+                    expect(spy).not.toHaveBeenCalled();
+                });
+
+                it('should set collapsed to false if collapseOnClick and collapsed', () => {
+                    const spy = jest.spyOn(wrapper.vm, 'setCollapse');
+
+                    wrapper.setProps({ collapseOnClickOutside: true });
+                    wrapper.setData({ collapsed: true });
+
+                    wrapper.vm.onClickOutside();
 
                     expect(spy).toHaveBeenCalled();
                     expect(spy).toHaveBeenCalledWith(false);
@@ -83,7 +119,7 @@ describe('Components', () => {
                 wrapper.vm.created();
 
                 expect(spy).toHaveBeenCalled();
-                expect(spy).toHaveBeenCalledWith('item-click', wrapper.vm.onItemClick);
+                expect(spy).toHaveBeenCalledWith('item-click', wrapper.vm.onClickItem);
             });
         });
 
@@ -94,7 +130,7 @@ describe('Components', () => {
                 wrapper.vm.beforeDestroy();
 
                 expect(spy).toHaveBeenCalled();
-                expect(spy).toHaveBeenCalledWith('item-click', wrapper.vm.onItemClick);
+                expect(spy).toHaveBeenCalledWith('item-click', wrapper.vm.onClickItem);
             });
         });
     });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Navbar does not collapse when clicking outside of it.


* **What is the new behavior?** (If this is a feature change)
Navbar collapses when clicking outside of it. This uses the `v-click-outside` custom directive and can be controlled using the `collapseOnClickOutside` property.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If using manual collapse via v-model, use set `:collapse-on-click-outside="false"` to avoid double toggling.