### PR TITLE
Docs update: fix typo in sidebar.md

### DIFF
--- a/packages/docs/pages/docs/components/sidebar.md
+++ b/packages/docs/pages/docs/components/sidebar.md
@@ -360,7 +360,7 @@ You can easily place your sidebar on the right side of a layout by setting the `
 <i-tab type="html">
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Left Sidebar</i-navbar-brand>
@@ -381,7 +381,7 @@ You can easily place your sidebar on the right side of a layout by setting the `
 ~~~
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Right Sidebar</i-navbar-brand>

--- a/packages/docs/pages/docs/components/sidebar.md
+++ b/packages/docs/pages/docs/components/sidebar.md
@@ -445,7 +445,7 @@ You can control what breakpoint your sidebar will collapse at using the `collaps
 <i-tab type="html">
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Sidebar</i-navbar-brand>
@@ -512,7 +512,7 @@ Setting a `collapse` value of `true` will set the sidebar to be always collapsib
 <i-tab type="html">
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Sidebar</i-navbar-brand>
@@ -574,7 +574,7 @@ Setting a `collapse` value of `false` will set the sidebar to never be collapsib
 <i-tab type="html">
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Sidebar</i-navbar-brand>
@@ -675,7 +675,7 @@ This property allows you to control whether the sidebar will affect the content 
 <i-tab type="html">
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Relative Position Sidebar</i-navbar-brand>
@@ -696,7 +696,7 @@ This property allows you to control whether the sidebar will affect the content 
 ~~~
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Absolute Position Sidebar</i-navbar-brand>
@@ -717,7 +717,7 @@ This property allows you to control whether the sidebar will affect the content 
 ~~~
 
 ~~~html
-<i-layout">
+<i-layout>
     <i-layout-header class="_padding-0">
         <i-navbar :collapse="false">
             <i-navbar-brand>Fixed Position Sidebar</i-navbar-brand>


### PR DESCRIPTION
Fix typo in the sidebar placement example code, there was a double quote inside the i-layout element's markup.


