### PR TITLE
sass-loader@11 is not compatible on installation. 

### DIFF
--- a/packages/docs/pages/docs/introduction/installation/nuxt.md
+++ b/packages/docs/pages/docs/introduction/installation/nuxt.md
@@ -12,7 +12,7 @@ npm install --save-dev @inkline/nuxt
 Inkline uses Sass as a peer dependency to compile its styles, so we'll need to add it to our Nuxt.js installation as well:
 
 ~~~bash
-npm install --save-dev node-sass sass-loader
+npm install --save-dev node-sass sass-loader@10
 ~~~
 
 Next, add `@inkline/nuxt` to the `modules` section of your `nuxt.config.js` file:


### PR DESCRIPTION
If you downgrade sass-loader to sass-loader@10 the setup will work. Hence my small addition to the docs.

* **Please check if the PR fulfills these requirements**
    - [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
Very small change in documents. I noticed this when first time installation of nuxt + inkline. First thought something was wrong with my setup...

* **Other information**:
Can find more about this on the internet search
https://exerror.com/typeerror-this-getoptions-is-not-a-function-in-vue-js/
