### PR TITLE
fix: remove redundant link role from link components

### DIFF
--- a/src/components/IDropdownItem/IDropdownItem.vue
+++ b/src/components/IDropdownItem/IDropdownItem.vue
@@ -104,7 +104,7 @@ export default defineComponent({
             return disabled.value ? 'true' : null;
         });
 
-        const role = computed(() => (props.to || props.href ? 'link' : 'menuitem'));
+        const role = computed(() => (props.to || props.href ? null : 'menuitem'));
         const tabIndex = computed(() => (disabled.value ? -1 : props.tabindex));
 
         function onClick(event: Event) {

--- a/src/components/IListGroupItem/IListGroupItem.vue
+++ b/src/components/IListGroupItem/IListGroupItem.vue
@@ -84,7 +84,7 @@ export default defineComponent({
             return disabled.value ? 'true' : null;
         });
 
-        const role = computed(() => (props.to || props.href ? 'link' : 'listitem'));
+        const role = computed(() => (props.to || props.href ? null : 'listitem'));
         const tabIndex = computed(() => (disabled.value ? -1 : props.tabindex));
 
         const classes = computed(() => ({

--- a/src/components/INavItem/INavItem.vue
+++ b/src/components/INavItem/INavItem.vue
@@ -102,7 +102,7 @@ export default defineComponent({
             '-disabled': disabled.value
         }));
 
-        const role = computed(() => (props.to || props.href ? 'link' : 'menuitem'));
+        const role = computed(() => (props.to || props.href ? null : 'menuitem'));
         const tabIndex = computed(() => (disabled.value ? -1 : props.tabindex));
 
         function onClick(event: Event) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [ ] Tests for the changes have been added (for bug fixes / features)
    - [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    On the components that can be used as links (IButton, IDropdownItem, IListGroupItem and INavItem) the aria-role "link" was redundant because they were already rendered as links.

* **What is the current behavior?** 
    a6e99d2 only IButton has the role removed

* **What is the new behavior?** 
    IDropdownItem, IListGroupItem and INavItem have the fix implemented as well

* **Does this PR introduce a breaking change?** 
    None

* **Other information**:


