### PR TITLE
Select mobile scoped slots ssr fix

### DIFF
--- a/packages/docs/pages/docs/components/dashboard/datatable/expanding.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/expanding.md
@@ -14,7 +14,7 @@ To be able to expand a Data Table entry, you will need to provide an `expand` sc
     </template>
 </i-datatable>
 
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -29,7 +29,7 @@ To be able to expand a Data Table entry, you will need to provide an `expand` sc
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {

--- a/packages/docs/pages/docs/components/dashboard/datatable/filtering.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/filtering.md
@@ -5,17 +5,15 @@ Inkline's Data Table rows are easily and efficiently filtered using a fuzzy sear
 Filtering is enabled by default and can be changed using the `filterable` attribute if needed.
 
 <i-code-preview title="Data Table Default Filtering" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
-
 <i-datatable :columns="columns" :rows="rows" />
-
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -66,17 +64,15 @@ export default {
 ~~~
 
 <i-code-preview title="Data Table Selective Filtering" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
-
 <i-datatable :columns="selectiveFilteringColumns" :rows="rows" :filtering="filteringConfig" />
-
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" :filtering="filtering" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -111,7 +107,7 @@ export default {
 Filtering can be configured by providing an object for the `filtering` attribute. Inkline uses <a href="https://fusejs.io" rel="nofollow">Fuse.js</a> for providing a fuzzy search implementation. 
 
 <i-alert variant="info" class="-code">
-<template v-slot:icon><i-icon icon="info"></i-icon></template>
+<template slot="icon"><i-icon icon="info"></i-icon></template>
 
 The <a href="https://fusejs.io" rel="nofollow">Fuse.js Configuration</a> can be fine-tuned using the `fuse` field in the filtering configuration.
 
@@ -155,7 +151,7 @@ Filtering can be handled asynchronously by setting the `async` attribute to `tru
 This will tell the DataTable component to only display the rows and let the pagination and filtering handling be done externally using the `update` event. 
 
 <i-alert variant="info" class="-code">
-<template v-slot:icon><i-icon icon="info"></i-icon></template>
+<template slot="icon"><i-icon icon="info"></i-icon></template>
 
 The `filtering` event occurs whenever the search input is updated.
 
@@ -164,14 +160,14 @@ The `filtering` event occurs whenever the search input is updated.
 
 <i-code-preview title="Data Table Async Filtering" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="columns" :rows="rowsAsync" :rows-count="rowsCount" @update="onUpdate"></i-datatable>
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rowsAsync" :rows-count="rowsCount" @update="onUpdate" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {

--- a/packages/docs/pages/docs/components/dashboard/datatable/introduction.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/introduction.md
@@ -43,20 +43,19 @@ export default {
     <p>Each data row should also have a unique <code>id</code> field, which will be used internally for identifying the row during rendering.</p>
 </i-alert>
 
-
 ### Usage
 Let's put it all together. The `columns` defined above, together with the `rows` data will render the following data table:
 
 <i-code-preview title="Data Table Example" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="columns" :rows="rows" />
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -108,14 +107,14 @@ export default {
 
 <i-code-preview title="Data Table Property Nesting" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="columnsNested" :rows="rows" />
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {

--- a/packages/docs/pages/docs/components/dashboard/datatable/pagination.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/pagination.md
@@ -6,14 +6,14 @@ Pagination is enabled by default and can be changed using the `pagination` attri
 
 <i-code-preview title="Data Table Default Pagination" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="columns" :rows="rows" pagination></i-datatable>
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" pagination />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -46,14 +46,14 @@ Pagination can be disabled by setting the `pagination` attribute to `false`.
 
 <i-code-preview title="Data Table Disabled Pagination" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="columns" :rows="rowsShort" :pagination="false"></i-datatable>
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" :pagination="false" >
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -111,7 +111,7 @@ Pagination can be handled asynchronously by setting the `async` attribute to `tr
 This will tell the DataTable component to only display the rows and let the pagination handling be done asynchronously and externally using the `update` event. 
 
 <i-alert variant="info" class="-code">
-<template v-slot:icon><i-icon icon="info"></i-icon></template>
+<template slot="icon"><i-icon icon="info"></i-icon></template>
 
 The first `update` event occurs when the DataTable is `created`.
 
@@ -119,14 +119,14 @@ The first `update` event occurs when the DataTable is `created`.
 
 <i-code-preview title="Data Table Async Pagination" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable async :columns="columns" :rows="asyncRows" :rows-count="rowsCount" @update="onUpdate"></i-datatable>
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable async :columns="columns" :rows="rows" :rows-count="rowsCount" @update="onUpdate" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {

--- a/packages/docs/pages/docs/components/dashboard/datatable/rendering.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/rendering.md
@@ -32,14 +32,14 @@ export default {
 
 <i-code-preview title="Data Table Path" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="dataPathColumns" :rows="rows" />
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -91,14 +91,14 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
 
 <i-code-preview title="Data Table Render Function" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="renderColumns" :rows="rows" />
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -164,7 +164,7 @@ Here's an example for how to display a progress bar component on each row:
 
 <i-code-preview title="Data Table Custom Component" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="componentColumns" :rows="componentRows"></i-datatable>
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -173,7 +173,7 @@ Here's an example for how to display a progress bar component on each row:
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -244,7 +244,7 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
         <td>{{row.address.city}}, {{row.address.country}}</td>
     </template>
 </i-datatable>
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -259,7 +259,7 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -304,14 +304,14 @@ export default {
 
 <i-code-preview title="Data Table Render Header Function" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="renderHeaderColumns" :rows="rows" />
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -380,7 +380,7 @@ Here's a practical example where the header component contains a dropdown:
 
 <i-code-preview title="Data Table Custom Header Component" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="headerComponentColumns" :rows="rows"></i-datatable>
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -389,7 +389,7 @@ Here's a practical example where the header component contains a dropdown:
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -466,7 +466,7 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
         <th>Country</th>
     </template>
 </i-datatable>
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -481,7 +481,7 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -526,14 +526,14 @@ export default {
 
 <i-code-preview title="Data Table Render Header Function" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="renderFooterColumns" :rows="rows" />
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -602,7 +602,7 @@ Here's a practical example where the header component contains a dropdown:
 
 <i-code-preview title="Data Table Custom Footer Component" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="footerComponentColumns" :rows="rows"></i-datatable>
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -611,7 +611,7 @@ Here's a practical example where the header component contains a dropdown:
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -668,7 +668,7 @@ By providing a scoped `footer` slot, you can render the datatable footer as you 
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows">
-    <template v-slot:footer>
+    <template slot="footer">
         <td class="_text-right">No.</td>
         <td>Name</td>
         <td>Country</td>
@@ -682,13 +682,13 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
 
 <i-code-preview title="Data Table Scoped Footer Slot" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
 <i-datatable :columns="dataPathColumns" :rows="rows">
-    <template v-slot:footer>
+    <template slot="footer">
         <th class="_text-right">No.</th>
         <th>Name</th>
         <th>Country</th>
     </template>
 </i-datatable>
-<template v-slot:html>
+<template slot="html">
 <div v-pre>
 
 ~~~html
@@ -703,7 +703,7 @@ Keep in mind that, by providing a custom `render` function, you will need to pro
 
 </div>
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {

--- a/packages/docs/pages/docs/components/dashboard/datatable/scrolling.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/scrolling.md
@@ -22,17 +22,15 @@ export default {
 By default, sorting for the `string`, `number` and `Date` value types is supported natively. 
 
 <i-code-preview title="Data Table Default Scrolling" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
-
 <i-datatable :columns="columns" :rows="rows" nowrap />
-
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" nowrap />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -82,17 +80,15 @@ export default {
 
 
 <i-code-preview title="Data Table Default Scrolling" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
-
 <i-datatable :columns="columnsSticky" :rows="rows" :count-column="countColumn" nowrap />
-
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" :count-column="countColumn" nowrap />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {

--- a/packages/docs/pages/docs/components/dashboard/datatable/sorting.md
+++ b/packages/docs/pages/docs/components/dashboard/datatable/sorting.md
@@ -22,17 +22,15 @@ export default {
 By default, sorting for the `string`, `number` and `Date` value types is supported natively. 
 
 <i-code-preview title="Data Table Default Sorting" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
-
 <i-datatable :columns="columns" :rows="rows" />
-
-<template v-slot:html>
+<template slot="html">
 
 ~~~html
 <i-datatable :columns="columns" :rows="rows" />
 ~~~
 
 </template>
-<template v-slot:js>
+<template slot="js">
 
 ~~~js
 export default {
@@ -42,75 +40,6 @@ export default {
                 { title: 'Name', path: 'name', sortable: true },
                 { title: 'Email', path: 'email', sortable: true },
                 { title: 'Age', path: 'age', sortable: true }
-            ],
-            rows: [
-                { id: '1', name: 'Richard Hendricks', email: 'richard.hendricks@email.com', age: 26 },
-                { id: '2', name: 'Bertram Gilfoyle', email: 'bertram.gilfoyle@email.com', age: 30 },
-                { id: '3', name: 'Dinesh Chugtai', email: 'dinesh.chugtai@email.com', age: 30 },
-                { id: '4', name: 'Jared Dunn', email: 'jared.dunn@email.com', age: 35 },
-                { id: '5', name: 'Erlich Bachman', email: 'erlich.bachman@email.com', age: 32 }
-            ]
-        }
-    }
-}
-~~~
-
-</template>
-</i-code-preview>
-
-
-### Custom Sorting
-You can provide a custom sorting function to be used inside the data array `sort()` method by providing a `sort` property on the column. This allows you to sort elements based on extra criteria. 
-
-The two arguments for the custom sort function are the two rows being compared:
-
-~~~js
-const customSort = (a, b) => {
-    if (a.field > b.field) {
-        return 1;
-    }
-    
-    if (a.field < b.field) {
-        return -1;
-    }
-    
-    return 0;
-};
-export default {
-    data() {
-        return {
-            columns: [
-                { title: 'Name', path: 'name', sortable: true, sortFn: customSort },
-                { title: 'Email', path: 'email' },
-                { title: 'Age', path: 'age' }
-            ],
-            rows: [ ... ]
-        }
-    }
-}
-~~~
-
-<i-code-preview title="Data Table Custom Sorting" link="https://github.com/inkline/inkline/tree/master/src/components/Datatable/index.vue">
-
-<i-datatable :columns="customSortColumns" :rows="rows" />
-
-<template v-slot:html>
-
-~~~html
-<i-datatable :columns="columns" :rows="rows" />
-~~~
-
-</template>
-<template v-slot:js>
-
-~~~js
-export default {
-    data() {
-        return {
-            columns: [
-                { title: 'Name', path: 'name', sortable: true, sortFn: customSort },
-                { title: 'Email', path: 'email' },
-                { title: 'Age', path: 'age' }
             ],
             rows: [
                 { id: '1', name: 'Richard Hendricks', email: 'richard.hendricks@email.com', age: 26 },

--- a/packages/inkline/src/components/Datatable/script.js
+++ b/packages/inkline/src/components/Datatable/script.js
@@ -210,8 +210,7 @@ export default {
             return to > this.rowsLength ? this.rowsLength : to;
         },
         hasExpandableRows() {
-            return Boolean(this.$slots && this.$slots.expand) ||
-                Boolean(this.$scopedSlots && this.$scopedSlots.expand);
+            return Boolean(this.$slots.expand || this.$scopedSlots.expand);
         }
     },
     methods: {

--- a/packages/inkline/src/components/Datatable/template.html
+++ b/packages/inkline/src/components/Datatable/template.html
@@ -3,16 +3,14 @@
         <div class="pagination-select" v-if="pagination">
             <template v-for="part in i18nConfig.pagination.rowsPerPage">
                 <i-select v-model="rowsPerPage" :size="paginationConfig.size" v-if="part === 'rowsPerPage'">
-                    <i-select-option v-for="(item, index) in paginationConfig.rowsPerPageOptions" :value="item" :key="index">
-                        {{ item }}
-                    </i-select-option>
+                    <i-select-option v-for="(item, index) in paginationConfig.rowsPerPageOptions" :value="item" :label="'' + item" :key="index" />
                 </i-select>
                 <template v-else>{{part}}</template>
             </template>
         </div>
         <div class="filtering-input">
             <i-input v-model="filter" :placeholder="i18nConfig.filtering.inputPlaceholder">
-                <i-icon icon="search" slot="suffix"></i-icon>
+                <i-icon icon="search" slot="suffix" />
             </i-input>
         </div>
     </div>
@@ -27,13 +25,13 @@
                             <span v-if="!column.headerComponent">
                                 {{tableColumnsHeaderRendered[column.path]}}
                                 <i-icon class="sortable-icon" v-if="column.sortable" icon="sort">
-                                    <i-icon v-if="sortBy === column.path" :icon="`sort-${sortDirection}`"></i-icon>
+                                    <i-icon v-if="sortBy === column.path" :icon="`sort-${sortDirection}`" />
                                 </i-icon>
                             </span>
-                            <span v-else :is="column.headerComponent" :column="column" :index="index" :sort-by="sortBy"></span>
+                            <span v-else :is="column.headerComponent" :column="column" :index="index" :sort-by="sortBy" />
                         </th>
                     </slot>
-                    <th class="dth" v-if="hasExpandableRows"></th>
+                    <th class="dth" v-if="hasExpandableRows" />
                 </tr>
             </thead>
             <tbody>
@@ -45,7 +43,7 @@
                                 <span v-if="!column.component">
                                     {{row[column.path]}}
                                 </span>
-                                <span v-else :is="column.component" :row="row" :column="column"></span>
+                                <span v-else :is="column.component" :row="row" :column="column" />
                             </td>
                         </slot>
                         <td class="dtd" v-if="hasExpandableRows">
@@ -56,7 +54,7 @@
                                :aria-describedby="`expandable-row-${row.id}`"
                                @click="onClickExpand(row.id)"
                                tabindex="0">
-                                <i class="icon"></i>
+                                <i class="icon" />
                             </span>
                         </td>
                     </tr>
@@ -65,7 +63,7 @@
                         :id="`expandable-row-${row.id}`" :key="row.id + '-expandable'"
                         :aria-hidden="!expanded[row.id]"
                         :aria-labelledby="`expand-row-${row.id}`">
-                            <slot name="expand" :columns="tableColumns" :row="row" :expaned="expanded[row.id]"></slot>
+                            <slot name="expand" :columns="tableColumns" :row="row" :expaned="expanded[row.id]" />
                     </tr>
                 </template>
 
@@ -109,7 +107,7 @@
                 :limit="paginationConfig.limit"
                 :size="paginationConfig.size"
                 :variant="paginationConfig.variant"
-                v-model="page"></i-pagination>
+                v-model="page" />
         </slot>
     </div>
 </div>

--- a/packages/inkline/src/components/Select/style.scss
+++ b/packages/inkline/src/components/Select/style.scss
@@ -27,6 +27,7 @@
         top: 0;
         left: 0;
         opacity: 0;
+        z-index: 1;
         -webkit-appearance: menulist-button;
     }
 

--- a/packages/inkline/src/components/Select/template.html
+++ b/packages/inkline/src/components/Select/template.html
@@ -9,7 +9,6 @@
         hide-on-click
         ref="dropdown">
     <i-input
-            v-bind="$attrs"
             ref="input"
             :value="labelModel"
             :name="name"
@@ -29,8 +28,9 @@
     </i-input>
 
     <select v-model="model"
-            v-if="isMobile"
+            v-show="isMobile"
             :name="name"
+            :readonly="!isMobile"
             :disabled="isDisabled"
             ref="select"
             class="form-select"

--- a/packages/inkline/tests/unit/components/__snapshots__/Datatable.spec.js.snap
+++ b/packages/inkline/tests/unit/components/__snapshots__/Datatable.spec.js.snap
@@ -4,18 +4,10 @@ exports[`Components Datatable should render correctly 1`] = `
 <div class="datatable-wrapper">
   <div class="header-wrapper">
     <div class="pagination-select">Show<i-select-stub value="10" size="md" tabindex="1">
-        <i-select-option-stub value="10" label="">
-          10
-        </i-select-option-stub>
-        <i-select-option-stub value="25" label="">
-          25
-        </i-select-option-stub>
-        <i-select-option-stub value="50" label="">
-          50
-        </i-select-option-stub>
-        <i-select-option-stub value="100" label="">
-          100
-        </i-select-option-stub>
+        <i-select-option-stub value="10" label="10"></i-select-option-stub>
+        <i-select-option-stub value="25" label="25"></i-select-option-stub>
+        <i-select-option-stub value="50" label="50"></i-select-option-stub>
+        <i-select-option-stub value="100" label="100"></i-select-option-stub>
       </i-select-stub>entries</div>
     <div class="filtering-input">
       <i-input-stub value="" size="" tabindex="1" placeholder="Search">

--- a/packages/inkline/tests/unit/components/__snapshots__/Select.spec.js.snap
+++ b/packages/inkline/tests/unit/components/__snapshots__/Select.spec.js.snap
@@ -6,17 +6,16 @@ exports[`Components Select should render correctly 1`] = `
     <!---->
     <div class="form-input">
       <!---->
-      <!----> <input tabindex="1" readonly="readonly" aria-readonly="true" id="select" v-model="value"></div>
+      <!----> <input tabindex="1" readonly="readonly" aria-readonly="true"></div>
     <!---->
-  </div>
-  <!---->
+  </div> <select readonly="readonly" class="form-select" style="display: none;"></select>
   <div class="menu" style="display: none;" id="select"><span class="arrow"></span> </div>
 </div>
 `;
 
 exports[`Components Select should render native correctly 1`] = `
 <i-dropdown-stub trigger="click" showtimeout="250" hidetimeout="150" variant="" disabled="true" hideonclick="true" placement="bottom" keymap="[object Object]" size="" id="select" tabindex="-1" class="select">
-  <i-input-stub value="" readonly="true" size="" tabindex="-1" id="select"><template></template> <template></template> <template></template> <template></template></i-input-stub> <select class="form-select"></select>
+  <i-input-stub value="" readonly="true" size="" tabindex="-1"><template></template> <template></template> <template></template> <template></template></i-input-stub> <select class="form-select"></select>
   <i-dropdown-menu-stub size="" variant="" transformorigin="true" placement="bottom" offset="0" arrow="true" arrowoffset="0" popperoptions="[object Object]"></i-dropdown-menu-stub>
 </i-dropdown-stub>
 `;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
There was a bug saying that `t.$scopedSlots` is not defined when using `i-select` inside of `i-datatable`, after `nuxt generate` (or SSR in general). This was caused by the `v-if="isMobile"` applied on the hidden select with a `v-model` directive. This caused the page to crash during SSR.


* **What is the new behavior?** (If this is a feature change)
The `i-select` is always rendered, but hidden unless `isMobile` is true.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
