### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/packages/inkline/src/plugin.ts
+++ b/packages/inkline/src/plugin.ts
@@ -133,7 +133,7 @@ export const Inkline: Plugin = {
     }
 };
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         $inkline: InklineService;
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.

* **Other information**:


