### PR TITLE
INK-1 - feat(ui/core): add headless IBadge component

### DIFF
--- a/ui/core/src/IBadge.ink.css
+++ b/ui/core/src/IBadge.ink.css
@@ -1,0 +1,11 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}

--- a/ui/core/src/IBadge.ink.test.ts
+++ b/ui/core/src/IBadge.ink.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  expectOutputContains,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const BADGE = resolveComponent(import.meta.url, "./IBadge.ink.tsx");
+
+describe("Badge", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(BADGE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    const result = await compileComponent(BADGE);
+    expectNoDiagnostics(result);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    const result = await compileComponent(BADGE);
+    expectCorrectFileExtensions(result);
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    const result = await compileComponent(BADGE);
+    assertConformance(result);
+  });
+
+  it("renders label in all targets", async () => {
+    const result = await compileComponent(BADGE);
+    for (const target of ["react", "vue", "solid", "svelte"] as const) {
+      expectOutputContains(result.filesFor(target), "label");
+    }
+  });
+
+  it("output matches snapshots", async () => {
+    const result = await compileComponent(BADGE);
+    const output = snapshotOutput(result);
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/ui/core/src/IBadge.ink.tsx
+++ b/ui/core/src/IBadge.ink.tsx
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import { defineComponent } from "@inkline/core";
+
+export interface BadgeProps {
+  label: string;
+  variant?: string;
+}
+
+export default defineComponent((props: { label: string; variant?: string }) => {
+  return (
+    <span class={props.variant ? `badge badge--${props.variant}` : "badge"}>{props.label}</span>
+  );
+});

--- a/ui/core/src/__snapshots__/IBadge.ink.test.ts.snap
+++ b/ui/core/src/__snapshots__/IBadge.ink.test.ts.snap
@@ -1,0 +1,163 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Badge > output matches snapshots 1`] = `
+{
+  "angular/IBadge.component.ts": "import { Component, signal, computed, effect, Input } from "@angular/core";
+import "./IBadge.css";
+@Component({ standalone: true, selector: 'IBadge', template: \`<span [class]="variant ? \\\`badge badge--\\\${variant}\\\` : "badge"">
+{{ label }}
+</span>\` })
+export class IBadgeComponent
+{
+@Input() label!: string
+@Input() variant?: string
+}
+",
+  "angular/IBadge.css": ".badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+",
+  "astro/IBadge.astro": "---
+interface Props { label: string; variant?: string }
+const { label, variant } = Astro.props as Props;
+---
+<span class={variant ? \`badge badge--\${variant}\` : "badge"}>
+{label}
+</span>
+<style scoped>
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  
+</style>
+",
+  "qwik/IBadge.css": ".badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+",
+  "qwik/IBadge.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $ } from "@qwik.dev/core";
+import "./IBadge.css";
+export const IBadge = component$((props) =>
+{
+return (
+<span class={props.variant ? \`badge badge--\${props.variant}\` : "badge"}>
+  {props.label}
+</span>
+)
+});
+",
+  "react/IBadge.css": ".badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+",
+  "react/IBadge.tsx": "import "./IBadge.css";
+export function IBadge(props: { label: string; variant?: string })
+{
+return (
+<span className={props.variant ? \`badge badge--\${props.variant}\` : "badge"}>
+  {props.label}
+</span>
+)
+}
+",
+  "solid/IBadge.css": ".badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+",
+  "solid/IBadge.tsx": "import "./IBadge.css";
+export default function IBadge(props: { label: string; variant?: string })
+{
+return (
+<span class={props.variant ? \`badge badge--\${props.variant}\` : "badge"}>
+  {props.label}
+</span>
+)
+}
+",
+  "svelte/IBadge.svelte": "<script lang="ts">
+  interface Props { label: string; variant?: string }
+  let { label, variant }: Props = $props()
+</script>
+<span class={variant ? \`badge badge--\${variant}\` : "badge"}>
+  {label}
+</span>
+<style scoped>
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  
+</style>
+",
+  "vue/IBadge.vue": "<script setup lang="ts">
+  const props = defineProps<{ label: string; variant?: string }>()
+</script>
+<template>
+<span :class='variant ? \`badge badge--\${variant}\` : "badge"'>
+  {{ label }}
+</span>
+</template>
+<style scoped>
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  
+</style>
+",
+}
+`;


### PR DESCRIPTION
Adds IBadge.ink.tsx with exported BadgeProps (label, variant?), base CSS, tests covering all 7 compilation targets, and a snapshot for regression detection.

[INK-1](https://multica.ai/inkline/issues/85b65139-52e2-424c-b936-7566394ef270)