### PR TITLE
Fix dropdown hover and click outside

### DIFF
--- a/src/components/IDropdown/script.ts
+++ b/src/components/IDropdown/script.ts
@@ -1,16 +1,16 @@
 /* eslint-disable no-case-declarations */
 
-import { defineComponent } from 'vue';
+import { defineComponent } from "vue";
 import {
     PopupMixin,
     PopupControlsMixin,
     sizePropValidator,
     colorVariantClass,
-    defaultPropValue
-} from '@inkline/inkline/mixins';
-import { ClickOutside } from '@inkline/inkline/directives';
-import { on, off, isFocusable, isKey } from '@inkline/inkline/helpers';
-import { Classes } from '@inkline/inkline/types';
+    defaultPropValue,
+} from "@inkline/inkline/mixins";
+import { ClickOutside } from "@inkline/inkline/directives";
+import { on, off, isFocusable, isKey } from "@inkline/inkline/helpers";
+import { Classes } from "@inkline/inkline/types";
 
 /**
  * Slot for dropdown trigger
@@ -36,33 +36,30 @@ import { Classes } from '@inkline/inkline/types';
  * @kind slot
  */
 
-const componentName = 'IDropdown';
+const componentName = "IDropdown";
 
 export default defineComponent({
     name: componentName,
     directives: {
-        ClickOutside
+        ClickOutside,
     },
-    mixins: [
-        PopupMixin,
-        PopupControlsMixin
-    ],
-    provide () {
+    mixins: [PopupMixin, PopupControlsMixin],
+    provide() {
         return {
-            dropdown: this
+            dropdown: this,
         };
     },
     inject: {
         navbar: {
             default: () => ({
-                onItemClick: () => {}
-            })
+                onItemClick: () => {},
+            }),
         },
         sidebar: {
             default: () => ({
-                onItemClick: () => {}
-            })
-        }
+                onItemClick: () => {},
+            }),
+        },
     },
     props: {
         /**
@@ -73,7 +70,7 @@ export default defineComponent({
          */
         animationDuration: {
             type: Number,
-            default: 300
+            default: 300,
         },
         /**
          * The color variant of the dropdown
@@ -83,7 +80,7 @@ export default defineComponent({
          */
         color: {
             type: String,
-            default: defaultPropValue<string>(componentName, 'color')
+            default: defaultPropValue<string>(componentName, "color"),
         },
         /**
          * The disabled state of the dropdown
@@ -93,7 +90,7 @@ export default defineComponent({
          */
         disabled: {
             type: Boolean,
-            default: false
+            default: false,
         },
         /**
          * Used to hide the dropdown when clicking or selecting a dropdown item
@@ -103,7 +100,7 @@ export default defineComponent({
          */
         hideOnItemClick: {
             type: Boolean,
-            default: true
+            default: true,
         },
         /**
          * The keydown events bound to the trigger element
@@ -113,7 +110,14 @@ export default defineComponent({
          */
         keydownTrigger: {
             type: Array,
-            default: (): string[] => ['up', 'down', 'enter', 'space', 'tab', 'esc']
+            default: (): string[] => [
+                "up",
+                "down",
+                "enter",
+                "space",
+                "tab",
+                "esc",
+            ],
         },
         /**
          * The keydown events bound to the dropdown item elements
@@ -123,7 +127,14 @@ export default defineComponent({
          */
         keydownItem: {
             type: Array,
-            default: (): string[] => ['up', 'down', 'enter', 'space', 'tab', 'esc']
+            default: (): string[] => [
+                "up",
+                "down",
+                "enter",
+                "space",
+                "tab",
+                "esc",
+            ],
         },
         /**
          * Used to manually control the visibility of the dropdown
@@ -133,7 +144,7 @@ export default defineComponent({
          */
         modelValue: {
             type: Boolean,
-            default: false
+            default: false,
         },
         /**
          * Displays an arrow on the dropdown pointing to the trigger element
@@ -143,7 +154,7 @@ export default defineComponent({
          */
         arrow: {
             type: Boolean,
-            default: true
+            default: true,
         },
         /**
          * The placement of the dropdown
@@ -153,7 +164,7 @@ export default defineComponent({
          */
         placement: {
             type: String,
-            default: 'bottom'
+            default: "bottom",
         },
         /**
          * The events used to trigger the dropdown
@@ -163,7 +174,7 @@ export default defineComponent({
          */
         trigger: {
             type: [String, Array],
-            default: (): string[] => ['click']
+            default: (): string[] => ["click"],
         },
         /**
          * The offset of the dropdown relative to the trigger element
@@ -173,7 +184,17 @@ export default defineComponent({
          */
         offset: {
             type: Number,
-            default: 6
+            default: 6,
+        },
+        /**
+         * Determines whether hover state should be transferred from trigger to popup
+         * @type Boolean
+         * @default true
+         * @name interactable
+         */
+        interactable: {
+            type: Boolean,
+            default: true,
         },
         /**
          * Used to override the popper.js options used for creating the dropdown
@@ -183,7 +204,7 @@ export default defineComponent({
          */
         popperOptions: {
             type: Object,
-            default: (): any => ({})
+            default: (): any => ({}),
         },
         /**
          * The size variant of the dropdown
@@ -193,50 +214,50 @@ export default defineComponent({
          */
         size: {
             type: String,
-            default: defaultPropValue<string>(componentName, 'size'),
-            validator: sizePropValidator
-        }
+            default: defaultPropValue<string>(componentName, "size"),
+            validator: sizePropValidator,
+        },
     },
     emits: [
         /**
          * Event emitted for setting the modelValue
          * @event update:modelValue
          */
-        'update:modelValue'
+        "update:modelValue",
     ],
     computed: {
-        classes (): Classes {
+        classes(): Classes {
             return {
                 ...colorVariantClass(this),
-                [`-${this.size}`]: Boolean(this.size)
+                [`-${this.size}`]: Boolean(this.size),
             };
-        }
+        },
     },
-    mounted () {
+    mounted() {
         for (const child of (this.$refs.trigger as HTMLElement).children) {
-            on(child as HTMLElement, 'keydown', this.onTriggerKeyDown);
+            on(child as HTMLElement, "keydown", this.onTriggerKeyDown);
         }
 
-        on(this.$refs.popup as HTMLElement, 'keydown', this.onItemKeyDown);
+        on(this.$refs.popup as HTMLElement, "keydown", this.onItemKeyDown);
     },
-    beforeUnmount () {
+    beforeUnmount() {
         for (const child of (this.$refs.trigger as HTMLElement).children) {
-            off(child as HTMLElement, 'keydown', this.onTriggerKeyDown);
+            off(child as HTMLElement, "keydown", this.onTriggerKeyDown);
         }
 
-        off(this.$refs.popup as HTMLElement, 'keydown', this.onItemKeyDown);
+        off(this.$refs.popup as HTMLElement, "keydown", this.onItemKeyDown);
     },
     methods: {
-        onEscape () {
+        onEscape() {
             this.visible = false;
-            this.$emit('update:modelValue', false);
+            this.$emit("update:modelValue", false);
         },
-        handleClickOutside () {
+        handleClickOutside() {
             this.visible = false;
-            this.$emit('update:modelValue', false);
+            this.$emit("update:modelValue", false);
             this.onClickOutside();
         },
-        getFocusableItems (): HTMLElement[] {
+        getFocusableItems(): HTMLElement[] {
             const focusableItems = [];
 
             for (const child of (this.$refs.body as HTMLElement).children) {
@@ -247,96 +268,111 @@ export default defineComponent({
 
             return focusableItems;
         },
-        onTriggerKeyDown (event: KeyboardEvent) {
+        onTriggerKeyDown(event: KeyboardEvent) {
             if (this.keydownTrigger.length === 0) {
                 return;
             }
 
             const focusableItems = this.getFocusableItems();
-            const activeIndex = focusableItems.findIndex((item: any) => item.active);
+            const activeIndex = focusableItems.findIndex(
+                (item: any) => item.active
+            );
             const initialIndex = activeIndex > -1 ? activeIndex : 0;
             const focusTarget = focusableItems[initialIndex];
 
             switch (true) {
-            case isKey('up', event) && this.keydownTrigger.includes('up'):
-            case isKey('down', event) && this.keydownTrigger.includes('down'):
-                this.show();
+                case isKey("up", event) && this.keydownTrigger.includes("up"):
+                case isKey("down", event) &&
+                    this.keydownTrigger.includes("down"):
+                    this.show();
 
-                setTimeout(() => {
-                    focusTarget.focus();
-                }, this.visible ? 0 : this.animationDuration);
+                    setTimeout(
+                        () => {
+                            focusTarget.focus();
+                        },
+                        this.visible ? 0 : this.animationDuration
+                    );
 
-                event.preventDefault();
-                event.stopPropagation();
-                break;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    break;
 
-            case isKey('enter', event) && this.keydownTrigger.includes('enter'):
-            case isKey('space', event) && this.keydownTrigger.includes('space'):
-                this.onClick();
+                case isKey("enter", event) &&
+                    this.keydownTrigger.includes("enter"):
+                case isKey("space", event) &&
+                    this.keydownTrigger.includes("space"):
+                    this.onClick();
 
-                if (!this.visible) {
-                    setTimeout(() => {
-                        focusTarget.focus();
-                    }, this.animationDuration);
-                }
+                    if (!this.visible) {
+                        setTimeout(() => {
+                            focusTarget.focus();
+                        }, this.animationDuration);
+                    }
 
-                event.preventDefault();
-                break;
+                    event.preventDefault();
+                    break;
 
-            case isKey('tab', event) && this.keydownTrigger.includes('tab'):
-            case isKey('esc', event) && this.keydownTrigger.includes('esc'):
-                this.hide();
-                break;
+                case isKey("tab", event) && this.keydownTrigger.includes("tab"):
+                case isKey("esc", event) && this.keydownTrigger.includes("esc"):
+                    this.hide();
+                    break;
             }
         },
-        onItemKeyDown (event: KeyboardEvent) {
+        onItemKeyDown(event: KeyboardEvent) {
             if (this.keydownItem.length === 0) {
                 return;
             }
 
             switch (true) {
-            case isKey('up', event) && this.keydownItem.includes('up'):
-            case isKey('down', event) && this.keydownItem.includes('down'):
-                const focusableItems = this.getFocusableItems();
+                case isKey("up", event) && this.keydownItem.includes("up"):
+                case isKey("down", event) && this.keydownItem.includes("down"):
+                    const focusableItems = this.getFocusableItems();
 
-                const currentIndex = focusableItems.findIndex((item) => item === event.target);
-                const maxIndex = focusableItems.length - 1;
-                let nextIndex;
+                    const currentIndex = focusableItems.findIndex(
+                        (item) => item === event.target
+                    );
+                    const maxIndex = focusableItems.length - 1;
+                    let nextIndex;
 
-                if (isKey('up', event)) {
-                    nextIndex = currentIndex > 0 ? currentIndex - 1 : 0;
-                } else {
-                    nextIndex = currentIndex < maxIndex ? currentIndex + 1 : maxIndex;
-                }
+                    if (isKey("up", event)) {
+                        nextIndex = currentIndex > 0 ? currentIndex - 1 : 0;
+                    } else {
+                        nextIndex =
+                            currentIndex < maxIndex
+                                ? currentIndex + 1
+                                : maxIndex;
+                    }
 
-                focusableItems[nextIndex].focus();
+                    focusableItems[nextIndex].focus();
 
-                event.preventDefault();
-                event.stopPropagation();
-                break;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    break;
 
-            case isKey('enter', event) && this.keydownItem.includes('enter'):
-            case isKey('space', event) && this.keydownItem.includes('space'):
-                (event as any).target.click();
+                case isKey("enter", event) &&
+                    this.keydownItem.includes("enter"):
+                case isKey("space", event) &&
+                    this.keydownItem.includes("space"):
+                    (event as any).target.click();
 
-                if (this.hideOnItemClick) {
+                    if (this.hideOnItemClick) {
+                        this.hide();
+                    }
+                    this.focusTrigger();
+
+                    event.preventDefault();
+                    break;
+
+                case isKey("tab", event) && this.keydownItem.includes("tab"):
+                case isKey("esc", event) && this.keydownItem.includes("esc"):
                     this.hide();
-                }
-                this.focusTrigger();
+                    this.focusTrigger();
 
-                event.preventDefault();
-                break;
-
-            case isKey('tab', event) && this.keydownItem.includes('tab'):
-            case isKey('esc', event) && this.keydownItem.includes('esc'):
-                this.hide();
-                this.focusTrigger();
-
-                event.preventDefault();
-                break;
+                    event.preventDefault();
+                    break;
             }
         },
-        onItemClick () {
+        onItemClick() {
             if (this.hideOnItemClick) {
                 this.hide();
             }
@@ -344,6 +380,6 @@ export default defineComponent({
             [(this as any).navbar, (this as any).sidebar].forEach((parent) => {
                 parent.onItemClick();
             });
-        }
-    }
+        },
+    },
 });

--- a/src/components/IDropdown/script.ts
+++ b/src/components/IDropdown/script.ts
@@ -1,16 +1,16 @@
 /* eslint-disable no-case-declarations */
 
-import { defineComponent } from "vue";
+import { defineComponent } from 'vue';
 import {
     PopupMixin,
     PopupControlsMixin,
     sizePropValidator,
     colorVariantClass,
-    defaultPropValue,
-} from "@inkline/inkline/mixins";
-import { ClickOutside } from "@inkline/inkline/directives";
-import { on, off, isFocusable, isKey } from "@inkline/inkline/helpers";
-import { Classes } from "@inkline/inkline/types";
+    defaultPropValue
+} from '@inkline/inkline/mixins';
+import { ClickOutside } from '@inkline/inkline/directives';
+import { on, off, isFocusable, isKey } from '@inkline/inkline/helpers';
+import { Classes } from '@inkline/inkline/types';
 
 /**
  * Slot for dropdown trigger
@@ -36,30 +36,30 @@ import { Classes } from "@inkline/inkline/types";
  * @kind slot
  */
 
-const componentName = "IDropdown";
+const componentName = 'IDropdown';
 
 export default defineComponent({
     name: componentName,
     directives: {
-        ClickOutside,
+        ClickOutside
     },
     mixins: [PopupMixin, PopupControlsMixin],
-    provide() {
+    provide () {
         return {
-            dropdown: this,
+            dropdown: this
         };
     },
     inject: {
         navbar: {
             default: () => ({
-                onItemClick: () => {},
-            }),
+                onItemClick: () => {}
+            })
         },
         sidebar: {
             default: () => ({
-                onItemClick: () => {},
-            }),
-        },
+                onItemClick: () => {}
+            })
+        }
     },
     props: {
         /**
@@ -70,7 +70,7 @@ export default defineComponent({
          */
         animationDuration: {
             type: Number,
-            default: 300,
+            default: 300
         },
         /**
          * The color variant of the dropdown
@@ -80,7 +80,7 @@ export default defineComponent({
          */
         color: {
             type: String,
-            default: defaultPropValue<string>(componentName, "color"),
+            default: defaultPropValue<string>(componentName, 'color')
         },
         /**
          * The disabled state of the dropdown
@@ -90,7 +90,7 @@ export default defineComponent({
          */
         disabled: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * Used to hide the dropdown when clicking or selecting a dropdown item
@@ -100,7 +100,7 @@ export default defineComponent({
          */
         hideOnItemClick: {
             type: Boolean,
-            default: true,
+            default: true
         },
         /**
          * The keydown events bound to the trigger element
@@ -111,13 +111,13 @@ export default defineComponent({
         keydownTrigger: {
             type: Array,
             default: (): string[] => [
-                "up",
-                "down",
-                "enter",
-                "space",
-                "tab",
-                "esc",
-            ],
+                'up',
+                'down',
+                'enter',
+                'space',
+                'tab',
+                'esc'
+            ]
         },
         /**
          * The keydown events bound to the dropdown item elements
@@ -128,13 +128,13 @@ export default defineComponent({
         keydownItem: {
             type: Array,
             default: (): string[] => [
-                "up",
-                "down",
-                "enter",
-                "space",
-                "tab",
-                "esc",
-            ],
+                'up',
+                'down',
+                'enter',
+                'space',
+                'tab',
+                'esc'
+            ]
         },
         /**
          * Used to manually control the visibility of the dropdown
@@ -144,7 +144,7 @@ export default defineComponent({
          */
         modelValue: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * Displays an arrow on the dropdown pointing to the trigger element
@@ -154,7 +154,7 @@ export default defineComponent({
          */
         arrow: {
             type: Boolean,
-            default: true,
+            default: true
         },
         /**
          * The placement of the dropdown
@@ -164,7 +164,7 @@ export default defineComponent({
          */
         placement: {
             type: String,
-            default: "bottom",
+            default: 'bottom'
         },
         /**
          * The events used to trigger the dropdown
@@ -174,7 +174,7 @@ export default defineComponent({
          */
         trigger: {
             type: [String, Array],
-            default: (): string[] => ["click"],
+            default: (): string[] => ['click']
         },
         /**
          * The offset of the dropdown relative to the trigger element
@@ -184,7 +184,7 @@ export default defineComponent({
          */
         offset: {
             type: Number,
-            default: 6,
+            default: 6
         },
         /**
          * Determines whether hover state should be transferred from trigger to popup
@@ -194,7 +194,7 @@ export default defineComponent({
          */
         interactable: {
             type: Boolean,
-            default: true,
+            default: true
         },
         /**
          * Used to override the popper.js options used for creating the dropdown
@@ -204,7 +204,7 @@ export default defineComponent({
          */
         popperOptions: {
             type: Object,
-            default: (): any => ({}),
+            default: (): any => ({})
         },
         /**
          * The size variant of the dropdown
@@ -214,50 +214,50 @@ export default defineComponent({
          */
         size: {
             type: String,
-            default: defaultPropValue<string>(componentName, "size"),
-            validator: sizePropValidator,
-        },
+            default: defaultPropValue<string>(componentName, 'size'),
+            validator: sizePropValidator
+        }
     },
     emits: [
         /**
          * Event emitted for setting the modelValue
          * @event update:modelValue
          */
-        "update:modelValue",
+        'update:modelValue'
     ],
     computed: {
-        classes(): Classes {
+        classes (): Classes {
             return {
                 ...colorVariantClass(this),
-                [`-${this.size}`]: Boolean(this.size),
+                [`-${this.size}`]: Boolean(this.size)
             };
-        },
+        }
     },
-    mounted() {
+    mounted () {
         for (const child of (this.$refs.trigger as HTMLElement).children) {
-            on(child as HTMLElement, "keydown", this.onTriggerKeyDown);
+            on(child as HTMLElement, 'keydown', this.onTriggerKeyDown);
         }
 
-        on(this.$refs.popup as HTMLElement, "keydown", this.onItemKeyDown);
+        on(this.$refs.popup as HTMLElement, 'keydown', this.onItemKeyDown);
     },
-    beforeUnmount() {
+    beforeUnmount () {
         for (const child of (this.$refs.trigger as HTMLElement).children) {
-            off(child as HTMLElement, "keydown", this.onTriggerKeyDown);
+            off(child as HTMLElement, 'keydown', this.onTriggerKeyDown);
         }
 
-        off(this.$refs.popup as HTMLElement, "keydown", this.onItemKeyDown);
+        off(this.$refs.popup as HTMLElement, 'keydown', this.onItemKeyDown);
     },
     methods: {
-        onEscape() {
+        onEscape () {
             this.visible = false;
-            this.$emit("update:modelValue", false);
+            this.$emit('update:modelValue', false);
         },
-        handleClickOutside() {
+        handleClickOutside () {
             this.visible = false;
-            this.$emit("update:modelValue", false);
+            this.$emit('update:modelValue', false);
             this.onClickOutside();
         },
-        getFocusableItems(): HTMLElement[] {
+        getFocusableItems (): HTMLElement[] {
             const focusableItems = [];
 
             for (const child of (this.$refs.body as HTMLElement).children) {
@@ -268,7 +268,7 @@ export default defineComponent({
 
             return focusableItems;
         },
-        onTriggerKeyDown(event: KeyboardEvent) {
+        onTriggerKeyDown (event: KeyboardEvent) {
             if (this.keydownTrigger.length === 0) {
                 return;
             }
@@ -281,98 +281,98 @@ export default defineComponent({
             const focusTarget = focusableItems[initialIndex];
 
             switch (true) {
-                case isKey("up", event) && this.keydownTrigger.includes("up"):
-                case isKey("down", event) &&
-                    this.keydownTrigger.includes("down"):
-                    this.show();
+            case isKey('up', event) && this.keydownTrigger.includes('up'):
+            case isKey('down', event) &&
+                    this.keydownTrigger.includes('down'):
+                this.show();
 
-                    setTimeout(
-                        () => {
-                            focusTarget.focus();
-                        },
-                        this.visible ? 0 : this.animationDuration
-                    );
+                setTimeout(
+                    () => {
+                        focusTarget.focus();
+                    },
+                    this.visible ? 0 : this.animationDuration
+                );
 
-                    event.preventDefault();
-                    event.stopPropagation();
-                    break;
+                event.preventDefault();
+                event.stopPropagation();
+                break;
 
-                case isKey("enter", event) &&
-                    this.keydownTrigger.includes("enter"):
-                case isKey("space", event) &&
-                    this.keydownTrigger.includes("space"):
-                    this.onClick();
+            case isKey('enter', event) &&
+                    this.keydownTrigger.includes('enter'):
+            case isKey('space', event) &&
+                    this.keydownTrigger.includes('space'):
+                this.onClick();
 
-                    if (!this.visible) {
-                        setTimeout(() => {
-                            focusTarget.focus();
-                        }, this.animationDuration);
-                    }
+                if (!this.visible) {
+                    setTimeout(() => {
+                        focusTarget.focus();
+                    }, this.animationDuration);
+                }
 
-                    event.preventDefault();
-                    break;
+                event.preventDefault();
+                break;
 
-                case isKey("tab", event) && this.keydownTrigger.includes("tab"):
-                case isKey("esc", event) && this.keydownTrigger.includes("esc"):
-                    this.hide();
-                    break;
+            case isKey('tab', event) && this.keydownTrigger.includes('tab'):
+            case isKey('esc', event) && this.keydownTrigger.includes('esc'):
+                this.hide();
+                break;
             }
         },
-        onItemKeyDown(event: KeyboardEvent) {
+        onItemKeyDown (event: KeyboardEvent) {
             if (this.keydownItem.length === 0) {
                 return;
             }
 
             switch (true) {
-                case isKey("up", event) && this.keydownItem.includes("up"):
-                case isKey("down", event) && this.keydownItem.includes("down"):
-                    const focusableItems = this.getFocusableItems();
+            case isKey('up', event) && this.keydownItem.includes('up'):
+            case isKey('down', event) && this.keydownItem.includes('down'):
+                const focusableItems = this.getFocusableItems();
 
-                    const currentIndex = focusableItems.findIndex(
-                        (item) => item === event.target
-                    );
-                    const maxIndex = focusableItems.length - 1;
-                    let nextIndex;
+                const currentIndex = focusableItems.findIndex(
+                    (item) => item === event.target
+                );
+                const maxIndex = focusableItems.length - 1;
+                let nextIndex;
 
-                    if (isKey("up", event)) {
-                        nextIndex = currentIndex > 0 ? currentIndex - 1 : 0;
-                    } else {
-                        nextIndex =
+                if (isKey('up', event)) {
+                    nextIndex = currentIndex > 0 ? currentIndex - 1 : 0;
+                } else {
+                    nextIndex =
                             currentIndex < maxIndex
                                 ? currentIndex + 1
                                 : maxIndex;
-                    }
+                }
 
-                    focusableItems[nextIndex].focus();
+                focusableItems[nextIndex].focus();
 
-                    event.preventDefault();
-                    event.stopPropagation();
-                    break;
+                event.preventDefault();
+                event.stopPropagation();
+                break;
 
-                case isKey("enter", event) &&
-                    this.keydownItem.includes("enter"):
-                case isKey("space", event) &&
-                    this.keydownItem.includes("space"):
-                    (event as any).target.click();
+            case isKey('enter', event) &&
+                    this.keydownItem.includes('enter'):
+            case isKey('space', event) &&
+                    this.keydownItem.includes('space'):
+                (event as any).target.click();
 
-                    if (this.hideOnItemClick) {
-                        this.hide();
-                    }
-                    this.focusTrigger();
-
-                    event.preventDefault();
-                    break;
-
-                case isKey("tab", event) && this.keydownItem.includes("tab"):
-                case isKey("esc", event) && this.keydownItem.includes("esc"):
+                if (this.hideOnItemClick) {
                     this.hide();
-                    this.focusTrigger();
+                }
+                this.focusTrigger();
 
-                    event.preventDefault();
-                    break;
+                event.preventDefault();
+                break;
+
+            case isKey('tab', event) && this.keydownItem.includes('tab'):
+            case isKey('esc', event) && this.keydownItem.includes('esc'):
+                this.hide();
+                this.focusTrigger();
+
+                event.preventDefault();
+                break;
             }
         },
-        onItemClick() {
+        onItemClick () {
             if (this.hideOnItemClick) {
                 this.hide();
             }
@@ -380,6 +380,6 @@ export default defineComponent({
             [(this as any).navbar, (this as any).sidebar].forEach((parent) => {
                 parent.onItemClick();
             });
-        },
-    },
+        }
+    }
 });

--- a/src/components/IPopover/script.ts
+++ b/src/components/IPopover/script.ts
@@ -1,14 +1,14 @@
-import { defineComponent } from 'vue';
+import { defineComponent } from "vue";
 import {
     PopupMixin,
     PopupControlsMixin,
     sizePropValidator,
     colorVariantClass,
-    defaultPropValue
-} from '@inkline/inkline/mixins';
-import ClickOutside from '@inkline/inkline/directives/click-outside';
-import { Classes } from '@inkline/inkline/types';
-import { uid } from '@inkline/inkline/helpers';
+    defaultPropValue,
+} from "@inkline/inkline/mixins";
+import ClickOutside from "@inkline/inkline/directives/click-outside";
+import { Classes } from "@inkline/inkline/types";
+import { uid } from "@inkline/inkline/helpers";
 
 /**
  * Slot for tooltip trigger
@@ -34,17 +34,14 @@ import { uid } from '@inkline/inkline/helpers';
  * @kind slot
  */
 
-const componentName = 'IPopover';
+const componentName = "IPopover";
 
 export default defineComponent({
     name: componentName,
     directives: {
-        ClickOutside
+        ClickOutside,
     },
-    mixins: [
-        PopupMixin,
-        PopupControlsMixin
-    ],
+    mixins: [PopupMixin, PopupControlsMixin],
     props: {
         /**
          * The color variant of the popover
@@ -54,7 +51,7 @@ export default defineComponent({
          */
         color: {
             type: String,
-            default: defaultPropValue<string>(componentName, 'color')
+            default: defaultPropValue<string>(componentName, "color"),
         },
         /**
          * The disabled state of the popover
@@ -64,7 +61,7 @@ export default defineComponent({
          */
         disabled: {
             type: Boolean,
-            default: false
+            default: false,
         },
         /**
          * Used to manually control the visibility of the popover
@@ -74,7 +71,7 @@ export default defineComponent({
          */
         modelValue: {
             type: Boolean,
-            default: false
+            default: false,
         },
         /**
          * The identifier of the popover
@@ -84,9 +81,9 @@ export default defineComponent({
          */
         name: {
             type: String,
-            default (): string {
-                return uid('popover');
-            }
+            default(): string {
+                return uid("popover");
+            },
         },
         /**
          * Displays an arrow on the popover pointing to the trigger element
@@ -96,7 +93,7 @@ export default defineComponent({
          */
         arrow: {
             type: Boolean,
-            default: true
+            default: true,
         },
         /**
          * The placement of the popover
@@ -106,7 +103,7 @@ export default defineComponent({
          */
         placement: {
             type: String,
-            default: 'top'
+            default: "top",
         },
         /**
          * The events used to trigger the popover
@@ -116,7 +113,7 @@ export default defineComponent({
          */
         trigger: {
             type: [String, Array],
-            default: (): string[] => ['click']
+            default: (): string[] => ["click"],
         },
         /**
          * The offset of the popover relative to the trigger element
@@ -126,7 +123,17 @@ export default defineComponent({
          */
         offset: {
             type: Number,
-            default: 6
+            default: 6,
+        },
+        /**
+         * Determines whether hover state should be transferred from trigger to popup
+         * @type Boolean
+         * @default false
+         * @name interactable
+         */
+        interactable: {
+            type: Boolean,
+            default: false,
         },
         /**
          * Used to override the popper.js options used for creating the popover
@@ -136,7 +143,7 @@ export default defineComponent({
          */
         popperOptions: {
             type: Object,
-            default: (): any => ({})
+            default: (): any => ({}),
         },
         /**
          * The size variant of the popover
@@ -146,34 +153,34 @@ export default defineComponent({
          */
         size: {
             type: String,
-            default: defaultPropValue<string>(componentName, 'size'),
-            validator: sizePropValidator
-        }
+            default: defaultPropValue<string>(componentName, "size"),
+            validator: sizePropValidator,
+        },
     },
     emits: [
         /**
          * Event emitted for setting the modelValue
          * @event update:modelValue
          */
-        'update:modelValue'
+        "update:modelValue",
     ],
     computed: {
-        classes (): Classes {
+        classes(): Classes {
             return {
                 ...colorVariantClass(this),
-                [`-${this.size}`]: Boolean(this.size)
+                [`-${this.size}`]: Boolean(this.size),
             };
-        }
+        },
     },
     methods: {
-        onEscape () {
+        onEscape() {
             this.visible = false;
-            this.$emit('update:modelValue', false);
+            this.$emit("update:modelValue", false);
         },
-        handleClickOutside () {
+        handleClickOutside() {
             this.visible = false;
-            this.$emit('update:modelValue', false);
+            this.$emit("update:modelValue", false);
             this.onClickOutside();
-        }
-    }
+        },
+    },
 });

--- a/src/components/IPopover/script.ts
+++ b/src/components/IPopover/script.ts
@@ -1,14 +1,14 @@
-import { defineComponent } from "vue";
+import { defineComponent } from 'vue';
 import {
     PopupMixin,
     PopupControlsMixin,
     sizePropValidator,
     colorVariantClass,
-    defaultPropValue,
-} from "@inkline/inkline/mixins";
-import ClickOutside from "@inkline/inkline/directives/click-outside";
-import { Classes } from "@inkline/inkline/types";
-import { uid } from "@inkline/inkline/helpers";
+    defaultPropValue
+} from '@inkline/inkline/mixins';
+import ClickOutside from '@inkline/inkline/directives/click-outside';
+import { Classes } from '@inkline/inkline/types';
+import { uid } from '@inkline/inkline/helpers';
 
 /**
  * Slot for tooltip trigger
@@ -34,12 +34,12 @@ import { uid } from "@inkline/inkline/helpers";
  * @kind slot
  */
 
-const componentName = "IPopover";
+const componentName = 'IPopover';
 
 export default defineComponent({
     name: componentName,
     directives: {
-        ClickOutside,
+        ClickOutside
     },
     mixins: [PopupMixin, PopupControlsMixin],
     props: {
@@ -51,7 +51,7 @@ export default defineComponent({
          */
         color: {
             type: String,
-            default: defaultPropValue<string>(componentName, "color"),
+            default: defaultPropValue<string>(componentName, 'color')
         },
         /**
          * The disabled state of the popover
@@ -61,7 +61,7 @@ export default defineComponent({
          */
         disabled: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * Used to manually control the visibility of the popover
@@ -71,7 +71,7 @@ export default defineComponent({
          */
         modelValue: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * The identifier of the popover
@@ -81,9 +81,9 @@ export default defineComponent({
          */
         name: {
             type: String,
-            default(): string {
-                return uid("popover");
-            },
+            default (): string {
+                return uid('popover');
+            }
         },
         /**
          * Displays an arrow on the popover pointing to the trigger element
@@ -93,7 +93,7 @@ export default defineComponent({
          */
         arrow: {
             type: Boolean,
-            default: true,
+            default: true
         },
         /**
          * The placement of the popover
@@ -103,7 +103,7 @@ export default defineComponent({
          */
         placement: {
             type: String,
-            default: "top",
+            default: 'top'
         },
         /**
          * The events used to trigger the popover
@@ -113,7 +113,7 @@ export default defineComponent({
          */
         trigger: {
             type: [String, Array],
-            default: (): string[] => ["click"],
+            default: (): string[] => ['click']
         },
         /**
          * The offset of the popover relative to the trigger element
@@ -123,7 +123,7 @@ export default defineComponent({
          */
         offset: {
             type: Number,
-            default: 6,
+            default: 6
         },
         /**
          * Determines whether hover state should be transferred from trigger to popup
@@ -133,7 +133,7 @@ export default defineComponent({
          */
         interactable: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * Used to override the popper.js options used for creating the popover
@@ -143,7 +143,7 @@ export default defineComponent({
          */
         popperOptions: {
             type: Object,
-            default: (): any => ({}),
+            default: (): any => ({})
         },
         /**
          * The size variant of the popover
@@ -153,34 +153,34 @@ export default defineComponent({
          */
         size: {
             type: String,
-            default: defaultPropValue<string>(componentName, "size"),
-            validator: sizePropValidator,
-        },
+            default: defaultPropValue<string>(componentName, 'size'),
+            validator: sizePropValidator
+        }
     },
     emits: [
         /**
          * Event emitted for setting the modelValue
          * @event update:modelValue
          */
-        "update:modelValue",
+        'update:modelValue'
     ],
     computed: {
-        classes(): Classes {
+        classes (): Classes {
             return {
                 ...colorVariantClass(this),
-                [`-${this.size}`]: Boolean(this.size),
+                [`-${this.size}`]: Boolean(this.size)
             };
-        },
+        }
     },
     methods: {
-        onEscape() {
+        onEscape () {
             this.visible = false;
-            this.$emit("update:modelValue", false);
+            this.$emit('update:modelValue', false);
         },
-        handleClickOutside() {
+        handleClickOutside () {
             this.visible = false;
-            this.$emit("update:modelValue", false);
+            this.$emit('update:modelValue', false);
             this.onClickOutside();
-        },
-    },
+        }
+    }
 });

--- a/src/components/ITooltip/script.ts
+++ b/src/components/ITooltip/script.ts
@@ -1,14 +1,14 @@
-import { defineComponent } from 'vue';
+import { defineComponent } from "vue";
 import {
     PopupMixin,
     PopupControlsMixin,
     sizePropValidator,
     colorVariantClass,
-    defaultPropValue
-} from '@inkline/inkline/mixins';
-import ClickOutside from '@inkline/inkline/directives/click-outside';
-import { Classes } from '@inkline/inkline/types';
-import { uid } from '@inkline/inkline/helpers';
+    defaultPropValue,
+} from "@inkline/inkline/mixins";
+import ClickOutside from "@inkline/inkline/directives/click-outside";
+import { Classes } from "@inkline/inkline/types";
+import { uid } from "@inkline/inkline/helpers";
 
 /**
  * Slot for tooltip trigger
@@ -22,17 +22,14 @@ import { uid } from '@inkline/inkline/helpers';
  * @kind slot
  */
 
-const componentName = 'ITooltip';
+const componentName = "ITooltip";
 
 export default defineComponent({
     name: componentName,
     directives: {
-        ClickOutside
+        ClickOutside,
     },
-    mixins: [
-        PopupMixin,
-        PopupControlsMixin
-    ],
+    mixins: [PopupMixin, PopupControlsMixin],
     props: {
         /**
          * The color variant of the tooltip
@@ -42,7 +39,7 @@ export default defineComponent({
          */
         color: {
             type: String,
-            default: defaultPropValue<string>(componentName, 'color')
+            default: defaultPropValue<string>(componentName, "color"),
         },
         /**
          * The disabled state of the tooltip
@@ -52,7 +49,7 @@ export default defineComponent({
          */
         disabled: {
             type: Boolean,
-            default: false
+            default: false,
         },
         /**
          * Used to manually control the visibility of the tooltip
@@ -62,7 +59,7 @@ export default defineComponent({
          */
         modelValue: {
             type: Boolean,
-            default: false
+            default: false,
         },
         /**
          * The identifier of the tooltip
@@ -72,9 +69,9 @@ export default defineComponent({
          */
         name: {
             type: String,
-            default (): string {
-                return uid('tooltip');
-            }
+            default(): string {
+                return uid("tooltip");
+            },
         },
         /**
          * Displays an arrow on the tooltip pointing to the trigger element
@@ -84,7 +81,7 @@ export default defineComponent({
          */
         arrow: {
             type: Boolean,
-            default: true
+            default: true,
         },
         /**
          * The placement of the tooltip
@@ -94,7 +91,7 @@ export default defineComponent({
          */
         placement: {
             type: String,
-            default: 'top'
+            default: "top",
         },
         /**
          * The events used to trigger the tooltip
@@ -104,7 +101,7 @@ export default defineComponent({
          */
         trigger: {
             type: [String, Array],
-            default: (): string[] => ['hover', 'focus']
+            default: (): string[] => ["hover", "focus"],
         },
         /**
          * The offset of the tooltip relative to the trigger element
@@ -114,7 +111,17 @@ export default defineComponent({
          */
         offset: {
             type: Number,
-            default: 6
+            default: 6,
+        },
+        /**
+         * Determines whether hover state should be transferred from trigger to popup
+         * @type Boolean
+         * @default false
+         * @name interactable
+         */
+        interactable: {
+            type: Boolean,
+            default: false,
         },
         /**
          * Used to override the popper.js options used for creating the tooltip
@@ -124,7 +131,7 @@ export default defineComponent({
          */
         popperOptions: {
             type: Object,
-            default: (): any => ({})
+            default: (): any => ({}),
         },
         /**
          * The size variant of the tooltip
@@ -134,34 +141,34 @@ export default defineComponent({
          */
         size: {
             type: String,
-            default: defaultPropValue<string>(componentName, 'size'),
-            validator: sizePropValidator
-        }
+            default: defaultPropValue<string>(componentName, "size"),
+            validator: sizePropValidator,
+        },
     },
     emits: [
         /**
          * Event emitted for setting the modelValue
          * @event update:modelValue
          */
-        'update:modelValue'
+        "update:modelValue",
     ],
     computed: {
-        classes (): Classes {
+        classes(): Classes {
             return {
                 ...colorVariantClass(this),
-                [`-${this.size}`]: Boolean(this.size)
+                [`-${this.size}`]: Boolean(this.size),
             };
-        }
+        },
     },
     methods: {
-        onEscape () {
+        onEscape() {
             this.visible = false;
-            this.$emit('update:modelValue', false);
+            this.$emit("update:modelValue", false);
         },
-        handleClickOutside () {
+        handleClickOutside() {
             this.visible = false;
-            this.$emit('update:modelValue', false);
+            this.$emit("update:modelValue", false);
             this.onClickOutside();
-        }
-    }
+        },
+    },
 });

--- a/src/components/ITooltip/script.ts
+++ b/src/components/ITooltip/script.ts
@@ -1,14 +1,14 @@
-import { defineComponent } from "vue";
+import { defineComponent } from 'vue';
 import {
     PopupMixin,
     PopupControlsMixin,
     sizePropValidator,
     colorVariantClass,
-    defaultPropValue,
-} from "@inkline/inkline/mixins";
-import ClickOutside from "@inkline/inkline/directives/click-outside";
-import { Classes } from "@inkline/inkline/types";
-import { uid } from "@inkline/inkline/helpers";
+    defaultPropValue
+} from '@inkline/inkline/mixins';
+import ClickOutside from '@inkline/inkline/directives/click-outside';
+import { Classes } from '@inkline/inkline/types';
+import { uid } from '@inkline/inkline/helpers';
 
 /**
  * Slot for tooltip trigger
@@ -22,12 +22,12 @@ import { uid } from "@inkline/inkline/helpers";
  * @kind slot
  */
 
-const componentName = "ITooltip";
+const componentName = 'ITooltip';
 
 export default defineComponent({
     name: componentName,
     directives: {
-        ClickOutside,
+        ClickOutside
     },
     mixins: [PopupMixin, PopupControlsMixin],
     props: {
@@ -39,7 +39,7 @@ export default defineComponent({
          */
         color: {
             type: String,
-            default: defaultPropValue<string>(componentName, "color"),
+            default: defaultPropValue<string>(componentName, 'color')
         },
         /**
          * The disabled state of the tooltip
@@ -49,7 +49,7 @@ export default defineComponent({
          */
         disabled: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * Used to manually control the visibility of the tooltip
@@ -59,7 +59,7 @@ export default defineComponent({
          */
         modelValue: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * The identifier of the tooltip
@@ -69,9 +69,9 @@ export default defineComponent({
          */
         name: {
             type: String,
-            default(): string {
-                return uid("tooltip");
-            },
+            default (): string {
+                return uid('tooltip');
+            }
         },
         /**
          * Displays an arrow on the tooltip pointing to the trigger element
@@ -81,7 +81,7 @@ export default defineComponent({
          */
         arrow: {
             type: Boolean,
-            default: true,
+            default: true
         },
         /**
          * The placement of the tooltip
@@ -91,7 +91,7 @@ export default defineComponent({
          */
         placement: {
             type: String,
-            default: "top",
+            default: 'top'
         },
         /**
          * The events used to trigger the tooltip
@@ -101,7 +101,7 @@ export default defineComponent({
          */
         trigger: {
             type: [String, Array],
-            default: (): string[] => ["hover", "focus"],
+            default: (): string[] => ['hover', 'focus']
         },
         /**
          * The offset of the tooltip relative to the trigger element
@@ -111,7 +111,7 @@ export default defineComponent({
          */
         offset: {
             type: Number,
-            default: 6,
+            default: 6
         },
         /**
          * Determines whether hover state should be transferred from trigger to popup
@@ -121,7 +121,7 @@ export default defineComponent({
          */
         interactable: {
             type: Boolean,
-            default: false,
+            default: false
         },
         /**
          * Used to override the popper.js options used for creating the tooltip
@@ -131,7 +131,7 @@ export default defineComponent({
          */
         popperOptions: {
             type: Object,
-            default: (): any => ({}),
+            default: (): any => ({})
         },
         /**
          * The size variant of the tooltip
@@ -141,34 +141,34 @@ export default defineComponent({
          */
         size: {
             type: String,
-            default: defaultPropValue<string>(componentName, "size"),
-            validator: sizePropValidator,
-        },
+            default: defaultPropValue<string>(componentName, 'size'),
+            validator: sizePropValidator
+        }
     },
     emits: [
         /**
          * Event emitted for setting the modelValue
          * @event update:modelValue
          */
-        "update:modelValue",
+        'update:modelValue'
     ],
     computed: {
-        classes(): Classes {
+        classes (): Classes {
             return {
                 ...colorVariantClass(this),
-                [`-${this.size}`]: Boolean(this.size),
+                [`-${this.size}`]: Boolean(this.size)
             };
-        },
+        }
     },
     methods: {
-        onEscape() {
+        onEscape () {
             this.visible = false;
-            this.$emit("update:modelValue", false);
+            this.$emit('update:modelValue', false);
         },
-        handleClickOutside() {
+        handleClickOutside () {
             this.visible = false;
-            this.$emit("update:modelValue", false);
+            this.$emit('update:modelValue', false);
             this.onClickOutside();
-        },
-    },
+        }
+    }
 });

--- a/src/directives/__tests__/click-outside.spec.ts
+++ b/src/directives/__tests__/click-outside.spec.ts
@@ -1,4 +1,7 @@
-import { ClickOutsideDirective, onClickOutside } from '@inkline/inkline/directives/click-outside';
+import {
+    ClickOutsideDirective,
+    onClickOutside
+} from '@inkline/inkline/directives/click-outside';
 
 vi.mock('@inkline/inkline/helpers', async () => {
     const { isVisible } = await vi.importActual('@inkline/inkline/helpers');
@@ -17,13 +20,17 @@ const helpersModule: {
 describe('Directives', () => {
     describe('v-click-outside', () => {
         describe('beforeMount()', () => {
-            it('should attach window.document mouseup event with onClickOutside result', () => {
+            it('should attach window.document mousedown event with onClickOutside result', () => {
                 const element = document.createElement('div');
                 const binding = vi.fn();
 
                 (ClickOutsideDirective as any).beforeMount(element, binding);
 
-                expect(helpersModule.on).toHaveBeenCalledWith(window.document, 'mouseup', expect.any(Function));
+                expect(helpersModule.on).toHaveBeenCalledWith(
+                    window.document,
+                    'mousedown',
+                    expect.any(Function)
+                );
             });
         });
 

--- a/src/directives/click-outside.ts
+++ b/src/directives/click-outside.ts
@@ -1,17 +1,18 @@
 import { Directive } from 'vue';
 import { on, isVisible } from '@inkline/inkline/helpers';
 
-export const onClickOutside = (element: HTMLElement, binding: any) => (e: { target: HTMLElement }) => {
-    if (!isVisible(element) || !e.target) {
-        return;
-    }
+export const onClickOutside =
+    (element: HTMLElement, binding: any) => (e: { target: HTMLElement }) => {
+        if (!isVisible(element) || !e.target) {
+            return;
+        }
 
-    if (element === e.target || element.contains(e.target)) {
-        return;
-    }
+        if (element === e.target || element.contains(e.target)) {
+            return;
+        }
 
-    binding.value(e);
-};
+        binding.value(e);
+    };
 
 /**
  * v-click-outside
@@ -22,9 +23,9 @@ export const onClickOutside = (element: HTMLElement, binding: any) => (e: { targ
  */
 
 export const ClickOutsideDirective: Directive = {
-    beforeMount (element: HTMLElement, binding: any) {
+    beforeMount(element: HTMLElement, binding: any) {
         if (typeof window !== 'undefined') {
-            on(window.document as any, 'mouseup', onClickOutside(element, binding));
+            on(window.document as any, 'mousedown', onClickOutside(element, binding));
         }
     }
 };

--- a/src/directives/click-outside.ts
+++ b/src/directives/click-outside.ts
@@ -23,7 +23,7 @@ export const onClickOutside =
  */
 
 export const ClickOutsideDirective: Directive = {
-    beforeMount(element: HTMLElement, binding: any) {
+    beforeMount (element: HTMLElement, binding: any) {
         if (typeof window !== 'undefined') {
             on(window.document as any, 'mousedown', onClickOutside(element, binding));
         }

--- a/src/mixins/PopupControlsMixin.ts
+++ b/src/mixins/PopupControlsMixin.ts
@@ -1,60 +1,60 @@
-import { defineComponent } from "vue";
-import { on, off, focusFirstDescendant } from "@inkline/inkline/helpers";
+import { defineComponent } from 'vue';
+import { on, off, focusFirstDescendant } from '@inkline/inkline/helpers';
 
 export default defineComponent({
     props: {
         disabled: {
             type: Boolean,
-            default: false,
+            default: false
         },
         modelValue: {
             type: Boolean,
-            default: undefined,
+            default: undefined
         },
         trigger: {
             type: Array,
-            default: () => ["hover", "click", "focus"],
+            default: () => ['hover', 'click', 'focus']
         },
         interactable: {
             type: Boolean,
-            default: true,
+            default: true
         },
         hoverHideDelay: {
             type: Number,
-            default: 300,
-        },
+            default: 300
+        }
     },
-    emits: ["update:modelValue"],
-    data() {
+    emits: ['update:modelValue'],
+    data () {
         return {
             visible: this.modelValue,
             triggerStack: 0,
-            hoverHideTransition: false,
+            hoverHideTransition: false
         };
     },
     watch: {
-        modelValue(value) {
+        modelValue (value) {
             if (value) {
                 this.show();
             } else {
                 this.hide();
             }
-        },
+        }
     },
-    mounted() {
+    mounted () {
         if (!(this as any).$slots.default) {
             throw new Error(
-                "Popup components require one child element to be used as trigger."
+                'Popup components require one child element to be used as trigger.'
             );
         }
 
         this.addEventListeners();
     },
-    beforeUnmount() {
+    beforeUnmount () {
         this.removeEventListeners();
     },
     methods: {
-        show() {
+        show () {
             if (this.disabled || this.visible) {
                 return;
             }
@@ -63,9 +63,9 @@ export default defineComponent({
             this.visible = true;
 
             (this as any).createPopper();
-            this.$emit("update:modelValue", true);
+            this.$emit('update:modelValue', true);
         },
-        hide() {
+        hide () {
             if (this.disabled || !this.visible) {
                 return;
             }
@@ -78,14 +78,14 @@ export default defineComponent({
 
                 // Destroyed by <transition> component after transition is finished
                 // this.destroyPopper();
-                this.$emit("update:modelValue", false);
+                this.$emit('update:modelValue', false);
             }
         },
-        hoverShow() {
+        hoverShow () {
             this.hoverHideTransition = false;
             this.show();
         },
-        hoverHide() {
+        hoverHide () {
             this.hoverHideTransition = true;
             setTimeout(() => {
                 if (this.hoverHideTransition) {
@@ -93,119 +93,119 @@ export default defineComponent({
                 }
             }, this.hoverHideDelay);
         },
-        onClick() {
+        onClick () {
             if (this.visible) {
                 this.hide();
             } else {
                 this.show();
             }
         },
-        onClickOutside() {
+        onClickOutside () {
             if (this.modelValue) return;
 
             this.hide();
         },
-        addEventListeners() {
+        addEventListeners () {
             [].concat((this as any).trigger).forEach((trigger) => {
                 switch (trigger) {
-                    case "hover":
-                        on(
+                case 'hover':
+                    on(
                             this.$refs.trigger as HTMLElement,
-                            "mouseenter",
+                            'mouseenter',
                             this.interactable ? this.hoverShow : this.show
-                        );
-                        on(
+                    );
+                    on(
                             this.$refs.trigger as HTMLElement,
-                            "mouseleave",
+                            'mouseleave',
                             this.interactable ? this.hoverHide : this.hide
-                        );
+                    );
 
-                        if (this.interactable) {
-                            on(
-                                this.$refs.popup as HTMLElement,
-                                "mouseenter",
-                                this.hoverShow
-                            );
-                            on(
-                                this.$refs.popup as HTMLElement,
-                                "mouseleave",
-                                this.hoverHide
-                            );
-                        }
-                        break;
-                    case "click":
+                    if (this.interactable) {
                         on(
-                            this.$refs.trigger as HTMLElement,
-                            "click",
-                            this.onClick
+                                this.$refs.popup as HTMLElement,
+                                'mouseenter',
+                                this.hoverShow
                         );
-                        break;
-                    case "focus":
-                        for (const child of (this as any).$refs.trigger
-                            .children) {
-                            on(child, "focus", this.show);
-                            on(child, "blur", this.hide);
-                        }
-                        break;
-                    default:
-                        break;
+                        on(
+                                this.$refs.popup as HTMLElement,
+                                'mouseleave',
+                                this.hoverHide
+                        );
+                    }
+                    break;
+                case 'click':
+                    on(
+                            this.$refs.trigger as HTMLElement,
+                            'click',
+                            this.onClick
+                    );
+                    break;
+                case 'focus':
+                    for (const child of (this as any).$refs.trigger
+                        .children) {
+                        on(child, 'focus', this.show);
+                        on(child, 'blur', this.hide);
+                    }
+                    break;
+                default:
+                    break;
                 }
             });
         },
-        removeEventListeners() {
+        removeEventListeners () {
             [].concat((this as any).trigger).forEach((trigger) => {
                 switch (trigger) {
-                    case "hover":
-                        off(
+                case 'hover':
+                    off(
                             this.$refs.trigger as HTMLElement,
-                            "mouseenter",
+                            'mouseenter',
                             this.interactable ? this.hoverShow : this.show
-                        );
-                        off(
+                    );
+                    off(
                             this.$refs.trigger as HTMLElement,
-                            "mouseleave",
+                            'mouseleave',
                             this.interactable ? this.hoverHide : this.hide
-                        );
+                    );
 
-                        if (this.interactable) {
-                            off(
-                                this.$refs.popup as HTMLElement,
-                                "mouseenter",
-                                this.hoverShow
-                            );
-                            off(
-                                this.$refs.popup as HTMLElement,
-                                "mouseleave",
-                                this.hoverHide
-                            );
-                        }
-                        break;
-                    case "click":
+                    if (this.interactable) {
                         off(
-                            this.$refs.trigger as HTMLElement,
-                            "click",
-                            this.onClick
+                                this.$refs.popup as HTMLElement,
+                                'mouseenter',
+                                this.hoverShow
                         );
-                        break;
-                    case "focus":
-                        for (const child of (this as any).$refs.trigger
-                            .children) {
-                            off(child, "focus", this.show);
-                            off(child, "blur", this.hide);
-                        }
-                        break;
-                    default:
-                        break;
+                        off(
+                                this.$refs.popup as HTMLElement,
+                                'mouseleave',
+                                this.hoverHide
+                        );
+                    }
+                    break;
+                case 'click':
+                    off(
+                            this.$refs.trigger as HTMLElement,
+                            'click',
+                            this.onClick
+                    );
+                    break;
+                case 'focus':
+                    for (const child of (this as any).$refs.trigger
+                        .children) {
+                        off(child, 'focus', this.show);
+                        off(child, 'blur', this.hide);
+                    }
+                    break;
+                default:
+                    break;
                 }
             });
         },
-        focusTrigger() {
+        focusTrigger () {
             for (const child of (this as any).$refs.trigger.children) {
                 if (focusFirstDescendant(child)) {
                     child.focus();
                     break;
                 }
             }
-        },
-    },
+        }
+    }
 });

--- a/src/mixins/PopupControlsMixin.ts
+++ b/src/mixins/PopupControlsMixin.ts
@@ -1,49 +1,60 @@
-import { defineComponent } from 'vue';
-import { on, off, focusFirstDescendant } from '@inkline/inkline/helpers';
+import { defineComponent } from "vue";
+import { on, off, focusFirstDescendant } from "@inkline/inkline/helpers";
 
 export default defineComponent({
     props: {
         disabled: {
             type: Boolean,
-            default: false
+            default: false,
         },
         modelValue: {
             type: Boolean,
-            default: undefined
+            default: undefined,
         },
         trigger: {
             type: Array,
-            default: () => ['hover', 'click', 'focus']
-        }
+            default: () => ["hover", "click", "focus"],
+        },
+        interactable: {
+            type: Boolean,
+            default: true,
+        },
+        hoverHideDelay: {
+            type: Number,
+            default: 300,
+        },
     },
-    emits: ['update:modelValue'],
-    data () {
+    emits: ["update:modelValue"],
+    data() {
         return {
             visible: this.modelValue,
-            triggerStack: 0
+            triggerStack: 0,
+            hoverHideTransition: false,
         };
     },
     watch: {
-        modelValue (value) {
+        modelValue(value) {
             if (value) {
                 this.show();
             } else {
                 this.hide();
             }
-        }
+        },
     },
-    mounted () {
+    mounted() {
         if (!(this as any).$slots.default) {
-            throw new Error('Popup components require one child element to be used as trigger.');
+            throw new Error(
+                "Popup components require one child element to be used as trigger."
+            );
         }
 
         this.addEventListeners();
     },
-    beforeUnmount () {
+    beforeUnmount() {
         this.removeEventListeners();
     },
     methods: {
-        show () {
+        show() {
             if (this.disabled || this.visible) {
                 return;
             }
@@ -52,9 +63,9 @@ export default defineComponent({
             this.visible = true;
 
             (this as any).createPopper();
-            this.$emit('update:modelValue', true);
+            this.$emit("update:modelValue", true);
         },
-        hide () {
+        hide() {
             if (this.disabled || !this.visible) {
                 return;
             }
@@ -67,70 +78,134 @@ export default defineComponent({
 
                 // Destroyed by <transition> component after transition is finished
                 // this.destroyPopper();
-                this.$emit('update:modelValue', false);
+                this.$emit("update:modelValue", false);
             }
         },
-        onClick () {
+        hoverShow() {
+            this.hoverHideTransition = false;
+            this.show();
+        },
+        hoverHide() {
+            this.hoverHideTransition = true;
+            setTimeout(() => {
+                if (this.hoverHideTransition) {
+                    this.hide();
+                }
+            }, this.hoverHideDelay);
+        },
+        onClick() {
             if (this.visible) {
                 this.hide();
             } else {
                 this.show();
             }
         },
-        onClickOutside () {
+        onClickOutside() {
             if (this.modelValue) return;
 
             this.hide();
         },
-        addEventListeners () {
+        addEventListeners() {
             [].concat((this as any).trigger).forEach((trigger) => {
                 switch (trigger) {
-                case 'hover':
-                    on(this.$refs.trigger as HTMLElement, 'mouseenter', this.show);
-                    on(this.$refs.trigger as HTMLElement, 'mouseleave', this.hide);
-                    break;
-                case 'click':
-                    on(this.$refs.trigger as HTMLElement, 'click', this.onClick);
-                    break;
-                case 'focus':
-                    for (const child of (this as any).$refs.trigger.children) {
-                        on(child, 'focus', this.show);
-                        on(child, 'blur', this.hide);
-                    }
-                    break;
-                default:
-                    break;
+                    case "hover":
+                        on(
+                            this.$refs.trigger as HTMLElement,
+                            "mouseenter",
+                            this.interactable ? this.hoverShow : this.show
+                        );
+                        on(
+                            this.$refs.trigger as HTMLElement,
+                            "mouseleave",
+                            this.interactable ? this.hoverHide : this.hide
+                        );
+
+                        if (this.interactable) {
+                            on(
+                                this.$refs.popup as HTMLElement,
+                                "mouseenter",
+                                this.hoverShow
+                            );
+                            on(
+                                this.$refs.popup as HTMLElement,
+                                "mouseleave",
+                                this.hoverHide
+                            );
+                        }
+                        break;
+                    case "click":
+                        on(
+                            this.$refs.trigger as HTMLElement,
+                            "click",
+                            this.onClick
+                        );
+                        break;
+                    case "focus":
+                        for (const child of (this as any).$refs.trigger
+                            .children) {
+                            on(child, "focus", this.show);
+                            on(child, "blur", this.hide);
+                        }
+                        break;
+                    default:
+                        break;
                 }
             });
         },
-        removeEventListeners () {
+        removeEventListeners() {
             [].concat((this as any).trigger).forEach((trigger) => {
                 switch (trigger) {
-                case 'hover':
-                    off(this.$refs.trigger as HTMLElement, 'mouseenter', this.show);
-                    off(this.$refs.trigger as HTMLElement, 'mouseleave', this.hide);
-                    break;
-                case 'click':
-                    off(this.$refs.trigger as HTMLElement, 'click', this.onClick);
-                    break;
-                case 'focus':
-                    for (const child of (this as any).$refs.trigger.children) {
-                        off(child, 'focus', this.show);
-                        off(child, 'blur', this.hide);
-                    }
-                    break;
-                default:
-                    break;
+                    case "hover":
+                        off(
+                            this.$refs.trigger as HTMLElement,
+                            "mouseenter",
+                            this.interactable ? this.hoverShow : this.show
+                        );
+                        off(
+                            this.$refs.trigger as HTMLElement,
+                            "mouseleave",
+                            this.interactable ? this.hoverHide : this.hide
+                        );
+
+                        if (this.interactable) {
+                            off(
+                                this.$refs.popup as HTMLElement,
+                                "mouseenter",
+                                this.hoverShow
+                            );
+                            off(
+                                this.$refs.popup as HTMLElement,
+                                "mouseleave",
+                                this.hoverHide
+                            );
+                        }
+                        break;
+                    case "click":
+                        off(
+                            this.$refs.trigger as HTMLElement,
+                            "click",
+                            this.onClick
+                        );
+                        break;
+                    case "focus":
+                        for (const child of (this as any).$refs.trigger
+                            .children) {
+                            off(child, "focus", this.show);
+                            off(child, "blur", this.hide);
+                        }
+                        break;
+                    default:
+                        break;
                 }
             });
         },
-        focusTrigger () {
+        focusTrigger() {
             for (const child of (this as any).$refs.trigger.children) {
                 if (focusFirstDescendant(child)) {
                     child.focus();
                     break;
                 }
             }
-        }
-    }
+        },
+    },
 });

--- a/src/mixins/__tests__/PopupControlsMixin.spec.ts
+++ b/src/mixins/__tests__/PopupControlsMixin.spec.ts
@@ -7,6 +7,12 @@ describe('mixins', () => {
         const Component = {
             name: 'PopupControls',
             mixins: [PopupControlsMixin],
+            props: {
+                interactable: {
+                    type: Boolean,
+                    default: false
+                }
+            },
             methods: {
                 createPopper: vi.fn()
             },
@@ -68,12 +74,17 @@ describe('mixins', () => {
                             const wrapper = render(Component, {
                                 slots
                             });
-                            const trigger = wrapper.container.querySelector(triggerName);
+                            const trigger =
+                                wrapper.container.querySelector(triggerName);
 
-                            await (fireEvent as any)[eventName](trigger as Element);
+                            await (fireEvent as any)[eventName](
+                                trigger as Element
+                            );
 
                             expect(wrapper.getByRole('tooltip')).toBeVisible();
-                            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([true]);
+                            expect(
+                                wrapper.emitted()['update:modelValue'][0]
+                            ).toEqual([true]);
                         });
 
                         it('should not show popup if disabled', async () => {
@@ -83,11 +94,16 @@ describe('mixins', () => {
                                     disabled: true
                                 }
                             });
-                            const trigger = wrapper.container.querySelector(triggerName);
+                            const trigger =
+                                wrapper.container.querySelector(triggerName);
 
-                            await (fireEvent as any)[eventName](trigger as Element);
+                            await (fireEvent as any)[eventName](
+                                trigger as Element
+                            );
 
-                            expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
+                            expect(
+                                wrapper.emitted()['update:modelValue']
+                            ).not.toBeDefined();
                         });
 
                         it('should not show popup if already visible', async () => {
@@ -97,11 +113,16 @@ describe('mixins', () => {
                                     modelValue: true
                                 }
                             });
-                            const trigger = wrapper.container.querySelector(triggerName);
+                            const trigger =
+                                wrapper.container.querySelector(triggerName);
 
-                            await (fireEvent as any)[eventName](trigger as Element);
+                            await (fireEvent as any)[eventName](
+                                trigger as Element
+                            );
 
-                            expect(wrapper.emitted()['update:modelValue']).not.toEqual([[true]]);
+                            expect(
+                                wrapper.emitted()['update:modelValue']
+                            ).not.toEqual([[true]]);
                         });
                     });
                 });
@@ -121,13 +142,18 @@ describe('mixins', () => {
                                     modelValue: true
                                 }
                             });
-                            const trigger = wrapper.container.querySelector(triggerName);
+                            const trigger =
+                                wrapper.container.querySelector(triggerName);
                             const popup = await wrapper.getByRole('tooltip');
 
-                            await (fireEvent as any)[eventName](trigger as Element);
+                            await (fireEvent as any)[eventName](
+                                trigger as Element
+                            );
 
                             expect(popup).not.toBeVisible();
-                            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([false]);
+                            expect(
+                                wrapper.emitted()['update:modelValue'][0]
+                            ).toEqual([false]);
                         });
 
                         it('should not hide popup if disabled', async () => {
@@ -138,11 +164,16 @@ describe('mixins', () => {
                                     disabled: true
                                 }
                             });
-                            const trigger = wrapper.container.querySelector(triggerName);
+                            const trigger =
+                                wrapper.container.querySelector(triggerName);
 
-                            await (fireEvent as any)[eventName](trigger as Element);
+                            await (fireEvent as any)[eventName](
+                                trigger as Element
+                            );
 
-                            expect(wrapper.emitted()['update:modelValue']).not.toBeDefined();
+                            expect(
+                                wrapper.emitted()['update:modelValue']
+                            ).not.toBeDefined();
                         });
 
                         it('should not hide popup if already hidden', async () => {
@@ -152,11 +183,16 @@ describe('mixins', () => {
                                     modelValue: false
                                 }
                             });
-                            const trigger = wrapper.container.querySelector(triggerName);
+                            const trigger =
+                                wrapper.container.querySelector(triggerName);
 
-                            await (fireEvent as any)[eventName](trigger as Element);
+                            await (fireEvent as any)[eventName](
+                                trigger as Element
+                            );
 
-                            expect(wrapper.emitted()['update:modelValue']).not.toEqual([[false]]);
+                            expect(
+                                wrapper.emitted()['update:modelValue']
+                            ).not.toEqual([[false]]);
                         });
                     });
                 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    Feature #314 and Bugfix #296 

* **What is the new behavior?** 
    Popup components now have an `interactable` prop that allows transfer of hover state between trigger and popup. By default, only `IDropdown` will be interactable for now.