### PR TITLE
Last of type fix

### DIFF
--- a/src/components/IAlert/css/_component.scss
+++ b/src/components/IAlert/css/_component.scss
@@ -125,13 +125,5 @@
             margin-right: 0;
             margin-left: 0;
         }
-
-        > *:first-of-type {
-            margin-top: 0;
-        }
-
-        > *:last-of-type {
-            margin-bottom: 0;
-        }
     }
 }

--- a/src/components/IAlert/examples/basic.vue
+++ b/src/components/IAlert/examples/basic.vue
@@ -3,6 +3,6 @@
         <template #icon>
             <IIcon name="ink-circle" />
         </template>
-        <p>Heads up! This alert needs your attention, and it might be <a href="">important</a>.</p>
+        Heads up! This alert needs your attention, and it might be <a href="">important</a>.
     </IAlert>
 </template>

--- a/src/components/IAlert/examples/color-variants.vue
+++ b/src/components/IAlert/examples/color-variants.vue
@@ -3,27 +3,27 @@
         <template #icon>
             <IIcon name="ink-info" />
         </template>
-        <p>Heads up! This alert needs your attention, but it's not super important.</p>
+        Heads up! This alert needs your attention, but it's not super important.
     </IAlert>
 
     <IAlert color="success">
         <template #icon>
             <IIcon name="ink-check" />
         </template>
-        <p>Well done! You successfully read this important alert message.</p>
+        Well done! You successfully read this important alert message.
     </IAlert>
 
     <IAlert color="warning">
         <template #icon>
             <IIcon name="ink-warning" />
         </template>
-        <p>Warning! Better check yourself, you're not looking too good.</p>
+        Warning! Better check yourself, you're not looking too good.
     </IAlert>
 
     <IAlert color="danger">
         <template #icon>
             <IIcon name="ink-danger" />
         </template>
-        <p>Oh snap! Change a few things up and try submitting again.</p>
+        Oh snap! Change a few things up and try submitting again.
     </IAlert>
 </template>

--- a/src/components/IAlert/examples/content.vue
+++ b/src/components/IAlert/examples/content.vue
@@ -4,7 +4,7 @@
             <IIcon name="ink-info" size="lg" />
         </template>
         <template #title>Alert Title</template>
-        <p class="_margin-top:0">
+        <p class="_margin:0">
             Some quick example text to build on the alert and make up the bulk of the alert's
             content.
         </p>

--- a/src/components/IAlert/examples/dismissible.vue
+++ b/src/components/IAlert/examples/dismissible.vue
@@ -5,5 +5,5 @@ const visible = ref(true);
 </script>
 
 <template>
-    <IAlert v-model="visible" dismissible> <p>Whoa! Nicely done.</p> </IAlert>
+    <IAlert v-model="visible" dismissible> Whoa! Nicely done. </IAlert>
 </template>

--- a/src/components/IAlert/examples/icon.vue
+++ b/src/components/IAlert/examples/icon.vue
@@ -3,9 +3,7 @@
         <template #icon>
             <IIcon name="ink-info" />
         </template>
-        <p>
-            Some quick example text to build on the alert title and make up the bulk of the alert's
-            content.
-        </p>
+        Some quick example text to build on the alert title and make up the bulk of the alert's
+        content.
     </IAlert>
 </template>

--- a/src/components/ICard/css/_component.scss
+++ b/src/components/ICard/css/_component.scss
@@ -270,22 +270,14 @@
             var(--card--transition-timing-function, var(--transition-timing-function))
         );
 
-        &:not(:first-of-type) {
+        &:not(:first-child) {
             border-top-left-radius: 0;
             border-top-right-radius: 0;
         }
 
-        &:not(:last-of-type) {
+        &:not(:last-child) {
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
-        }
-
-        > *:first-of-type {
-            margin-top: 0;
-        }
-
-        > *:last-of-type {
-            margin-bottom: 0;
         }
     }
 
@@ -373,16 +365,14 @@
             var(--card--transition-timing-function, var(--transition-timing-function))
         );
 
-        &:last-of-type {
-            border-bottom-left-radius: var(
-                --card--footer--border-bottom-left-radius,
-                var(--card--border-bottom-left-radius)
-            );
-            border-bottom-right-radius: var(
-                --card--footer--border-bottom-right-radius,
-                var(--card--border-bottom-right-radius)
-            );
-        }
+        border-bottom-left-radius: var(
+            --card--footer--border-bottom-left-radius,
+            var(--card--border-bottom-left-radius)
+        );
+        border-bottom-right-radius: var(
+            --card--footer--border-bottom-right-radius,
+            var(--card--border-bottom-right-radius)
+        );
     }
 
     > img {

--- a/src/components/ICard/css/_component.scss
+++ b/src/components/ICard/css/_component.scss
@@ -392,11 +392,6 @@
         margin-left: 0;
     }
 
-    &:last-of-type {
-        border-bottom-left-radius: var(--card--border-bottom-left-radius);
-        border-bottom-right-radius: var(--card--border-bottom-right-radius);
-    }
-
     > .list-group:first-of-type,
     .list-group-item:first-of-type {
         border-top-left-radius: var(

--- a/src/components/IDropdown/css/_component.scss
+++ b/src/components/IDropdown/css/_component.scss
@@ -312,7 +312,7 @@
             );
         }
 
-        > *:nth-child(2) {
+        > div:first-of-type {
             border-top-left-radius: var(
                 --dropdown--border-top-left-radius,
                 var(--border-top-left-radius)
@@ -323,7 +323,7 @@
             );
         }
 
-        > *:last-of-type {
+        > div:last-of-type {
             border-bottom-left-radius: var(
                 --dropdown--border-bottom-left-radius,
                 var(--border-bottom-left-radius)

--- a/src/components/IListGroup/examples/content.vue
+++ b/src/components/IListGroup/examples/content.vue
@@ -2,24 +2,25 @@
     <IListGroup>
         <IListGroupItem>
             <h4>List Group Heading</h4>
-            <p>
+            <p class="_margin:0">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua.
             </p>
         </IListGroupItem>
         <IListGroupItem>
             <h4>List Group Heading</h4>
-            <p>
+            <p class="_margin:0">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua.
             </p>
         </IListGroupItem>
         <IListGroupItem>
             <h4>List Group Heading</h4>
-            <p>
+            <p class="_margin:0">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua.
             </p>
         </IListGroupItem>
     </IListGroup>
 </template>
+<script setup></script>

--- a/src/components/IListGroupItem/css/_component.scss
+++ b/src/components/IListGroupItem/css/_component.scss
@@ -41,14 +41,6 @@
         text-decoration: none;
     }
 
-    > *:first-of-type {
-        margin-top: 0;
-    }
-
-    > *:last-of-type {
-        margin-bottom: 0;
-    }
-
     &.-disabled {
         color: var(--list-group--disabled--color);
         pointer-events: none;

--- a/src/components/IMedia/css/_component.scss
+++ b/src/components/IMedia/css/_component.scss
@@ -9,14 +9,6 @@
 
     > .media-body {
         flex: 0 1 auto;
-
-        > *:first-of-type {
-            margin-top: 0;
-        }
-
-        > *:last-of-type {
-            margin-bottom: 0;
-        }
     }
 
     > img,

--- a/src/components/IMedia/examples/alignment.vue
+++ b/src/components/IMedia/examples/alignment.vue
@@ -9,8 +9,8 @@
                 alt="Media Image"
             />
         </template>
-        <h3>Media Title</h3>
-        <p>
+        <h3 class="_margin:0">Media Title</h3>
+        <p class="_margin:0">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
             exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -27,8 +27,8 @@
                 alt="Media Image"
             />
         </template>
-        <h3>Media Title</h3>
-        <p>
+        <h3 class="_margin:0">Media Title</h3>
+        <p class="_margin:0">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
             exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -45,11 +45,12 @@
                 alt="Media Image"
             />
         </template>
-        <h3>Media Title</h3>
-        <p>
+        <h3 class="_margin:0">Media Title</h3>
+        <p class="_margin:0">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
             exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
     </IMedia>
 </template>
+<script setup></script>

--- a/src/components/IMedia/examples/basic.vue
+++ b/src/components/IMedia/examples/basic.vue
@@ -8,10 +8,11 @@
                 alt="Media Image"
             />
         </template>
-        <h3>Media Title</h3>
-        <p>
+        <h3 class="_margin:0">Media Title</h3>
+        <p class="_margin:0">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et...
         </p>
     </IMedia>
 </template>
+<script setup></script>

--- a/src/components/IMedia/examples/nesting.vue
+++ b/src/components/IMedia/examples/nesting.vue
@@ -8,8 +8,8 @@
                 alt="Media Image"
             />
         </template>
-        <h3>Media Title</h3>
-        <p>
+        <h3 class="_margin:0">Media Title</h3>
+        <p class="_margin:0">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
             exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -24,8 +24,8 @@
                     alt="Media Image"
                 />
             </template>
-            <h3>Nested Media Title</h3>
-            <p>
+            <h3 class="_margin:0">Nested Media Title</h3>
+            <p class="_margin:0">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
                 exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -33,3 +33,4 @@
         </IMedia>
     </IMedia>
 </template>
+<script setup></script>

--- a/src/components/IPopover/css/_component.scss
+++ b/src/components/IPopover/css/_component.scss
@@ -257,7 +257,7 @@
             background-color: var(--popover--footer--background, var(--popover--background));
         }
 
-        > *:nth-child(2) {
+        > div:first-of-type {
             border-top-left-radius: var(
                 --popover--border-top-left-radius,
                 var(--border-top-left-radius)
@@ -268,7 +268,7 @@
             );
         }
 
-        > *:last-of-type {
+        > div:last-of-type {
             border-bottom-left-radius: var(
                 --popover--border-bottom-left-radius,
                 var(--border-bottom-left-radius)

--- a/src/components/ISelect/css/_component.scss
+++ b/src/components/ISelect/css/_component.scss
@@ -64,10 +64,7 @@
                         --select--header--border-right-width,
                         var(--select--border-right-width, var(--border-right-width))
                     )
-                    var(
-                        --select--header--border-bottom-width,
-                        var(--select--border-bottom-width, var(--border-bottom-width))
-                    )
+                    var(--select--header--border-bottom-width, 0)
                     var(
                         --select--header--border-left-width,
                         var(--select--border-left-width, var(--border-left-width))
@@ -223,10 +220,7 @@
             );
             border-width: var(
                 --select--footer--border-width,
-                var(
-                        --select--footer--border-top-width,
-                        var(--select--border-top-width, var(--border-top-width))
-                    )
+                var(--select--footer--border-top-width, 0)
                     var(
                         --select--footer--border-right-width,
                         var(--select--border-right-width, var(--border-right-width))
@@ -278,7 +272,7 @@
             );
         }
 
-        > *:nth-child(2) {
+        > div:first-of-type {
             border-top-left-radius: var(
                 --select--border-top-left-radius,
                 var(--border-top-left-radius)
@@ -289,7 +283,7 @@
             );
         }
 
-        > *:last-of-type {
+        > div:last-of-type {
             border-bottom-left-radius: var(
                 --select--border-bottom-left-radius,
                 var(--border-bottom-left-radius)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
    - [x] The commit message follows our guidelines
    - [x] Tests for the changes have been added (for bug fixes / features)
    - [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
    Bug fix

* **What is the current behavior?** 
Component border radiuses are wrong for cards and popup type components when both body and footer are present.

* **What is the new behavior?** 
Changed component styles to use `:last-child` and `:last-of-type` correctly where applicable.

* **Does this PR introduce a breaking change?** 
The following components no longer apply margin removal CSS to their content:
  - `IAlert`
  - `ICard`
  - `IMedia`
  - `IListGroupItem`

