### PR TITLE
Fix invalid position property

### DIFF
--- a/packages/inkline/src/css/helpers/_position.scss
+++ b/packages/inkline/src/css/helpers/_position.scss
@@ -4,7 +4,7 @@
 
 @each $position in ('static', 'relative', 'absolute', 'fixed', 'sticky') {
     ._position-#{$position} {
-        position: $position !important;
+        position: #{$position} !important;
     }
 }
 


### PR DESCRIPTION
I found and fixed an issue where the position property values 
of the position utility contained unnecessary quotes that caused 
"invalid property value".

example:

- Class
  "_position-sticky"

- Result contained quotes
  position: "sticky" !important;

- Correct property value
  position: sticky !important;