### PR TITLE
Datatable $scopedSlots fix

### DIFF
--- a/packages/docs/pages/docs/components/dashboard/datatable/introduction.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/introduction.md
@@ -38,7 +38,7 @@ export default {
 }
 ~~~
 
-<i-alert variant="info" class="-code">
+<i-alert variant="info" class="-code _margin-top-1">
 <template v-slot:icon><i-icon icon="info"></i-icon></template>
 
 Each data row should also have a unique `id` field, which will be used internally for identifying the row during rendering.

--- a/packages/inkline/src/components/Datatable/script.js
+++ b/packages/inkline/src/components/Datatable/script.js
@@ -210,7 +210,8 @@ export default {
             return to > this.rowsLength ? this.rowsLength : to;
         },
         hasExpandableRows() {
-            return Boolean(this.$slots.expand) || Boolean(this.$scopedSlots.expand);
+            return Boolean(this.$slots && this.$slots.expand) ||
+                Boolean(this.$scopedSlots && this.$scopedSlots.expand);
         }
     },
     methods: {

--- a/packages/inkline/src/components/Datatable/style.scss
+++ b/packages/inkline/src/components/Datatable/style.scss
@@ -102,6 +102,10 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+
+        @include breakpoint-down(xs) {
+            flex-direction: column;
+        }
     }
 
     .header-wrapper {
@@ -121,6 +125,23 @@
 
         .filtering-input {
             margin-left: auto;
+        }
+
+        @include breakpoint-down(lg) {
+            .filtering-input {
+                margin-left: $spacer;
+            }
+        }
+
+        @include breakpoint-down(xs) {
+            .pagination-select {
+                margin-bottom: $spacer;
+            }
+
+            .filtering-input {
+                margin-left: 0;
+                width: 100%;
+            }
         }
     }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
There's an error on the current version of Safari that causes `this.$scopedSlots` to be undefined on page load.


* **What is the new behavior?** (If this is a feature change)
DataTable checks whether `this.$scopedSlots` is defined or not in computed property.