### PR TITLE
fix(ci): use Node 22 in changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
The project requires Node >=22.12.0 but the changesets workflow used Node 20, causing the build to fail with a missing tsgo platform binary.