### PR TITLE
fix: normalize inject key import paths to fix symbols regeneration bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1095,6 +1095,11 @@
             "import": "./constants/eventValueMap.mjs",
             "types": "./constants/eventValueMap.d.ts"
         },
+        "./constants/injectKeys": {
+            "require": "./constants/injectKeys.js",
+            "import": "./constants/injectKeys.mjs",
+            "types": "./constants/injectKeys.d.ts"
+        },
         "./constants/keymap": {
             "require": "./constants/keymap.js",
             "import": "./constants/keymap.mjs",

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -1,10 +1,10 @@
 import {
     createInklineService,
     Inkline,
-    InklineKey,
     InklineOptions,
     InklinePluginOptions
 } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { IButton } from '@inkline/inkline/components';
 import { i18n } from '@inkline/inkline/i18n';
 

--- a/src/components/IAlert/__tests__/index.spec.ts
+++ b/src/components/IAlert/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IAlert } from '@inkline/inkline/components';
 import { createInkline, Placeholder } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 
 describe('Components', () => {
     describe('IAlert', () => {

--- a/src/components/IBadge/__tests__/index.spec.ts
+++ b/src/components/IBadge/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IBadge } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IBreadcrumb/__tests__/index.spec.ts
+++ b/src/components/IBreadcrumb/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IBreadcrumb } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IBreadcrumbItem/__tests__/index.spec.ts
+++ b/src/components/IBreadcrumbItem/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IBreadcrumbItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IButton/__tests__/index.spec.ts
+++ b/src/components/IButton/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/vue';
 import { IButton } from '@inkline/inkline/components/IButton';
 import { ref } from 'vue';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { FormGroupKey } from '@inkline/inkline/components/IFormGroup/mixin';
 import { ButtonGroupKey } from '@inkline/inkline/components/IButtonGroup/mixin';
@@ -189,7 +189,6 @@ describe('Components', () => {
                 expect(wrapper.container.firstChild).not.toHaveAttribute('role', 'button');
             });
 
-
             it('should provide role="button" for non-button tags', () => {
                 const wrapper = render(IButton, {
                     props: {
@@ -315,7 +314,6 @@ describe('Components', () => {
                     props: {
                         tag: 'a',
                         type: 'button'
-
                     },
                     global: {
                         provide: {

--- a/src/components/IButtonGroup/__tests__/index.spec.ts
+++ b/src/components/IButtonGroup/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IButtonGroup } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { ButtonGroupKey } from '@inkline/inkline/components/IButtonGroup/mixin';
 import { ref } from 'vue';

--- a/src/components/ICard/__tests__/index.spec.ts
+++ b/src/components/ICard/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ICard } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ICheckbox/__tests__/index.spec.ts
+++ b/src/components/ICheckbox/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ICheckbox } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { FormGroupKey } from '@inkline/inkline/components/IFormGroup/mixin';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';

--- a/src/components/ICheckboxGroup/__tests__/index.spec.ts
+++ b/src/components/ICheckboxGroup/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ICheckbox, ICheckboxGroup } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';
 import { ref } from 'vue';

--- a/src/components/ICollapsible/__tests__/index.spec.ts
+++ b/src/components/ICollapsible/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ICollapsible, ICollapsibleItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ICollapsibleItem/__tests__/index.spec.ts
+++ b/src/components/ICollapsibleItem/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ICollapsibleItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { CollapsibleKey } from '@inkline/inkline/components/ICollapsible/mixin';
 import { ref } from 'vue';

--- a/src/components/IColumn/__tests__/index.spec.ts
+++ b/src/components/IColumn/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IColumn } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IContainer/__tests__/index.spec.ts
+++ b/src/components/IContainer/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IContainer } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IDropdown/__tests__/index.spec.ts
+++ b/src/components/IDropdown/__tests__/index.spec.ts
@@ -1,7 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IButton, IDropdown, IDropdownDivider, IDropdownItem } from '@inkline/inkline/components';
-import { keymap } from '@inkline/inkline/constants';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { keymap, InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { NavbarKey } from '@inkline/inkline/components/INavbar/mixin';
 import { SidebarKey } from '@inkline/inkline/components/ISidebar/mixin';

--- a/src/components/IDropdownDivider/__tests__/index.spec.ts
+++ b/src/components/IDropdownDivider/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/vue';
 import { IDropdownDivider } from '@inkline/inkline/components';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 
 describe('Components', () => {
     describe('IDropdownDivider', () => {

--- a/src/components/IDropdownItem/__tests__/index.spec.ts
+++ b/src/components/IDropdownItem/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IDropdownItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { DropdownKey } from '@inkline/inkline/components/IDropdown/mixin';
 import { ref } from 'vue';

--- a/src/components/IForm/__tests__/index.spec.ts
+++ b/src/components/IForm/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IForm, IInput } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IFormError/__tests__/index.spec.ts
+++ b/src/components/IFormError/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IFormError } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';
 import { ref } from 'vue';

--- a/src/components/IFormGroup/__tests__/index.spec.ts
+++ b/src/components/IFormGroup/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IFormGroup, IInput } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';
 import { ref } from 'vue';

--- a/src/components/IFormLabel/__tests__/index.spec.ts
+++ b/src/components/IFormLabel/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IFormLabel } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IHamburgerMenu/__tests__/index.spec.ts
+++ b/src/components/IHamburgerMenu/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IHamburgerMenu } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IHeader/__tests__/index.spec.ts
+++ b/src/components/IHeader/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IHeader } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IIcon/IIcon.vue
+++ b/src/components/IIcon/IIcon.vue
@@ -3,7 +3,7 @@ import { h, computed, defineComponent, onMounted, inject } from 'vue';
 import { toCamelCase } from '@grozav/utils';
 import { renderSvg } from '@inkline/inkline/utils';
 import { useComponentSize } from '@inkline/inkline/composables';
-import { InklineIconsKey } from '@inkline/inkline/plugins';
+import { InklineIconsKey } from '@inkline/inkline';
 
 /**
  * The icon to be displayed

--- a/src/components/IIcon/__tests__/index.spec.ts
+++ b/src/components/IIcon/__tests__/index.spec.ts
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IIcon } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
-import { InklineIconsKey } from '@inkline/inkline/plugins';
+import { InklineKey, InklineIconsKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IInput/__tests__/index.spec.ts
+++ b/src/components/IInput/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IInput } from '@inkline/inkline/components';
 import { createInkline, Placeholder } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';
 import { ref } from 'vue';
 

--- a/src/components/ILayout/__tests__/index.spec.ts
+++ b/src/components/ILayout/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ILayout } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ILayoutAside/__tests__/index.spec.ts
+++ b/src/components/ILayoutAside/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ILayoutAside } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ILayoutContent/__tests__/index.spec.ts
+++ b/src/components/ILayoutContent/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ILayoutContent } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ILayoutFooter/__tests__/index.spec.ts
+++ b/src/components/ILayoutFooter/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ILayoutFooter } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ILayoutHeader/__tests__/index.spec.ts
+++ b/src/components/ILayoutHeader/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ILayoutHeader } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IListGroup/__tests__/index.spec.ts
+++ b/src/components/IListGroup/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IListGroup, IListGroupItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IListGroupItem/__tests__/index.spec.ts
+++ b/src/components/IListGroupItem/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IListGroupItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ILoader/__tests__/index.spec.ts
+++ b/src/components/ILoader/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ILoader } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IMark/__tests__/index.spec.ts
+++ b/src/components/IMark/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IMark } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IMedia/__tests__/index.spec.ts
+++ b/src/components/IMedia/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IMedia } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IModal/__tests__/index.spec.ts
+++ b/src/components/IModal/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IModal } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/INav/__tests__/index.spec.ts
+++ b/src/components/INav/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { INav, INavItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { NavbarKey } from '@inkline/inkline/components/INavbar/mixin';
 import { SidebarKey } from '@inkline/inkline/components/ISidebar/mixin';

--- a/src/components/INavItem/__tests__/index.spec.ts
+++ b/src/components/INavItem/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { INavItem } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { NavKey } from '@inkline/inkline/components/INav/mixin';
 

--- a/src/components/INavbar/__tests__/index.spec.ts
+++ b/src/components/INavbar/__tests__/index.spec.ts
@@ -6,7 +6,7 @@ import {
     INavbarCollapsible,
     INavItem
 } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/INavbarBrand/__tests__/index.spec.ts
+++ b/src/components/INavbarBrand/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { INavbarBrand } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/INavbarCollapsible/__tests__/index.spec.ts
+++ b/src/components/INavbarCollapsible/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { INavbarCollapsible } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { NavbarKey } from '@inkline/inkline/components/INavbar/mixin';
 import { ref } from 'vue';

--- a/src/components/INumberInput/__tests__/index.spec.ts
+++ b/src/components/INumberInput/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { INumberInput } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IPagination/__tests__/index.spec.ts
+++ b/src/components/IPagination/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IPagination } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IPopover/__tests__/index.spec.ts
+++ b/src/components/IPopover/__tests__/index.spec.ts
@@ -1,8 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IPopover } from '@inkline/inkline/components';
-import { keymap } from '@inkline/inkline/constants';
+import { keymap, InklineKey } from '@inkline/inkline/constants';
 import { createInkline, Placeholder, PlaceholderButton } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
 
 describe('Components', () => {
     describe('IPopover', () => {

--- a/src/components/IProgress/__tests__/index.spec.ts
+++ b/src/components/IProgress/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IProgress, IProgressBar } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/IProgressBar/__tests__/index.spec.ts
+++ b/src/components/IProgressBar/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IProgressBar } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { ProgressKey } from '@inkline/inkline/components/IProgressBar/mixin';
 import { ref } from 'vue';

--- a/src/components/IRadio/__tests__/index.spec.ts
+++ b/src/components/IRadio/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IRadio } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { RadioGroupKey } from '@inkline/inkline/components/IRadioGroup';
 import { ref } from 'vue';

--- a/src/components/IRadioGroup/__tests__/index.spec.ts
+++ b/src/components/IRadioGroup/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IRadio, IRadioGroup } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';
 import { ref } from 'vue';

--- a/src/components/IRow/__tests__/index.spec.ts
+++ b/src/components/IRow/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { IRow } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ISelect/__tests__/index.spec.ts
+++ b/src/components/ISelect/__tests__/index.spec.ts
@@ -1,7 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ISelect } from '@inkline/inkline/components';
-import { keymap } from '@inkline/inkline/constants';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { keymap, InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { ref } from 'vue';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';

--- a/src/components/ISelectOption/__tests__/index.spec.ts
+++ b/src/components/ISelectOption/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ISelectOption } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { SelectKey } from '@inkline/inkline/components/ISelect/mixin';
 import { ref } from 'vue';

--- a/src/components/ISidebar/__tests__/index.spec.ts
+++ b/src/components/ISidebar/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { INav, INavItem, ISidebar } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ITab/__tests__/index.spec.ts
+++ b/src/components/ITab/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ITab } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { TabsKey } from '@inkline/inkline/components/ITabs/mixin';
 import { ref } from 'vue';

--- a/src/components/ITabTitle/__tests__/index.spec.ts
+++ b/src/components/ITabTitle/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ITabTitle } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { ref } from 'vue';
 import { TabsKey } from '@inkline/inkline/components/ITabs/mixin';

--- a/src/components/ITable/__tests__/index.spec.ts
+++ b/src/components/ITable/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import { ITable } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ITabs/__tests__/index.spec.ts
+++ b/src/components/ITabs/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ITabs, ITab, ITabTitle } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 
 describe('Components', () => {

--- a/src/components/ITextarea/__tests__/index.spec.ts
+++ b/src/components/ITextarea/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ITextarea } from '@inkline/inkline/components';
 import { createInkline, Placeholder } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';
 import { ref } from 'vue';
 

--- a/src/components/IToast/__tests__/index.spec.ts
+++ b/src/components/IToast/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IToast } from '@inkline/inkline/components';
 import { createInkline, Placeholder } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 
 describe('Components', () => {
     describe('IToast', () => {

--- a/src/components/IToastContainer/__tests__/index.spec.ts
+++ b/src/components/IToastContainer/__tests__/index.spec.ts
@@ -1,9 +1,8 @@
 import { render } from '@testing-library/vue';
 import { IToastContainer } from '@inkline/inkline/components';
 import { createInkline, retry } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey, InklineIconsKey } from '@inkline/inkline/constants';
 import { createEventBus } from '@grozav/utils';
-import { InklineIconsKey } from '@inkline/inkline/plugins';
 import * as inklineIcons from '@inkline/inkline/icons';
 
 describe('Components', () => {

--- a/src/components/IToggle/__tests__/index.spec.ts
+++ b/src/components/IToggle/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { IToggle } from '@inkline/inkline/components';
-import { InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline/constants';
 import { createInkline } from '@inkline/inkline/__tests__/utils';
 import { ref } from 'vue';
 import { FormKey } from '@inkline/inkline/components/IForm/mixin';

--- a/src/components/ITooltip/__tests__/index.spec.ts
+++ b/src/components/ITooltip/__tests__/index.spec.ts
@@ -1,8 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue';
 import { ITooltip } from '@inkline/inkline/components';
-import { keymap } from '@inkline/inkline/constants';
+import { keymap, InklineKey } from '@inkline/inkline/constants';
 import { createInkline, Placeholder, PlaceholderButton } from '@inkline/inkline/__tests__/utils';
-import { InklineKey } from '@inkline/inkline/plugin';
 
 describe('Components', () => {
     describe('ITooltip', () => {

--- a/src/composables/inkline.ts
+++ b/src/composables/inkline.ts
@@ -1,5 +1,6 @@
 import { inject } from 'vue';
-import { InklineService, InklineKey } from '@inkline/inkline/plugin';
+import { InklineKey } from '@inkline/inkline';
+import type { InklineService } from '@inkline/inkline/plugin';
 
 export function useInkline() {
     return inject(InklineKey) as InklineService;

--- a/src/composables/toast.ts
+++ b/src/composables/toast.ts
@@ -1,6 +1,7 @@
 import { inject } from 'vue';
-import { ToastKey, ToastService } from '@inkline/inkline/plugins';
+import { InklineToastKey } from '@inkline/inkline';
+import type { ToastService } from '@inkline/inkline/plugins';
 
 export function useToast() {
-    return inject(ToastKey) as ToastService;
+    return inject(InklineToastKey) as ToastService;
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from '@inkline/inkline/constants/breakpoints';
-export * from '@inkline/inkline/constants/keymap';
 export * from '@inkline/inkline/constants/eventValueMap';
+export * from '@inkline/inkline/constants/injectKeys';
+export * from '@inkline/inkline/constants/keymap';
 export * from '@inkline/inkline/constants/validation';

--- a/src/constants/injectKeys.ts
+++ b/src/constants/injectKeys.ts
@@ -1,0 +1,10 @@
+import { InjectionKey } from 'vue/dist/vue';
+import type { InklineService } from '@inkline/inkline/plugin';
+import type { ToastService } from '@inkline/inkline/plugins';
+import type { SvgNode } from '@inkline/inkline/types';
+
+export const InklineKey = Symbol('inkline') as InjectionKey<InklineService>;
+
+export const InklineIconsKey = Symbol('inklineIcons') as InjectionKey<Record<string, SvgNode>>;
+
+export const InklineToastKey = Symbol('inklineToast') as InjectionKey<ToastService>;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,17 +1,14 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { InjectionKey, Plugin, reactive, watch } from 'vue';
+import { Plugin, reactive } from 'vue';
 import { addClass } from '@grozav/utils';
 import { initialize as initializeForm } from '@inkline/inkline/validation';
 import { setLocale } from '@inkline/inkline/i18n';
-import {
-    ColorModePlugin,
+import { ColorModePlugin, ToastPlugin, IconsPlugin, OverlayPlugin } from '@inkline/inkline/plugins';
+import type {
     InklineColorModeOptions,
-    ToastPlugin,
     InklineToastOptions,
-    IconsPlugin,
-    InklineIconsPluginOptions,
-    OverlayPlugin
+    InklineIconsPluginOptions
 } from '@inkline/inkline/plugins';
+import { InklineKey } from '@inkline/inkline';
 
 export interface InklineOptions extends InklineColorModeOptions, InklineToastOptions {
     locale: string;
@@ -35,14 +32,12 @@ export interface InklineService {
     options: InklineOptions;
 }
 
-export const InklineKey = Symbol('inkline') as InjectionKey<InklineService>;
-
 /**
  * Create inkline prototype
  */
 export function createInklineService({
-    icons,
-    components,
+    icons, // eslint-disable-line @typescript-eslint/no-unused-vars
+    components, // eslint-disable-line @typescript-eslint/no-unused-vars
     ...options
 }: InklinePluginOptions): InklineService {
     return {

--- a/src/plugins/__tests__/icons.spec.ts
+++ b/src/plugins/__tests__/icons.spec.ts
@@ -1,4 +1,5 @@
-import { IconsPlugin, InklineIconsKey } from '@inkline/inkline/plugins';
+import { IconsPlugin } from '@inkline/inkline/plugins';
+import { InklineIconsKey } from '@inkline/inkline/constants';
 import * as inklineIcons from '@inkline/inkline/icons';
 
 describe('IconsPlugin', () => {

--- a/src/plugins/icons.ts
+++ b/src/plugins/icons.ts
@@ -1,8 +1,7 @@
-import { InjectionKey, Plugin } from 'vue';
+import type { Plugin } from 'vue';
+import type { SvgNode } from '@inkline/inkline/types';
 import * as inklineIcons from '@inkline/inkline/icons';
-import { SvgNode } from '@inkline/inkline/types';
-
-export const InklineIconsKey = Symbol('inklineIcons') as InjectionKey<Record<string, SvgNode>>;
+import { InklineIconsKey } from '@inkline/inkline';
 
 export interface InklineIconsPluginOptions {
     icons: Record<string, SvgNode>;

--- a/src/plugins/toast.ts
+++ b/src/plugins/toast.ts
@@ -1,6 +1,7 @@
 import { createEventBus } from '@grozav/utils';
-import type { InjectionKey, Plugin, VNode } from 'vue';
+import type { Plugin, VNode } from 'vue';
 import type { EventBus } from '@grozav/utils';
+import { InklineToastKey } from '@inkline/inkline';
 
 export type ToastPosition =
     | 'top-left'
@@ -60,13 +61,11 @@ export const createToastService = (): ToastService => ({
     }
 });
 
-export const ToastKey = Symbol('toast') as InjectionKey<ToastService>;
-
 export const ToastPlugin: Plugin = {
     install: (app) => {
         const toastService = createToastService();
 
         app.config.globalProperties.$toast = toastService;
-        app.provide(ToastKey, toastService);
+        app.provide(InklineToastKey, toastService);
     }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "rootDir": "src",
         "outDir": "lib",
         "paths": {
+            "@inkline/inkline": ["./src/inkline.ts"],
             "@inkline/inkline/*": ["./src/*"]
         },
         "lib": ["esnext", "dom", "dom.iterable", "scripthost"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
     resolve: {
         alias: [
             {
+                find: /^@inkline\/inkline$/,
+                replacement: `${resolve(__dirname)}/src/inkline.ts`
+            },
+            {
                 find: /^@inkline\/inkline\//,
                 replacement: `${resolve(__dirname)}/src/`
             }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    Bug fix

* **What is the current behavior?** 
    Vite wrongly differentiates between direct symbols imports and re-exported symbol imports.

* **What is the new behavior?** 
    The symbols are now all imported from `@inkline/inkline`, fixing the issue.

* **Does this PR introduce a breaking change?** 
    All inject symbols are now found in `@inkline/inkline/constants/injectKeys`.


