### PR TITLE
fix: add icollapsible keyboard accessibility

### DIFF
--- a/src/components/ICollapsible/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/components/ICollapsible/__tests__/__snapshots__/index.spec.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`Components > ICollapsible > should render correctly 1`] = `
 "<div class=\\"collapsible -light -md\\" role=\\"tablist\\" aria-multiselectable=\\"true\\">
-  <div class=\\"collapsible-item\\" name=\\"collapsible-item-1\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item-1\\" aria-expanded=\\"false\\" aria-controls=\\"collapsible-item-content-collapsible-item-1\\" aria-describedby=\\"collapsible-item-content-collapsible-item-1\\" tabindex=\\"0\\"><i class=\\"icon\\"></i></a>
+  <div class=\\"collapsible-item\\" name=\\"collapsible-item-1\\" tabindex=\\"0\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item-1\\" aria-expanded=\\"false\\" aria-controls=\\"collapsible-item-content-collapsible-item-1\\" aria-describedby=\\"collapsible-item-content-collapsible-item-1\\"><i class=\\"icon\\"></i></a>
     <transition-stub data-v-1ace5b61=\\"\\">
       <div class=\\"collapsible-body\\" role=\\"tabpanel\\" id=\\"collapsible-item-content-collapsible-item-1\\" aria-hidden=\\"true\\" aria-labelledby=\\"collapsible-item-heading-collapsible-item-1\\" style=\\"display: none;\\">
         <div class=\\"content\\"></div>
       </div>
     </transition-stub>
   </div>
-  <div class=\\"collapsible-item\\" name=\\"collapsible-item-2\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item-2\\" aria-expanded=\\"false\\" aria-controls=\\"collapsible-item-content-collapsible-item-2\\" aria-describedby=\\"collapsible-item-content-collapsible-item-2\\" tabindex=\\"0\\"><i class=\\"icon\\"></i></a>
+  <div class=\\"collapsible-item\\" name=\\"collapsible-item-2\\" tabindex=\\"0\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item-2\\" aria-expanded=\\"false\\" aria-controls=\\"collapsible-item-content-collapsible-item-2\\" aria-describedby=\\"collapsible-item-content-collapsible-item-2\\"><i class=\\"icon\\"></i></a>
     <transition-stub data-v-1ace5b61=\\"\\">
       <div class=\\"collapsible-body\\" role=\\"tabpanel\\" id=\\"collapsible-item-content-collapsible-item-2\\" aria-hidden=\\"true\\" aria-labelledby=\\"collapsible-item-heading-collapsible-item-2\\" style=\\"display: none;\\">
         <div class=\\"content\\"></div>

--- a/src/components/ICollapsible/components/ICollapsibleItem/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/components/ICollapsible/components/ICollapsibleItem/__tests__/__snapshots__/index.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`Components > ICollapsibleItem > computed > active > should add -active class when item is active 1`] = `
-"<div class=\\"collapsible-item -active\\" name=\\"collapsible-item\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item\\" aria-expanded=\\"true\\" aria-controls=\\"collapsible-item-content-collapsible-item\\" aria-describedby=\\"collapsible-item-content-collapsible-item\\" tabindex=\\"0\\"><i class=\\"icon\\"></i></a>
+"<div class=\\"collapsible-item -active\\" name=\\"collapsible-item\\" tabindex=\\"0\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item\\" aria-expanded=\\"true\\" aria-controls=\\"collapsible-item-content-collapsible-item\\" aria-describedby=\\"collapsible-item-content-collapsible-item\\"><i class=\\"icon\\"></i></a>
   <transition-stub data-v-1ace5b61=\\"\\">
     <div class=\\"collapsible-body\\" role=\\"tabpanel\\" id=\\"collapsible-item-content-collapsible-item\\" aria-hidden=\\"false\\" aria-labelledby=\\"collapsible-item-heading-collapsible-item\\">
       <div class=\\"content\\"></div>
@@ -11,7 +11,7 @@ exports[`Components > ICollapsibleItem > computed > active > should add -active 
 `;
 
 exports[`Components > ICollapsibleItem > should render correctly 1`] = `
-"<div class=\\"collapsible-item\\" name=\\"collapsible-item\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item\\" aria-expanded=\\"false\\" aria-controls=\\"collapsible-item-content-collapsible-item\\" aria-describedby=\\"collapsible-item-content-collapsible-item\\" tabindex=\\"0\\"><i class=\\"icon\\"></i></a>
+"<div class=\\"collapsible-item\\" name=\\"collapsible-item\\" tabindex=\\"0\\"><a class=\\"collapsible-header\\" role=\\"tab\\" id=\\"collapsible-item-heading-collapsible-item\\" aria-expanded=\\"false\\" aria-controls=\\"collapsible-item-content-collapsible-item\\" aria-describedby=\\"collapsible-item-content-collapsible-item\\"><i class=\\"icon\\"></i></a>
   <transition-stub data-v-1ace5b61=\\"\\">
     <div class=\\"collapsible-body\\" role=\\"tabpanel\\" id=\\"collapsible-item-content-collapsible-item\\" aria-hidden=\\"true\\" aria-labelledby=\\"collapsible-item-heading-collapsible-item\\" style=\\"display: none;\\">
       <div class=\\"content\\"></div>

--- a/src/components/ICollapsible/components/ICollapsibleItem/template.html
+++ b/src/components/ICollapsible/components/ICollapsibleItem/template.html
@@ -2,6 +2,9 @@
     class="collapsible-item"
     :class="classes"
     :name="name"
+    tabindex="0"
+    @click="onClick"
+    @keydown.prevent.enter="onClick"
 >
     <a
         class="collapsible-header"
@@ -10,8 +13,6 @@
         :aria-expanded="active ? 'true' : 'false'"
         :aria-controls="`collapsible-item-content-${name}`"
         :aria-describedby="`collapsible-item-content-${name}`"
-        tabindex="0"
-        @click="onClick"
     >
         <slot name="header">
             {{ title }}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [X] The commit message follows our guidelines
    - [X] Tests for the changes have been added (for bug fixes / features)
    - [X] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    Fixes ability to tab between collapsible parent items as well as open an item via the Enter key.

* **What is the current behavior?** 
    Cannot successfully navigate collapsible items via a keyboard.

* **What is the new behavior?** 
    If this is a feature change ...

* **Does this PR introduce a breaking change?** 
    No.

* **Other information**:


