### PR TITLE
fix: Fixed dropdown closing navbar on mobile by adding stopPropagation prop to navbar items.

### DIFF
--- a/src/components/IDropdown/__tests__/index.spec.ts
+++ b/src/components/IDropdown/__tests__/index.spec.ts
@@ -310,6 +310,34 @@ describe('Components', () => {
                     });
                 });
             });
+
+            describe('onItemClick()', () => {
+                ['navbar', 'sidebar'].forEach((parent) => {
+                    it(`should call parent ${parent} onItemClick`, async () => {
+                        const onItemClick = jest.fn();
+                        const wrapper = render(IDropdown, {
+                            global: {
+                                stubs,
+                                provide: {
+                                    [parent]: {
+                                        onItemClick
+                                    }
+                                }
+                            },
+                            props: {
+                                hideOnItemClick: true,
+                                modelValue: true,
+                                ...props
+                            },
+                            slots
+                        });
+                        const menuItems = await wrapper.getAllByRole('menuitem');
+                        await fireEvent.click(menuItems[0]);
+
+                        expect(onItemClick).toHaveBeenCalled();
+                    });
+                });
+            });
         });
     });
 });

--- a/src/components/IDropdown/script.ts
+++ b/src/components/IDropdown/script.ts
@@ -52,6 +52,18 @@ export default defineComponent({
             dropdown: this
         };
     },
+    inject: {
+        navbar: {
+            default: () => ({
+                onItemClick: () => {}
+            })
+        },
+        sidebar: {
+            default: () => ({
+                onItemClick: () => {}
+            })
+        }
+    },
     props: {
         /**
          * The duration of the hide and show animation
@@ -328,6 +340,10 @@ export default defineComponent({
             if (this.hideOnItemClick) {
                 this.hide();
             }
+
+            [(this as any).navbar, (this as any).sidebar].forEach((parent) => {
+                parent.onItemClick();
+            });
         }
     }
 });

--- a/src/components/INav/components/INavItem/__tests__/index.spec.ts
+++ b/src/components/INav/components/INavItem/__tests__/index.spec.ts
@@ -74,6 +74,27 @@ describe('Components', () => {
 
                     expect(onItemClick).toHaveBeenCalled();
                 });
+
+                it('should not call parent nav onItemClick if stopPropagation', async () => {
+                    const onItemClick = jest.fn();
+                    const wrapper = render(INavItem, {
+                        global: {
+                            provide: {
+                                nav: {
+                                    onItemClick
+                                }
+                            }
+                        },
+                        props: {
+                            ...props,
+                            stopPropagation: true
+                        }
+                    });
+
+                    await fireEvent.click(wrapper.container.firstChild as Element);
+
+                    expect(onItemClick).not.toHaveBeenCalled();
+                });
             });
         });
     });

--- a/src/components/INav/components/INavItem/manifest.ts
+++ b/src/components/INav/components/INavItem/manifest.ts
@@ -23,6 +23,14 @@ export const manifest = {
             description: 'The disabled state of the nav item'
         },
         {
+            name: 'stopPropagation',
+            type: [
+                'Boolean'
+            ],
+            default: 'false',
+            description: 'Used to close the nearest navbar or sidebar by propagating the onClick event'
+        },
+        {
             name: 'tag',
             type: [
                 'String'

--- a/src/components/INav/components/INavItem/script.ts
+++ b/src/components/INav/components/INavItem/script.ts
@@ -47,6 +47,16 @@ export default defineComponent({
             default: false
         },
         /**
+         * Used to close the nearest navbar or sidebar by propagating the onClick event
+         * @type Boolean
+         * @default false
+         * @name stopPropagation
+         */
+        stopPropagation: {
+            type: Boolean,
+            default: false
+        },
+        /**
          * Set the HTML tag to be used for rendering the nav item
          * @type String
          * @default div
@@ -90,6 +100,10 @@ export default defineComponent({
     },
     methods: {
         onClick (event: ElementEvent) {
+            if (this.stopPropagation) {
+                return;
+            }
+
             (this as any).nav.onItemClick(this, event);
         }
     }

--- a/src/components/INavbar/examples/dropdown.demo.html
+++ b/src/components/INavbar/examples/dropdown.demo.html
@@ -8,7 +8,7 @@
                 Home
             </i-nav-item>
             <i-dropdown>
-                <i-nav-item>Dropdown</i-nav-item>
+                <i-nav-item stop-propagation>Dropdown</i-nav-item>
                 <template #body>
                     <i-dropdown-item>Action</i-dropdown-item>
                     <i-dropdown-item>Another action</i-dropdown-item>

--- a/src/components/INavbar/examples/dropdown.html
+++ b/src/components/INavbar/examples/dropdown.html
@@ -8,7 +8,7 @@
                 Home
             </i-nav-item>
             <i-dropdown>
-                <i-nav-item>Dropdown</i-nav-item>
+                <i-nav-item stop-propagation>Dropdown</i-nav-item>
                 <template #body>
                     <i-dropdown-item>Action</i-dropdown-item>
                     <i-dropdown-item>Another action</i-dropdown-item>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    Bug fix

* **What is the current behavior?** 
    Navbar is getting closed by opening dropdown on mobile.

* **What is the new behavior?** 
    This behaviour can be prevented by adding the `stopPropagation` prop on an `i-nav-item`.

* **Does this PR introduce a breaking change?** 
    No


