### PR TITLE
feat: Changed modifier styles to update css variable instead of property

### DIFF
--- a/src/components/IBadge/style.scss
+++ b/src/components/IBadge/style.scss
@@ -27,7 +27,7 @@
     a:hover &,
     a:focus & {
         text-decoration: none;
-        background: var(----link--background--hover);
+        ----background: var(----link--background--hover);
     }
 
     .button & {
@@ -36,7 +36,6 @@
     }
 
     &.-pill {
-        padding: var(----padding);
-        border-radius: var(----pill--border-radius);
+        ----border-radius: var(----pill--border-radius);
     }
 }

--- a/src/components/IBreadcrumb/components/IBreadcrumbItem/style.scss
+++ b/src/components/IBreadcrumb/components/IBreadcrumbItem/style.scss
@@ -6,6 +6,26 @@
 
 .breadcrumb-item {
     margin-bottom: 0;
+    padding-left: var(----padding-left);
+
+    a {
+        color: var(----color);
+
+        &[href],
+        &[to] {
+            ----color: var(----color--link);
+        }
+    }
+
+    &.-active a {
+        ----color: var(----color--active);
+    }
+
+    + .breadcrumb-item {
+        &::before {
+            padding-right: var(----padding-right);
+        }
+    }
 
     > span {
         display: inline-block;

--- a/src/components/IBreadcrumb/css/_colors.scss
+++ b/src/components/IBreadcrumb/css/_colors.scss
@@ -13,12 +13,12 @@
         /// The text color of the breadcrumb component, for the light color variant
         /// @name color
         ////
-        ----color: #{color('primary')};
+        ----color: #{color('gray-90')};
         ////
-        /// The text default color of the breadcrumb component, for the light color variant
-        /// @name color--default
+        /// The link color of the breadcrumb component, for the light color variant
+        /// @name color--link
         ////
-        ----color--default: #{color('gray-90')};
+        ----color--link: #{color('primary')};
         ////
         /// The text active color of the breadcrumb component, for the light color variant
         /// @name color--active
@@ -35,12 +35,12 @@
         /// The text color of the breadcrumb component, for the dark color variant
         /// @name color
         ////
-        ----color: #{color('primary')};
+        ----color: #{color('white')};
         ////
-        /// The text default color of the breadcrumb component, for the dark color variant
-        /// @name color--default
+        /// The link color of the breadcrumb component, for the dark color variant
+        /// @name color--link
         ////
-        ----color--default: #{color('white')};
+        ----color--link: #{color('primary')};
         ////
         /// The text active color of the breadcrumb component, for the dark color variant
         /// @name color--active

--- a/src/components/IBreadcrumb/css/_variables.scss
+++ b/src/components/IBreadcrumb/css/_variables.scss
@@ -8,13 +8,13 @@
     /// @name color
     /// @type color
     ////
-    ----color: #{color('primary')};
+    ----color: #{color('gray-90')};
     ////
-    /// The text default color of the breadcrumb component
-    /// @name color--default
+    /// The link color of the breadcrumb component
+    /// @name color--link
     /// @type color
     ////
-    ----color--default: #{color('gray-90')};
+    ----color--link: #{color('primary')};
     ////
     /// The text active color of the breadcrumb component
     /// @name color--active

--- a/src/components/IBreadcrumb/manifest.js
+++ b/src/components/IBreadcrumb/manifest.js
@@ -45,14 +45,14 @@ export const manifest = {
             {
                 name: 'color',
                 type: 'color',
-                value: 'color(\'primary\')',
+                value: 'color(\'gray-90\')',
                 description: 'The text color of the breadcrumb component'
             },
             {
-                name: 'color--default',
+                name: 'color--link',
                 type: 'color',
-                value: 'color(\'gray-90\')',
-                description: 'The text default color of the breadcrumb component'
+                value: 'color(\'primary\')',
+                description: 'The link color of the breadcrumb component'
             },
             {
                 name: 'color--active',
@@ -94,14 +94,14 @@ export const manifest = {
                     {
                         name: 'color',
                         type: '',
-                        value: 'color(\'primary\')',
+                        value: 'color(\'gray-90\')',
                         description: 'The text color of the breadcrumb component, for the light color variant'
                     },
                     {
-                        name: 'color--default',
+                        name: 'color--link',
                         type: '',
-                        value: 'color(\'gray-90\')',
-                        description: 'The text default color of the breadcrumb component, for the light color variant'
+                        value: 'color(\'primary\')',
+                        description: 'The link color of the breadcrumb component, for the light color variant'
                     },
                     {
                         name: 'color--active',
@@ -119,14 +119,14 @@ export const manifest = {
                     {
                         name: 'color',
                         type: '',
-                        value: 'color(\'primary\')',
+                        value: 'color(\'white\')',
                         description: 'The text color of the breadcrumb component, for the dark color variant'
                     },
                     {
-                        name: 'color--default',
+                        name: 'color--link',
                         type: '',
-                        value: 'color(\'white\')',
-                        description: 'The text default color of the breadcrumb component, for the dark color variant'
+                        value: 'color(\'primary\')',
+                        description: 'The link color of the breadcrumb component, for the dark color variant'
                     },
                     {
                         name: 'color--active',

--- a/src/components/IBreadcrumb/style.scss
+++ b/src/components/IBreadcrumb/style.scss
@@ -17,28 +17,5 @@
         flex-wrap: wrap;
         padding-left: 0;
         list-style: none;
-
-        > .breadcrumb-item {
-            padding-left: var(----padding-left);
-
-            a {
-                color: var(----color--default);
-
-                &[href],
-                &[to] {
-                    color: var(----color);
-                }
-            }
-
-            &.-active a {
-                color: var(----color--active);
-            }
-
-            + .breadcrumb-item {
-                &::before {
-                    padding-right: var(----padding-right);
-                }
-            }
-        }
     }
 }

--- a/src/components/IButton/css/_variables.scss
+++ b/src/components/IButton/css/_variables.scss
@@ -54,7 +54,7 @@
     /// The border color of the button component when hovered or focused
     /// @name border-color--hover
     ////
-    ----border-color--hover: #{var(----border-color)};
+    ----border-color--hover: #{var(----border-top-color) var(----border-right-color) var(----border-bottom-color) var(----border-left-color)};
     ////
     /// The border style of the button component
     /// @name border-style
@@ -218,44 +218,4 @@
     /// @type color
     ////
     ----link--color--active: #{color('light-55')};
-    ////
-    /// The background of the button component outline variant
-    /// @name outline--background
-    ////
-    ----outline--background: #{transparent};
-    ////
-    /// The background of the button component outline variant when hovered
-    /// @name outline--background--hover
-    ////
-    ----outline--background--hover: #{var(----background)};
-    ////
-    /// The background of the button component outline variant when active
-    /// @name outline--background--active
-    ////
-    ----outline--background--active: #{var(----background--active)};
-    ////
-    /// The border color of the button component outline variant
-    /// @name outline--border-color
-    ////
-    ----outline--border-color: #{var(----background)};
-    ////
-    /// The border color of the button component outline variant when hovered or focused
-    /// @name outline--border-color--hover
-    ////
-    ----outline--border-color--hover: #{var(----border-color--hover)};
-    ////
-    /// The color of the button component outline variant
-    /// @name outline--color
-    ////
-    ----outline--color: #{var(----background)};
-    ////
-    /// The color of the button component outline variant when hovered or focused
-    /// @name outline--color--hover
-    ////
-    ----outline--color--hover: #{var(----color)};
-    ////
-    /// The color of the button component outline variant when hovered or focused
-    /// @name outline--color--active
-    ////
-    ----outline--color--active: #{var(----outline--color--hover)};
 }

--- a/src/components/IButton/examples/state-disabled.html
+++ b/src/components/IButton/examples/state-disabled.html
@@ -1,3 +1,3 @@
-<i-button active>Active Default Button</i-button>
+<i-button disabled>Disabled Default Button</i-button>
 
-<i-button active color="primary">Active Primary Button</i-button>
+<i-button disabled color="primary">Disabled Primary Button</i-button>

--- a/src/components/IButton/manifest.js
+++ b/src/components/IButton/manifest.js
@@ -172,7 +172,7 @@ export const manifest = {
             {
                 name: 'border-color--hover',
                 type: '',
-                value: 'var(----border-color)',
+                value: 'var(----border-top-color) var(----border-right-color) var(----border-bottom-color) var(----border-left-color)',
                 description: 'The border color of the button component when hovered or focused'
             },
             {
@@ -354,54 +354,6 @@ export const manifest = {
                 type: 'color',
                 value: 'color(\'light-55\')',
                 description: 'The color of the button component link variant when active'
-            },
-            {
-                name: 'background--outline',
-                type: '',
-                value: 'transparent',
-                description: 'The background of the button component outline variant'
-            },
-            {
-                name: 'background--outline--hover',
-                type: '',
-                value: 'var(----background)',
-                description: 'The background of the button component outline variant when hovered'
-            },
-            {
-                name: 'background--outline--active',
-                type: '',
-                value: 'var(----background--active)',
-                description: 'The background of the button component outline variant when active'
-            },
-            {
-                name: 'border-color--outline',
-                type: '',
-                value: 'var(----background)',
-                description: 'The border color of the button component outline variant'
-            },
-            {
-                name: 'border-color--outline--hover',
-                type: '',
-                value: 'var(----border-color--hover)',
-                description: 'The border color of the button component outline variant when hovered or focused'
-            },
-            {
-                name: 'color--outline',
-                type: '',
-                value: 'var(----background)',
-                description: 'The color of the button component outline variant'
-            },
-            {
-                name: 'color--outline--hover',
-                type: '',
-                value: 'var(----color)',
-                description: 'The color of the button component outline variant when hovered or focused'
-            },
-            {
-                name: 'color--outline--active',
-                type: '',
-                value: 'var(----color--outline--hover)',
-                description: 'The color of the button component outline variant when hovered or focused'
             }
         ],
         variants: [

--- a/src/components/IButton/manifest.js
+++ b/src/components/IButton/manifest.js
@@ -356,51 +356,51 @@ export const manifest = {
                 description: 'The color of the button component link variant when active'
             },
             {
-                name: 'outline--background',
+                name: 'background--outline',
                 type: '',
                 value: 'transparent',
                 description: 'The background of the button component outline variant'
             },
             {
-                name: 'outline--background--hover',
+                name: 'background--outline--hover',
                 type: '',
                 value: 'var(----background)',
                 description: 'The background of the button component outline variant when hovered'
             },
             {
-                name: 'outline--background--active',
+                name: 'background--outline--active',
                 type: '',
                 value: 'var(----background--active)',
                 description: 'The background of the button component outline variant when active'
             },
             {
-                name: 'outline--border-color',
+                name: 'border-color--outline',
                 type: '',
                 value: 'var(----background)',
                 description: 'The border color of the button component outline variant'
             },
             {
-                name: 'outline--border-color--hover',
+                name: 'border-color--outline--hover',
                 type: '',
                 value: 'var(----border-color--hover)',
                 description: 'The border color of the button component outline variant when hovered or focused'
             },
             {
-                name: 'outline--color',
+                name: 'color--outline',
                 type: '',
                 value: 'var(----background)',
                 description: 'The color of the button component outline variant'
             },
             {
-                name: 'outline--color--hover',
+                name: 'color--outline--hover',
                 type: '',
                 value: 'var(----color)',
                 description: 'The color of the button component outline variant when hovered or focused'
             },
             {
-                name: 'outline--color--active',
+                name: 'color--outline--active',
                 type: '',
-                value: 'var(----outline--color--hover)',
+                value: 'var(----color--outline--hover)',
                 description: 'The color of the button component outline variant when hovered or focused'
             }
         ],

--- a/src/components/IButton/style.scss
+++ b/src/components/IButton/style.scss
@@ -40,15 +40,15 @@
         &:focus,
         &.-hovered,
         &.-focused {
-            background: var(----background--hover);
-            border-color: var(----border-color--hover);
+            ----background: var(----background--hover);
+            ----border-color: var(----border-color--hover);
             text-decoration: none;
             outline: 0;
         }
 
         &:active,
         &.-active {
-            background: var(----background--active);
+            ----background: var(----background--active);
         }
     }
 
@@ -75,8 +75,8 @@
     // Link buttons
     // Make a button look and behave like a link
     &.-link {
+        ----color: var(----link--color);
         box-shadow: none;
-        color: var(----link--color);
         background-color: transparent;
         border-color: transparent;
 
@@ -87,7 +87,7 @@
             &.-hovered,
             &.-focused,
             &.-active {
-                color: var(----link--color--active);
+                ----color: var(----link--color--active);
                 background-color: transparent;
                 border-color: transparent;
                 box-shadow: none;
@@ -104,45 +104,31 @@
     // Outline buttons
     // Remove button background and add a beautiful transition on hover
     &.-outline {
-        color: var(----outline--color);
-        background: var(----outline--background);
-        border-color: var(----outline--border-color);
-        box-shadow: none;
+        background: transparent;
+        color: var(----background);
+        border-color: var(----background);
+        ----box-shadow: none;
 
         &:not(:disabled):not(.-disabled) {
             &:hover,
             &:focus,
-            &.-hovered,
-            &.-focused {
-                color: var(----outline--color--hover);
-                background: var(----outline--background--hover);
-                border-color: var(----outline--border-color--hover);
-            }
-
             &:active,
+            &.-hovered,
+            &.-focused,
             &.-active {
-                color: var(----outline--color--active);
-                background: var(----outline--background--active);
+                ----border-color: var(----border-color--hover);
+                background: var(----background);
+                color: var(----color);
             }
         }
     }
 
     // Circle button
     &.-circle {
-        border-radius: 100%;
+        ----border-radius: 100%;
         width: var(----circle--size);
         height: var(----circle--size);
         padding: 0;
-    }
-
-    // Transparent button
-    &.-transparent {
-        background-color: transparent;
-    }
-
-    // Flat buttons
-    &.-flat {
-        background-image: none;
     }
 
     .loader {
@@ -161,11 +147,11 @@
     //
 
     .button-group:not(.-vertical) > &:not(:first-child) {
-        border-left-color: var(----background--hover);
+        ----border-left-color: var(----background--hover);
     }
 
     .button-group.-vertical > &:not(:first-child) {
-        border-top-color: var(----background--hover);
+        ----border-top-color: var(----background--hover);
     }
 }
 

--- a/src/components/ICheckbox/style.scss
+++ b/src/components/ICheckbox/style.scss
@@ -42,8 +42,8 @@
         &:checked ~ .checkbox-label,
         &[type="checkbox"]:indeterminate ~ .checkbox-label {
             &::before {
-                border-color: var(----border-color--checked);
-                background-color: var(----background--checked);
+                ----border-color: var(----border-color--checked);
+                ----background: var(----background--checked);
             }
 
             &::after {
@@ -57,17 +57,17 @@
         &:disabled,
         &[readonly] {
             ~ .checkbox-label {
-                color: var(----label--color--disabled);
+                ----label--color: var(----label--color--disabled);
             }
 
             &:checked ~ .checkbox-label {
                 &::before {
-                    border-color: var(----border-color--checked-disabled);
-                    background-color: var(----background--checked-disabled);
+                    ----border-color: var(----border-color--checked-disabled);
+                    ----background: var(----background--checked-disabled);
                 }
 
                 &::after {
-                    background-color: var(----color--disabled);
+                    ----background: var(----color--disabled);
                 }
             }
         }

--- a/src/components/IDropdown/components/IDropdownItem/style.scss
+++ b/src/components/IDropdown/components/IDropdownItem/style.scss
@@ -18,6 +18,28 @@
     transition-property: background-color, border-color, color;
     transition-timing-function: var(--transition-easing);
     transition-duration: var(--transition-duration);
+    color: var(----color);
+    border-color: var(----border-color);
+    padding: var(----item--padding);
+    background: var(----background);
+
+    &:not(.-disabled):not(.-plaintext) {
+        &:hover,
+        &:focus {
+            ----color: var(----color--hover);
+            ----background: var(----background--hover);
+        }
+    }
+
+    &.-disabled {
+        ----color: var(----color--disabled);
+        ----background: var(----background--disabled);
+    }
+
+    &.-active {
+        ----color: var(----color--active);
+        ----background: var(----background--active);
+    }
 
     &:hover,
     &:focus {

--- a/src/components/IDropdown/style.scss
+++ b/src/components/IDropdown/style.scss
@@ -55,30 +55,6 @@
             margin-bottom: var(----divider--margin-bottom);
             background-color: var(----border-color);
         }
-
-        .dropdown-item {
-            color: var(----color);
-            border-color: var(----border-color);
-            padding: var(----item--padding);
-
-            &:not(.-disabled):not(.-plaintext) {
-                &:hover,
-                &:focus {
-                    color: var(----color--hover);
-                    background: var(----background--hover);
-                }
-            }
-
-            &.-disabled {
-                color: var(----color--disabled);
-                background: var(----background--disabled);
-            }
-
-            &.-active {
-                color: var(----color--active);
-                background: var(----background--active);
-            }
-        }
     }
 
     > .dropdown-footer {
@@ -110,12 +86,12 @@
     ));
 
     @include popup-arrow-color-variant-for-side('left', (
-        'background': var(----body--background),
+        'background': var(----background),
         'border-color': var(----border-left-color)
     ));
 
     @include popup-arrow-color-variant-for-side('right', (
-        'background': var(----body--background),
+        'background': var(----background),
         'border-color': var(----border-right-color)
     ));
 }

--- a/src/components/IHamburgerMenu/style.scss
+++ b/src/components/IHamburgerMenu/style.scss
@@ -18,7 +18,7 @@
     transition: opacity 0.3s ease;
 
     &:hover {
-        opacity: var(----opacity--hover);
+        ----opacity: var(----opacity--hover);
     }
 
     > .hamburger-menu-bars {

--- a/src/components/IInput/manifest.js
+++ b/src/components/IInput/manifest.js
@@ -422,13 +422,183 @@ export const manifest = {
                 name: 'light',
                 type: 'variant',
                 description: 'Variables for the light color variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'background',
+                        type: '',
+                        value: 'color(\'white\')',
+                        description: 'The background of the input component, for the light color variant'
+                    },
+                    {
+                        name: 'background--disabled',
+                        type: '',
+                        value: 'color(\'light-25\')',
+                        description: 'The background of the input component when disabled, for the light color variant'
+                    },
+                    {
+                        name: 'border-color',
+                        type: '',
+                        value: 'color(\'light-55\')',
+                        description: 'The border color of the input component, for the light color variant'
+                    },
+                    {
+                        name: 'border-color--hover',
+                        type: '',
+                        value: 'color(\'light-60\')',
+                        description: 'The border color of the input component when hovered, for the light color variant'
+                    },
+                    {
+                        name: 'border-color--focus',
+                        type: '',
+                        value: 'color(\'primary\')',
+                        description: 'The border color of the input component when focused, for the light color variant'
+                    },
+                    {
+                        name: 'color',
+                        type: '',
+                        value: 'contrast-color($color-white)',
+                        description: 'The color of the input component, for the light color variant'
+                    },
+                    {
+                        name: 'color--disabled',
+                        type: '',
+                        value: 'color(\'light-75\')',
+                        description: 'The color of the input component when disabled, for the light color variant'
+                    },
+                    {
+                        name: 'clear--background',
+                        type: '',
+                        value: 'transparent',
+                        description: 'The background of the input component clear button, for the light color variant'
+                    },
+                    {
+                        name: 'clear--background--hover',
+                        type: '',
+                        value: 'color(\'light-30\')',
+                        description: 'The background of the input component clear button, for the light color variant'
+                    },
+                    {
+                        name: 'clear--background--active',
+                        type: '',
+                        value: 'color(\'light-40\')',
+                        description: 'The background of the input component clear button, for the light color variant'
+                    },
+                    {
+                        name: 'clear--color',
+                        type: '',
+                        value: 'color(\'light-70\')',
+                        description: 'The color of the input component clear button, for the light color variant'
+                    },
+                    {
+                        name: 'placeholder--color',
+                        type: '',
+                        value: 'color(\'light-60\')',
+                        description: 'The color of the input component placeholder, for the light color variant'
+                    },
+                    {
+                        name: 'prefix-suffix--color',
+                        type: '',
+                        value: 'color(\'light-70\')',
+                        description: 'The color of the input component prefix and suffix, for the light color variant'
+                    },
+                    {
+                        name: 'prepend-append--background',
+                        type: '',
+                        value: 'color(\'light\')',
+                        description: 'The background of the input component prepend and append, for the light color variant'
+                    }
+                ]
             },
             {
                 name: 'dark',
                 type: 'variant',
                 description: 'Variables for the dark color variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'background',
+                        type: '',
+                        value: 'color(\'dark\')',
+                        description: 'The background of the input component, for the dark color variant'
+                    },
+                    {
+                        name: 'background--disabled',
+                        type: '',
+                        value: 'color(\'dark-40\')',
+                        description: 'The background of the input component when disabled, for the dark color variant'
+                    },
+                    {
+                        name: 'border-color',
+                        type: '',
+                        value: 'color(\'dark-45\')',
+                        description: 'The border color of the input component, for the dark color variant'
+                    },
+                    {
+                        name: 'border-color--hover',
+                        type: '',
+                        value: 'color(\'dark-40\')',
+                        description: 'The border color of the input component when hovered, for the dark color variant'
+                    },
+                    {
+                        name: 'border-color--focus',
+                        type: '',
+                        value: 'color(\'primary\')',
+                        description: 'The border color of the input component when focused, for the dark color variant'
+                    },
+                    {
+                        name: 'color',
+                        type: '',
+                        value: 'contrast-color($color-dark)',
+                        description: 'The color of the input component, for the dark color variant'
+                    },
+                    {
+                        name: 'color--disabled',
+                        type: '',
+                        value: 'color(\'gray-35\')',
+                        description: 'The color of the input component when disabled, for the dark color variant'
+                    },
+                    {
+                        name: 'clear--background',
+                        type: '',
+                        value: 'transparent',
+                        description: 'The background of the input component clear button, for the dark color variant'
+                    },
+                    {
+                        name: 'clear--background--hover',
+                        type: '',
+                        value: 'color(\'dark-35\')',
+                        description: 'The background of the input component clear button, for the dark color variant'
+                    },
+                    {
+                        name: 'clear--background--active',
+                        type: '',
+                        value: 'color(\'dark-30\')',
+                        description: 'The background of the input component clear button, for the dark color variant'
+                    },
+                    {
+                        name: 'clear--color',
+                        type: '',
+                        value: 'color(\'dark-30\')',
+                        description: 'The color of the input component clear button, for the dark color variant'
+                    },
+                    {
+                        name: 'placeholder--color',
+                        type: '',
+                        value: 'color(\'dark-25\')',
+                        description: 'The color of the input component placeholder, for the dark color variant'
+                    },
+                    {
+                        name: 'prefix-suffix--color',
+                        type: '',
+                        value: 'color(\'dark-25\')',
+                        description: 'The color of the input component prefix and suffix, for the dark color variant'
+                    },
+                    {
+                        name: 'prepend-append--background',
+                        type: '',
+                        value: 'color(\'dark\')',
+                        description: 'The background of the input component prepend and append, for the dark color variant'
+                    }
+                ]
             },
             {
                 name: 'sm',

--- a/src/components/IInput/style.scss
+++ b/src/components/IInput/style.scss
@@ -74,11 +74,11 @@
         &:focus-within {
             outline: 0;
             box-shadow: var(----box-shadow);
-            border-color: var(----border-color--focus);
+            ----border-color: var(----border-color--focus);
         }
 
         &:hover {
-            border-color: var(----border-color--hover);
+            ----border-color: var(----border-color--hover);
         }
 
         > input,
@@ -170,15 +170,16 @@
             height: var(----clear--size);
             border-radius: 100%;
             background-color: var(----clear--background);
+            color: var(----clear--color);
 
             &:hover,
             &:focus {
-                color: var(----clear--color--hover);
-                background-color: var(----clear--background--hover);
+                ----clear--color: var(----clear--color--hover);
+                ----clear--background: var(----clear--background--hover);
             }
 
             &:active {
-                background-color: var(----clear--background--active);
+                ----clear--background: var(----clear--background--active);
             }
 
             &::before {
@@ -220,15 +221,15 @@
 
     &.-error {
         .input {
-            border-color: color('danger');
+            ----border-color: color('danger');
         }
     }
 
     &.-disabled,
     &.-readonly {
         > .input {
-            color: var(----color--disabled);
-            background-color: var(----background--disabled);
+            ----color: var(----color--disabled);
+            ----background: var(----background--disabled);
 
             &:hover {
                 border-color: var(----border-color);
@@ -239,7 +240,7 @@
             > textarea {
                 &:disabled,
                 &[readonly] {
-                    color: var(----color--disabled);
+                    ----color: var(----color--disabled);
                 }
             }
         }
@@ -249,7 +250,7 @@
         > .input {
             &:focus-within {
                 outline: 0;
-                border-color: var(----border-color--focus);
+                ----border-color: var(----border-color--focus);
             }
         }
     }

--- a/src/components/INav/components/INavItem/style.scss
+++ b/src/components/INav/components/INavItem/style.scss
@@ -12,6 +12,8 @@
     transition-timing-function: var(--transition-easing);
     transition-duration: var(--transition-duration);
     padding: var(----padding);
+    color: var(----color);
+    font-size: var(----font-size);
 
     &:hover,
     &:focus {

--- a/src/components/INav/manifest.js
+++ b/src/components/INav/manifest.js
@@ -78,8 +78,225 @@ export const manifest = {
     ],
     events: [],
     css: {
-        variables: [],
-        variants: []
+        variables: [
+            {
+                name: 'font-size',
+                type: 'size',
+                value: 'font-size()',
+                description: 'The font size of the nav component'
+            },
+            {
+                name: 'padding-top',
+                type: 'size',
+                value: 'var(--padding-top)',
+                description: 'The padding top of the nav component'
+            },
+            {
+                name: 'padding-right',
+                type: 'size',
+                value: 'var(--padding-right)',
+                description: 'The padding right of the nav component'
+            },
+            {
+                name: 'padding-bottom',
+                type: 'size',
+                value: 'var(--padding-bottom)',
+                description: 'The padding bottom of the nav component'
+            },
+            {
+                name: 'padding-left',
+                type: 'size',
+                value: 'var(--padding-left)',
+                description: 'The padding left of the nav component'
+            },
+            {
+                name: 'padding',
+                type: '',
+                value: 'var(----padding-top) var(----padding-right) var(----padding-bottom) var(----padding-left)',
+                description: 'The padding of the nav component'
+            },
+            {
+                name: 'color',
+                type: 'color',
+                value: 'contrast-color($color-light)',
+                description: ''
+            },
+            {
+                name: 'color-active',
+                type: 'color',
+                value: 'color(\'primary\')',
+                description: 'The color of the nav component item when active'
+            },
+            {
+                name: 'color-disabled',
+                type: 'color',
+                value: 'var(--text-muted)',
+                description: 'The color of the nav component item when disabled'
+            }
+        ],
+        variants: [
+            {
+                name: 'light',
+                type: 'variant',
+                description: 'Variables for the light color variant',
+                variables: [
+                    {
+                        name: 'color',
+                        type: '',
+                        value: 'contrast-color($color-light)',
+                        description: 'The color of the nav component item, for the light color variant'
+                    },
+                    {
+                        name: 'color--active',
+                        type: '',
+                        value: 'contrast-color($color-primary)',
+                        description: 'The color of the nav component item when active, for the light color variant'
+                    },
+                    {
+                        name: 'color--disabled',
+                        type: '',
+                        value: 'var(--text-muted)',
+                        description: 'The color of the nav component item when disabled, for the light color variant'
+                    }
+                ]
+            },
+            {
+                name: 'dark',
+                type: 'variant',
+                description: 'Variables for the dark color variant',
+                variables: [
+                    {
+                        name: 'color',
+                        type: '',
+                        value: 'contrast-color($color-dark)',
+                        description: 'The color of the nav component item, for the dark color variant'
+                    },
+                    {
+                        name: 'color--active',
+                        type: '',
+                        value: 'contrast-color($color-primary)',
+                        description: 'The color of the nav component item when active, for the dark color variant'
+                    },
+                    {
+                        name: 'color--disabled',
+                        type: '',
+                        value: 'var(--text-muted)',
+                        description: 'The color of the nav component item when disabled, for the dark color variant'
+                    }
+                ]
+            },
+            {
+                name: 'sm',
+                type: 'variant',
+                description: 'Variables for the sm size variant',
+                variables: [
+                    {
+                        name: 'font-size',
+                        type: '',
+                        value: 'calc(#{font-size()} * #{size-multiplier(\'sm\')})',
+                        description: 'The font size of the nav component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-top',
+                        type: '',
+                        value: 'calc(#{var(--padding-top)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding top of the nav component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-right',
+                        type: '',
+                        value: 'calc(#{var(--padding-right)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding right of the nav component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-bottom',
+                        type: '',
+                        value: 'calc(#{var(--padding-bottom)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding bottom of the nav component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-left',
+                        type: '',
+                        value: 'calc(#{var(--padding-left)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding left of the nav component, for the sm size variant'
+                    }
+                ]
+            },
+            {
+                name: 'md',
+                type: 'variant',
+                description: 'Variables for the md size variant',
+                variables: [
+                    {
+                        name: 'font-size',
+                        type: '',
+                        value: 'calc(#{font-size()} * #{size-multiplier(\'md\')})',
+                        description: 'The font size of the nav component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-top',
+                        type: '',
+                        value: 'calc(#{var(--padding-top)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding top of the nav component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-right',
+                        type: '',
+                        value: 'calc(#{var(--padding-right)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding right of the nav component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-bottom',
+                        type: '',
+                        value: 'calc(#{var(--padding-bottom)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding bottom of the nav component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-left',
+                        type: '',
+                        value: 'calc(#{var(--padding-left)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding left of the nav component, for the md size variant'
+                    }
+                ]
+            },
+            {
+                name: 'lg',
+                type: 'variant',
+                description: 'Variables for the lg size variant',
+                variables: [
+                    {
+                        name: 'font-size',
+                        type: '',
+                        value: 'calc(#{font-size()} * #{size-multiplier(\'lg\')})',
+                        description: 'The font size of the nav component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-top',
+                        type: '',
+                        value: 'calc(#{var(--padding-top)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding top of the nav component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-right',
+                        type: '',
+                        value: 'calc(#{var(--padding-right)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding right of the nav component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-bottom',
+                        type: '',
+                        value: 'calc(#{var(--padding-bottom)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding bottom of the nav component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-left',
+                        type: '',
+                        value: 'calc(#{var(--padding-left)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding left of the nav component, for the lg size variant'
+                    }
+                ]
+            }
+        ]
     }
 };
 

--- a/src/components/INav/style.scss
+++ b/src/components/INav/style.scss
@@ -14,8 +14,6 @@
     padding-left: 0;
     margin-bottom: 0;
     list-style: none;
-    font-size: var(----font-size);
-    color: var(----color);
 
     &.-vertical {
         flex-direction: column;

--- a/src/components/INavbar/style.scss
+++ b/src/components/INavbar/style.scss
@@ -81,6 +81,7 @@
             ----padding: var(----item--padding);
             ----font-size: var(----font-size);
             ----background: var(----item--background);
+
             border-radius: var(----border-radius);
             background: var(----background);
 

--- a/src/components/INavbar/style.scss
+++ b/src/components/INavbar/style.scss
@@ -77,18 +77,19 @@
 
     .navbar-collapsible {
         .nav-item {
-            color: var(----item--color);
+            ----color: var(----item--color);
+            ----padding: var(----item--padding);
+            ----font-size: var(----font-size);
+            ----background: var(----item--background);
             border-radius: var(----border-radius);
-            background-color: var(----item--background);
-            font-size: var(----font-size);
-            padding: var(----item--padding);
+            background: var(----background);
 
             &.-focused,
             &.-hovered,
             &:focus,
             &:hover {
-                color: var(----item--color--hover);
-                background-color: var(----item--background--hover);
+                ----color: var(----item--color--hover);
+                ----background: var(----item--background--hover);
             }
         }
     }
@@ -98,12 +99,12 @@
             background: var(----collapsed--background);
 
             .nav-item {
-                background: var(----collapsed--item--background);
-                color: var(----collapsed--item--color);
+                ----background: var(----collapsed--item--background);
+                ----color: var(----collapsed--item--color);
 
                 &:hover {
-                    color: var(----collapsed--item--color--hover);
-                    background: var(----collapsed--item--background--hover);
+                    ----color: var(----collapsed--item--color--hover);
+                    ----background: var(----collapsed--item--background--hover);
                 }
             }
         }

--- a/src/components/IPagination/style.scss
+++ b/src/components/IPagination/style.scss
@@ -41,18 +41,18 @@
 
         &:hover:not(.-disabled),
         &:focus:not(.-disabled) {
-            background: var(----background--hover);
+            ----background: var(----background--hover);
         }
 
         &.-active {
+            ----background: var(----background--active);
+            ----border-color: var(----border-color--active);
+            ----color: var(----color--active);
             font-weight: bold;
-            background-color: var(----background--active);
-            border-color: var(----border-color--active);
-            color: var(----color--active);
 
             &:hover,
             &:focus {
-                background-color: var(----background--active);
+                ----background: var(----background--active);
             }
         }
 
@@ -64,8 +64,8 @@
         &.-quick-next,
         &.-quick-previous {
             &.-disabled {
+                ----border-color: var(----background);
                 opacity: var(----opacity--disabled);
-                border-color: var(----background);
             }
         }
     }

--- a/src/components/IPagination/style.scss
+++ b/src/components/IPagination/style.scss
@@ -48,6 +48,7 @@
             ----background: var(----background--active);
             ----border-color: var(----border-color--active);
             ----color: var(----color--active);
+
             font-weight: bold;
 
             &:hover,
@@ -65,6 +66,7 @@
         &.-quick-previous {
             &.-disabled {
                 ----border-color: var(----background);
+
                 opacity: var(----opacity--disabled);
             }
         }

--- a/src/components/IProgress/manifest.js
+++ b/src/components/IProgress/manifest.js
@@ -200,13 +200,75 @@ export const manifest = {
                 name: 'light',
                 type: 'variant',
                 description: 'Variables for the light color variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'background',
+                        type: '',
+                        value: 'color(\'light\')',
+                        description: 'The background of the progress component, for the light color variant'
+                    },
+                    {
+                        name: 'border-top-color',
+                        type: '',
+                        value: 'color(\'light-55\')',
+                        description: 'The border top color of the progress component, for the light color variant'
+                    },
+                    {
+                        name: 'border-right-color',
+                        type: '',
+                        value: 'color(\'light-55\')',
+                        description: 'The border right color of the progress component, for the light color variant'
+                    },
+                    {
+                        name: 'border-bottom-color',
+                        type: '',
+                        value: 'color(\'light-55\')',
+                        description: 'The border bottom color of the progress component, for the light color variant'
+                    },
+                    {
+                        name: 'border-left-color',
+                        type: '',
+                        value: 'color(\'light-55\')',
+                        description: 'The border left color of the progress component, for the light color variant'
+                    }
+                ]
             },
             {
                 name: 'dark',
                 type: 'variant',
                 description: 'Variables for the dark color variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'background',
+                        type: '',
+                        value: 'color(\'dark\')',
+                        description: 'The background of the progress component, for the dark color variant'
+                    },
+                    {
+                        name: 'border-top-color',
+                        type: '',
+                        value: 'color(\'dark-45\')',
+                        description: 'The border top color of the progress component, for the dark color variant'
+                    },
+                    {
+                        name: 'border-right-color',
+                        type: '',
+                        value: 'color(\'dark-45\')',
+                        description: 'The border right color of the progress component, for the dark color variant'
+                    },
+                    {
+                        name: 'border-bottom-color',
+                        type: '',
+                        value: 'color(\'dark-45\')',
+                        description: 'The border bottom color of the progress component, for the dark color variant'
+                    },
+                    {
+                        name: 'border-left-color',
+                        type: '',
+                        value: 'color(\'dark-45\')',
+                        description: 'The border left color of the progress component, for the dark color variant'
+                    }
+                ]
             },
             {
                 name: 'sm',

--- a/src/components/IRadio/style.scss
+++ b/src/components/IRadio/style.scss
@@ -35,8 +35,8 @@
         &:checked {
             ~ .radio-label {
                 &::before {
-                    border-color: var(----border-color--checked);
-                    background-color: var(----background--checked);
+                    ----border-color: var(----border-color--checked);
+                    ----background: var(----background--checked);
                 }
 
                 &::after {
@@ -51,18 +51,18 @@
         &:disabled,
         &[readonly] {
             ~ .radio-label {
-                color: var(----label--color--disabled);
+                ----label--color: var(----label--color--disabled);
             }
 
             &:checked {
                 ~ .radio-label {
                     &::before {
-                        border-color: var(----border-color--checked-disabled);
-                        background-color: var(----background--checked-disabled);
+                        ----border-color: var(----border-color--checked-disabled);
+                        ----background: var(----background--checked-disabled);
                     }
 
                     &::after {
-                        background-color: var(----color--disabled);
+                        ----background: var(----color--disabled);
                     }
                 }
             }

--- a/src/components/ISelect/style.scss
+++ b/src/components/ISelect/style.scss
@@ -58,19 +58,19 @@
                 &:not(.-disabled):not(.-plaintext) {
                     &:hover,
                     &:focus {
-                        color: var(----option--color--hover);
-                        background: var(----option--background--hover);
+                        ----option--color: var(----option--color--hover);
+                        ----option--background: var(----option--background--hover);
                     }
                 }
 
                 &.-disabled {
-                    color: var(----option--color--disabled);
-                    background: var(----option--background--disabled);
+                    ----option--color: var(----option--color--disabled);
+                    ----option--background: var(----option--background--disabled);
                 }
 
                 &.-active {
-                    color: var(----option--color--active);
-                    background: var(----option--background--active);
+                    ----option--color: var(----option--color--active);
+                    ----option--background: var(----option--background--active);
                 }
             }
 

--- a/src/components/ISidebar/style.scss
+++ b/src/components/ISidebar/style.scss
@@ -111,8 +111,8 @@
                 &.-hovered,
                 &:focus,
                 &:hover {
-                    color: var(----item--color--hover);
-                    background-color: var(----item--background--hover);
+                    ----item--color: var(----item--color--hover);
+                    ----item--background: var(----item--background--hover);
                 }
             }
         }

--- a/src/components/ITable/style.scss
+++ b/src/components/ITable/style.scss
@@ -79,7 +79,7 @@
     &.-condensed .table {
         th,
         td {
-            padding: var(----padding--condensed);
+            ----padding: var(----padding--condensed);
         }
     }
 
@@ -120,7 +120,7 @@
         tbody > tr:nth-of-type(odd) {
             th,
             td {
-                background-color: var(----background--striped);
+                ----background: var(----background--striped);
             }
         }
     }
@@ -139,7 +139,7 @@
             &:hover {
                 th,
                 td {
-                    background-color: var(----background--hover);
+                    ----background: var(----background--hover);
                 }
             }
         }

--- a/src/components/ITabs/components/ITabTitle/style.scss
+++ b/src/components/ITabs/components/ITabTitle/style.scss
@@ -17,17 +17,19 @@
         transition-property: background-color, border-color, color;
         transition-duration: var(--transition-duration);
         transition-timing-function: var(--transition-easing);
+        color: var(----header--color);
+        background: var(----header--background);
 
         &.-active {
-            color: var(----header--color--active);
-            background-color: var(----header--background--active);
-            border-color: var(----header--border-color--active);
+            ----header--color: var(----header--color--active);
+            ----header--background: var(----header--background--active);
+            ----header--border-color: var(----header--border-color--active);
             font-weight: font-weight('semibold');
         }
 
         &:hover,
         &:focus {
-            background: var(----header--background--hover);
+            ----header--background: var(----header--background--hover);
             cursor: pointer;
             outline: none;
         }

--- a/src/components/ITabs/components/ITabTitle/style.scss
+++ b/src/components/ITabs/components/ITabTitle/style.scss
@@ -24,12 +24,14 @@
             ----header--color: var(----header--color--active);
             ----header--background: var(----header--background--active);
             ----header--border-color: var(----header--border-color--active);
+
             font-weight: font-weight('semibold');
         }
 
         &:hover,
         &:focus {
             ----header--background: var(----header--background--hover);
+
             cursor: pointer;
             outline: none;
         }

--- a/src/components/IToggle/style.scss
+++ b/src/components/IToggle/style.scss
@@ -23,12 +23,12 @@
 
         &:checked + .toggle-label {
             &::before {
-                background-color: var(----background--checked);
-                border-color: var(----border-color--checked);
+                ----background: var(----background--checked);
+                ----border-color: var(----border-color--checked);
             }
 
             &::after {
-                background-color: var(----indicator--background--checked);
+                ----indicator--background: var(----indicator--background--checked);
                 transform: translate(calc(#{var(----width)} / 2), 0);
             }
         }
@@ -43,24 +43,24 @@
             color: var(----label--color--disabled);
 
             &::before {
-                background-color: var(----background--disabled);
-                border-color: var(----border-color--disabled);
+                ----background: var(----background--disabled);
+                ----border-color: var(----border-color--disabled);
             }
 
             &::after {
-                background-color: var(----indicator--background--disabled);
+                ----indicator--background: var(----indicator--background--disabled);
             }
         }
 
         &:disabled:checked + .toggle-label,
         &[readonly]:checked + .toggle-label {
             &::before {
-                background-color: var(----background--checked-disabled);
-                border-color: var(----border-color--checked-disabled);
+                ----background: var(----background--checked-disabled);
+                ----border-color: var(----border-color--checked-disabled);
             }
 
             &::after {
-                background-color: var(----indicator--background--checked-disabled);
+                ----indicator--background: var(----indicator--background--checked-disabled);
             }
         }
     }

--- a/src/components/IToggle/style.scss
+++ b/src/components/IToggle/style.scss
@@ -29,6 +29,7 @@
 
             &::after {
                 ----indicator--background: var(----indicator--background--checked);
+
                 transform: translate(calc(#{var(----width)} / 2), 0);
             }
         }

--- a/src/components/ITooltip/manifest.js
+++ b/src/components/ITooltip/manifest.js
@@ -448,19 +448,256 @@ export const manifest = {
                 name: 'sm',
                 type: 'variant',
                 description: 'Variables for the sm size variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'border-top-left-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-top-left-radius)} * #{size-multiplier(\'sm\')})',
+                        description: 'The border top left radius of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'border-top-right-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-top-right-radius)} * #{size-multiplier(\'sm\')})',
+                        description: 'The border top right radius of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'border-bottom-right-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-bottom-right-radius)} * #{size-multiplier(\'sm\')})',
+                        description: 'The border bottom right radius of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'border-bottom-left-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-bottom-left-radius)} * #{size-multiplier(\'sm\')})',
+                        description: 'The border bottom left radius of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'font-size',
+                        type: '',
+                        value: 'calc(#{font-size()} * #{size-multiplier(\'sm\')})',
+                        description: 'The font size of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'margin-top',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-top) / 2)} * #{size-multiplier(\'sm\')})',
+                        description: 'The margin top of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'margin-right',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-right) / 2)} * #{size-multiplier(\'sm\')})',
+                        description: 'The margin right of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'margin-bottom',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-bottom) / 2)} * #{size-multiplier(\'sm\')})',
+                        description: 'The margin bottom of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'margin-left',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-left) / 2)} * #{size-multiplier(\'sm\')})',
+                        description: 'The margin left of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-top',
+                        type: '',
+                        value: 'calc(#{calc(var(--padding-top) * 3 / 4)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding top of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-right',
+                        type: '',
+                        value: 'calc(#{var(--padding-right)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding right of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-bottom',
+                        type: '',
+                        value: 'calc(#{calc(var(--padding-bottom) * 3 / 4)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding bottom of the tooltip component, for the sm size variant'
+                    },
+                    {
+                        name: 'padding-left',
+                        type: '',
+                        value: 'calc(#{var(--padding-left)} * #{size-multiplier(\'sm\')})',
+                        description: 'The padding left of the tooltip component, for the sm size variant'
+                    }
+                ]
             },
             {
                 name: 'md',
                 type: 'variant',
                 description: 'Variables for the md size variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'border-top-left-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-top-left-radius)} * #{size-multiplier(\'md\')})',
+                        description: 'The border top left radius of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'border-top-right-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-top-right-radius)} * #{size-multiplier(\'md\')})',
+                        description: 'The border top right radius of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'border-bottom-right-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-bottom-right-radius)} * #{size-multiplier(\'md\')})',
+                        description: 'The border bottom right radius of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'border-bottom-left-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-bottom-left-radius)} * #{size-multiplier(\'md\')})',
+                        description: 'The border bottom left radius of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'font-size',
+                        type: '',
+                        value: 'calc(#{font-size()} * #{size-multiplier(\'md\')})',
+                        description: 'The font size of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'margin-top',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-top) / 2)} * #{size-multiplier(\'md\')})',
+                        description: 'The margin top of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'margin-right',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-right) / 2)} * #{size-multiplier(\'md\')})',
+                        description: 'The margin right of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'margin-bottom',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-bottom) / 2)} * #{size-multiplier(\'md\')})',
+                        description: 'The margin bottom of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'margin-left',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-left) / 2)} * #{size-multiplier(\'md\')})',
+                        description: 'The margin left of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-top',
+                        type: '',
+                        value: 'calc(#{calc(var(--padding-top) * 3 / 4)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding top of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-right',
+                        type: '',
+                        value: 'calc(#{var(--padding-right)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding right of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-bottom',
+                        type: '',
+                        value: 'calc(#{calc(var(--padding-bottom) * 3 / 4)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding bottom of the tooltip component, for the md size variant'
+                    },
+                    {
+                        name: 'padding-left',
+                        type: '',
+                        value: 'calc(#{var(--padding-left)} * #{size-multiplier(\'md\')})',
+                        description: 'The padding left of the tooltip component, for the md size variant'
+                    }
+                ]
             },
             {
                 name: 'lg',
                 type: 'variant',
                 description: 'Variables for the lg size variant',
-                variables: []
+                variables: [
+                    {
+                        name: 'border-top-left-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-top-left-radius)} * #{size-multiplier(\'lg\')})',
+                        description: 'The border top left radius of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'border-top-right-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-top-right-radius)} * #{size-multiplier(\'lg\')})',
+                        description: 'The border top right radius of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'border-bottom-right-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-bottom-right-radius)} * #{size-multiplier(\'lg\')})',
+                        description: 'The border bottom right radius of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'border-bottom-left-radius',
+                        type: '',
+                        value: 'calc(#{var(--border-bottom-left-radius)} * #{size-multiplier(\'lg\')})',
+                        description: 'The border bottom left radius of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'font-size',
+                        type: '',
+                        value: 'calc(#{font-size()} * #{size-multiplier(\'lg\')})',
+                        description: 'The font size of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'margin-top',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-top) / 2)} * #{size-multiplier(\'lg\')})',
+                        description: 'The margin top of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'margin-right',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-right) / 2)} * #{size-multiplier(\'lg\')})',
+                        description: 'The margin right of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'margin-bottom',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-bottom) / 2)} * #{size-multiplier(\'lg\')})',
+                        description: 'The margin bottom of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'margin-left',
+                        type: '',
+                        value: 'calc(#{calc(var(--margin-left) / 2)} * #{size-multiplier(\'lg\')})',
+                        description: 'The margin left of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-top',
+                        type: '',
+                        value: 'calc(#{calc(var(--padding-top) * 3 / 4)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding top of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-right',
+                        type: '',
+                        value: 'calc(#{var(--padding-right)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding right of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-bottom',
+                        type: '',
+                        value: 'calc(#{calc(var(--padding-bottom) * 3 / 4)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding bottom of the tooltip component, for the lg size variant'
+                    },
+                    {
+                        name: 'padding-left',
+                        type: '',
+                        value: 'calc(#{var(--padding-left)} * #{size-multiplier(\'lg\')})',
+                        description: 'The padding left of the tooltip component, for the lg size variant'
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
Updates all modifier styles to update the CSS variables related to it instead of setting the property.

i.e.
~~~
&.-active {
    background: var(----background--active);
}
~~~

becomes

~~~
&.-active {
    ----background: var(----background--active);
}
~~~
