### PR TITLE
fix: Fixed issue causing autocomplete popup to have wrong position wh…

### DIFF
--- a/src/__mocks__/createMockInstance.ts
+++ b/src/__mocks__/createMockInstance.ts
@@ -19,6 +19,7 @@ interface MockInstanceOptions {
 export const createMockInstance = (component: any, { inject = {}, data = {}, props = {}, computed = {}, methods = {}, mocks = {}, $el = document.createElement('div'), $refs = {} }: MockInstanceOptions = {}) => {
     const instance: any = {
         $emit: jest.fn(),
+        $nextTick: jest.fn(() => Promise.resolve()),
         $el,
         $refs
     };

--- a/src/components/ISelect/__tests__/index.spec.ts
+++ b/src/components/ISelect/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/vue';
+import { fireEvent, render, waitFor } from '@testing-library/vue';
 import { ISelect } from '@inkline/inkline/components';
 import { createMockInstance } from '@inkline/inkline/__mocks__/createMockInstance';
 import { keymap } from '@inkline/inkline/constants';
@@ -795,6 +795,22 @@ describe('Components', () => {
                     wrapper.onWindowResize();
 
                     expect(wrapper.onScroll).toHaveBeenCalled();
+                });
+
+                it('should createPopper if visible', async () => {
+                    const wrapper = createMockInstance(ISelect, {
+                        props,
+                        data: {
+                            visible: true
+                        },
+                        mocks: {
+                            createPopper: jest.fn(() => {})
+                        }
+                    });
+
+                    wrapper.onWindowResize();
+
+                    await waitFor(() => expect(wrapper.createPopper).toHaveBeenCalled());
                 });
             });
 

--- a/src/components/ISelect/script.ts
+++ b/src/components/ISelect/script.ts
@@ -518,6 +518,10 @@ export default defineComponent({
         },
         onWindowResize () {
             this.onScroll();
+
+            if (this.visible) {
+                this.$nextTick().then(() => this.createPopper());
+            }
         },
 
         /**


### PR DESCRIPTION
…en opening mobile keyboard.

* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    Bug fix for select autocomplete

* **What is the current behavior?** 
    When the keyboard opens on mobile, the select autocomplete popup position is wrong.

* **What is the new behavior?** 
    Added window resize trigger to recreate the popper instance.