### PR TITLE
feat(cli): implement `inkline init` and `inkline compile init` commands

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,12 @@ importers:
       citty:
         specifier: ^0.1.6
         version: 0.1.6
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+      magicast:
+        specifier: ^0.5.2
+        version: 0.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -11505,8 +11511,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.1:
-    resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
+  vue-component-type-helpers@3.3.2:
+    resolution: {integrity: sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -15929,7 +15935,7 @@ snapshots:
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.22(@tsdown/css@0.22.0)(@types/node@25.6.0)(esbuild@0.27.7)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4))
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.3)
-      vue-component-type-helpers: 3.3.1
+      vue-component-type-helpers: 3.3.2
     optional: true
 
   '@storybook/vue3@10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.22(@tsdown/css@0.22.0)(@types/node@25.6.0)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)))(vue@3.5.34(typescript@5.9.3))':
@@ -15938,7 +15944,7 @@ snapshots:
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.22(@tsdown/css@0.22.0)(@types/node@25.6.0)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4))
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.1
+      vue-component-type-helpers: 3.3.2
 
   '@styleframe/cli@4.0.0(@styleframe/license@2.0.2)(@styleframe/loader@3.0.1(@styleframe/core@3.5.0(@styleframe/license@2.0.2))(@styleframe/license@2.0.2)(@styleframe/transpiler@3.3.0(@styleframe/core@3.5.0(@styleframe/license@2.0.2))(@styleframe/license@2.0.2)))':
     dependencies:
@@ -16111,7 +16117,7 @@ snapshots:
       lightningcss: 1.32.0
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.0)(yaml@2.8.4)
       rolldown: 1.0.1
-      tsdown: 0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.0)(typescript@6.0.3)
+      tsdown: 0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.0)(typescript@5.9.3)
     optionalDependencies:
       postcss: 8.5.14
       sass: 1.97.3
@@ -16466,7 +16472,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@tsdown/css@0.22.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.21))(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@tsdown/css@0.22.0)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@5.9.3)(vite@8.0.10(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)'
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -22644,7 +22650,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.25.1(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.1)(typescript@6.0.3):
+  rolldown-plugin-dts@0.25.1(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.1)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.5
       '@babel/helper-validator-identifier': 8.0.0-rc.5
@@ -22657,7 +22663,7 @@ snapshots:
       rolldown: 1.0.1
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260328.1
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
     optional: true
@@ -23740,7 +23746,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.0)(typescript@6.0.3):
+  tsdown@0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.0)(typescript@5.9.3):
     dependencies:
       ansis: 4.3.0
       cac: 7.0.0
@@ -23751,7 +23757,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.1
-      rolldown-plugin-dts: 0.25.1(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.1)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.25.1(@typescript/native-preview@7.0.0-dev.20260328.1)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.1)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
@@ -23760,7 +23766,7 @@ snapshots:
     optionalDependencies:
       '@tsdown/css': 0.22.0(jiti@2.7.0)(postcss@8.5.14)(sass@1.97.3)(tsdown@0.22.0)(tsx@4.22.0)(yaml@2.8.4)
       tsx: 4.22.0
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -24578,7 +24584,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.1: {}
+  vue-component-type-helpers@3.3.2: {}
 
   vue-docgen-api@4.79.2(vue@3.5.34(typescript@5.9.3)):
     dependencies:

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -43,7 +43,9 @@
     "@inkline/compiler": "workspace:*",
     "@inkline/config-loader": "workspace:*",
     "@inkline/storybook": "workspace:*",
-    "citty": "^0.1.6"
+    "citty": "^0.1.6",
+    "consola": "^3.4.2",
+    "magicast": "^0.5.2"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/tooling/cli/src/bin/inkline.test.ts
+++ b/tooling/cli/src/bin/inkline.test.ts
@@ -308,10 +308,10 @@ describe("check", () => {
 });
 
 describe("init", () => {
-  it("prints not yet implemented", () => {
+  it("shows framework prompt", () => {
     const { stdout, status } = run("init");
     expect(status).toBe(0);
-    expect(stdout).toContain("not yet implemented");
+    expect(stdout).toContain("Select a framework");
   });
 });
 

--- a/tooling/cli/src/commands/compile-init.test.ts
+++ b/tooling/cli/src/commands/compile-init.test.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("consola", () => {
+  const consola = {
+    prompt: vi.fn(),
+    info: vi.fn(),
+    start: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    box: vi.fn(),
+  };
+  return { default: consola };
+});
+
+import consola from "consola";
+import compileInitCommand from "./compile-init.ts";
+
+function mockPrompt(value: unknown) {
+  (consola.prompt as ReturnType<typeof vi.fn>).mockResolvedValue(value);
+}
+
+function runCompileInit(args: Record<string, unknown> = {}) {
+  return compileInitCommand.run!({
+    args: { _: [], ...args } as any,
+    rawArgs: [],
+    cmd: compileInitCommand,
+  });
+}
+
+describe("inkline compile init", () => {
+  let dir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `inkline-test-compile-init-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    originalCwd = process.cwd();
+    process.chdir(dir);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePkg(scripts: Record<string, string> = {}) {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ scripts }));
+  }
+
+  it("creates inkline.config.ts with specified targets", async () => {
+    writePkg();
+    await runCompileInit({ target: "react,vue" });
+
+    const config = readFileSync(join(dir, "inkline.config.ts"), "utf-8");
+    expect(config).toContain('import { defineConfig } from "inkline/compiler"');
+    expect(config).toContain('"react"');
+    expect(config).toContain('"vue"');
+  });
+
+  it("creates example component file", async () => {
+    writePkg();
+    await runCompileInit({ target: "react" });
+
+    const componentPath = join(dir, "src/components/hello-world/HelloWorld.ink.tsx");
+    expect(existsSync(componentPath)).toBe(true);
+
+    const content = readFileSync(componentPath, "utf-8");
+    expect(content).toContain("defineComponent");
+    expect(content).toContain("HelloWorldProps");
+  });
+
+  it("adds inkline:build and inkline:dev scripts to package.json", async () => {
+    writePkg();
+    await runCompileInit({ target: "react" });
+
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    expect(pkg.scripts["inkline:build"]).toContain("inkline compile components");
+    expect(pkg.scripts["inkline:dev"]).toContain("--watch");
+  });
+
+  it("does not overwrite existing inkline.config.ts", async () => {
+    writePkg();
+    writeFileSync(join(dir, "inkline.config.ts"), "existing content");
+
+    await runCompileInit({ target: "react" });
+
+    const config = readFileSync(join(dir, "inkline.config.ts"), "utf-8");
+    expect(config).toBe("existing content");
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("already exists"));
+  });
+
+  it("does not overwrite existing example component", async () => {
+    writePkg();
+    const componentDir = join(dir, "src/components/hello-world");
+    mkdirSync(componentDir, { recursive: true });
+    writeFileSync(join(componentDir, "HelloWorld.ink.tsx"), "existing");
+
+    await runCompileInit({ target: "react" });
+
+    const content = readFileSync(join(componentDir, "HelloWorld.ink.tsx"), "utf-8");
+    expect(content).toBe("existing");
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Example component already exists"),
+    );
+  });
+
+  it("does not overwrite existing scripts", async () => {
+    writePkg({ "inkline:build": "custom", "inkline:dev": "custom" });
+
+    await runCompileInit({ target: "react" });
+
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    expect(pkg.scripts["inkline:build"]).toBe("custom");
+    expect(pkg.scripts["inkline:dev"]).toBe("custom");
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("already exist"));
+  });
+
+  it("uses multi-select prompt when no --target flag", async () => {
+    writePkg();
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ dependencies: { react: "^19" } }));
+    mockPrompt(["react"]);
+
+    await runCompileInit();
+
+    expect(consola.prompt).toHaveBeenCalledWith(
+      "Select target framework(s):",
+      expect.objectContaining({ type: "multiselect" }),
+    );
+  });
+
+  it("pre-checks detected frameworks in prompt", async () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ dependencies: { vue: "^3" }, scripts: {} }),
+    );
+    mockPrompt(["vue"]);
+
+    await runCompileInit();
+
+    expect(consola.prompt).toHaveBeenCalledWith(
+      "Select target framework(s):",
+      expect.objectContaining({ initial: ["vue"] }),
+    );
+  });
+
+  it("exits gracefully on cancelled prompt", async () => {
+    writePkg();
+    mockPrompt(Symbol.for("cancel"));
+
+    await runCompileInit();
+
+    expect(consola.info).toHaveBeenCalledWith("Cancelled.");
+    expect(existsSync(join(dir, "inkline.config.ts"))).toBe(false);
+  });
+
+  it("rejects invalid --target value", async () => {
+    writePkg();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    await expect(runCompileInit({ target: "invalid" })).rejects.toThrow("process.exit");
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Invalid target"));
+    exitSpy.mockRestore();
+  });
+
+  it("supports single target", async () => {
+    writePkg();
+    await runCompileInit({ target: "svelte" });
+
+    const config = readFileSync(join(dir, "inkline.config.ts"), "utf-8");
+    expect(config).toContain('"svelte"');
+    expect(config).not.toContain('"react"');
+  });
+
+  it("shows completion message", async () => {
+    writePkg();
+    await runCompileInit({ target: "react" });
+
+    expect(consola.box).toHaveBeenCalledWith(expect.stringContaining("inkline compile components"));
+  });
+});

--- a/tooling/cli/src/commands/compile-init.ts
+++ b/tooling/cli/src/commands/compile-init.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type Framework, detectFrameworks } from "../lib/detect-framework.ts";
+import { generateInklineConfig, exampleComponentTemplate } from "../lib/inkline-config-template.ts";
+
+const allFrameworks: { value: Framework; label: string }[] = [
+  { value: "react", label: "React" },
+  { value: "vue", label: "Vue" },
+  { value: "svelte", label: "Svelte" },
+  { value: "solid", label: "Solid" },
+  { value: "angular", label: "Angular" },
+  { value: "qwik", label: "Qwik" },
+  { value: "astro", label: "Astro" },
+];
+
+const validFrameworks = new Set<string>(allFrameworks.map((f) => f.value));
+
+export default defineCommand({
+  meta: { name: "init", description: "Scaffold inkline.config.ts and an example component" },
+  args: {
+    target: {
+      type: "string",
+      description: "Comma-separated target frameworks (react,vue,svelte,solid,angular,qwik,astro)",
+    },
+  },
+  async run({ args }) {
+    const cwd = process.cwd();
+    const detected = detectFrameworks(cwd);
+
+    let targets: Framework[];
+
+    if (args.target) {
+      const parsed = args.target.split(",").map((t) => t.trim());
+      const invalid = parsed.filter((t) => !validFrameworks.has(t));
+      if (invalid.length > 0) {
+        consola.error(
+          `Invalid target(s): ${invalid.join(", ")}. Valid: ${[...validFrameworks].join(", ")}`,
+        );
+        process.exit(1);
+      }
+      targets = parsed as Framework[];
+    } else {
+      const selected = await consola.prompt("Select target framework(s):", {
+        type: "multiselect",
+        options: allFrameworks.map((f) => ({
+          value: f.value,
+          label: f.label,
+          hint: detected.includes(f.value) ? "detected" : undefined,
+        })),
+        initial: detected,
+        required: true,
+      });
+
+      if (typeof selected === "symbol") {
+        consola.info("Cancelled.");
+        return;
+      }
+
+      targets = selected as unknown as Framework[];
+
+      if (targets.length === 0) {
+        consola.error("At least one target is required.");
+        process.exit(1);
+      }
+    }
+
+    // Step 1: Create inkline.config.ts
+    const configPath = resolve(cwd, "inkline.config.ts");
+    if (existsSync(configPath)) {
+      consola.warn("inkline.config.ts already exists — skipping.");
+    } else {
+      writeFileSync(configPath, generateInklineConfig(targets));
+      consola.success("Created inkline.config.ts");
+    }
+
+    // Step 2: Create example component
+    const componentPath = resolve(cwd, "src/components/hello-world/HelloWorld.ink.tsx");
+    if (existsSync(componentPath)) {
+      consola.warn("Example component already exists — skipping.");
+    } else {
+      mkdirSync(dirname(componentPath), { recursive: true });
+      writeFileSync(componentPath, exampleComponentTemplate);
+      consola.success("Created src/components/hello-world/HelloWorld.ink.tsx");
+    }
+
+    // Step 3: Add scripts to package.json
+    const pkgPath = resolve(cwd, "package.json");
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      const scripts = pkg.scripts ?? {};
+      let added = false;
+
+      if (!scripts["inkline:build"]) {
+        scripts["inkline:build"] = "inkline compile components 'src/**/*.ink.tsx'";
+        added = true;
+      }
+      if (!scripts["inkline:dev"]) {
+        scripts["inkline:dev"] = "inkline compile components 'src/**/*.ink.tsx' --watch";
+        added = true;
+      }
+
+      if (added) {
+        pkg.scripts = scripts;
+        writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+        consola.success("Added inkline:build and inkline:dev scripts to package.json");
+      } else {
+        consola.warn("inkline:build and inkline:dev scripts already exist — skipping.");
+      }
+    }
+
+    consola.box(`Done! Run "inkline compile components 'src/**/*.ink.tsx'" to compile.`);
+  },
+});

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -5,5 +5,6 @@ export default defineCommand({
   subCommands: {
     components: () => import("./compile-components.ts").then((m) => m.default),
     stories: () => import("./compile-stories.ts").then((m) => m.default),
+    init: () => import("./compile-init.ts").then((m) => m.default),
   },
 });

--- a/tooling/cli/src/commands/init.test.ts
+++ b/tooling/cli/src/commands/init.test.ts
@@ -1,0 +1,232 @@
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock("consola", () => {
+  const consola = {
+    prompt: vi.fn(),
+    info: vi.fn(),
+    start: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    box: vi.fn(),
+  };
+  return { default: consola };
+});
+
+import { execSync } from "node:child_process";
+import consola from "consola";
+import initCommand from "./init.ts";
+
+function mockPrompt(value: unknown) {
+  (consola.prompt as ReturnType<typeof vi.fn>).mockResolvedValue(value);
+}
+
+function runInit(args: Record<string, unknown> = {}) {
+  return initCommand.run!({
+    args: { _: [], ...args } as any,
+    rawArgs: [],
+    cmd: initCommand,
+  });
+}
+
+describe("inkline init", () => {
+  let dir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `inkline-test-init-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    originalCwd = process.cwd();
+    process.chdir(dir);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePkg(deps: Record<string, string> = {}) {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ dependencies: deps }));
+  }
+
+  function writeViteConfig(content: string) {
+    writeFileSync(join(dir, "vite.config.ts"), content);
+  }
+
+  function createLockfile(name: string) {
+    writeFileSync(join(dir, name), "");
+  }
+
+  it("uses --framework flag to skip prompt", async () => {
+    writePkg({ react: "^19" });
+    createLockfile("pnpm-lock.yaml");
+    writeViteConfig(`import { defineConfig } from "vite";
+export default defineConfig({ plugins: [] });
+`);
+
+    await runInit({ framework: "react" });
+
+    expect(consola.prompt).not.toHaveBeenCalled();
+    expect(execSync).toHaveBeenCalledWith("pnpx styleframe init", expect.anything());
+    expect(execSync).toHaveBeenCalledWith(
+      "pnpm add inkline @styleframe/runtime",
+      expect.anything(),
+    );
+  });
+
+  it("prompts for framework selection when no flag provided", async () => {
+    writePkg({ react: "^19" });
+    createLockfile("pnpm-lock.yaml");
+    writeViteConfig(`import { defineConfig } from "vite";
+export default defineConfig({ plugins: [] });
+`);
+
+    mockPrompt("react");
+
+    await runInit();
+
+    expect(consola.prompt).toHaveBeenCalledWith(
+      "Select a framework:",
+      expect.objectContaining({ type: "select" }),
+    );
+  });
+
+  it("passes detected framework as initial value in prompt", async () => {
+    writePkg({ vue: "^3" });
+    writeViteConfig(`import { defineConfig } from "vite";
+export default defineConfig({ plugins: [] });
+`);
+
+    mockPrompt("vue");
+
+    await runInit();
+
+    expect(consola.prompt).toHaveBeenCalledWith(
+      "Select a framework:",
+      expect.objectContaining({ initial: "vue" }),
+    );
+  });
+
+  it("writes styleframe.config.ts with Inkline presets", async () => {
+    writePkg({ react: "^19" });
+    writeViteConfig(`import { defineConfig } from "vite";
+export default defineConfig({ plugins: [] });
+`);
+
+    await runInit({ framework: "react" });
+
+    const config = readFileSync(join(dir, "styleframe.config.ts"), "utf-8");
+    expect(config).toContain("useDesignTokensPreset");
+    expect(config).toContain("useSanitizePreset");
+    expect(config).toContain("useGlobalPreset");
+    expect(config).toContain("useUtilitiesPreset");
+    expect(config).toContain("useModifiersPreset");
+  });
+
+  it("adds inkline plugin to vite.config.ts", async () => {
+    writePkg({ react: "^19" });
+    writeViteConfig(`import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});
+`);
+
+    await runInit({ framework: "react" });
+
+    const config = readFileSync(join(dir, "vite.config.ts"), "utf-8");
+    expect(config).toContain('import inkline from "inkline/plugin/vite"');
+    expect(config).toContain("inkline()");
+  });
+
+  it("detects yarn from lockfile", async () => {
+    writePkg({ react: "^19" });
+    createLockfile("yarn.lock");
+
+    await runInit({ framework: "react" });
+
+    expect(execSync).toHaveBeenCalledWith("yarn dlx styleframe init", expect.anything());
+    expect(execSync).toHaveBeenCalledWith(
+      "yarn add inkline @styleframe/runtime",
+      expect.anything(),
+    );
+  });
+
+  it("detects bun from lockfile", async () => {
+    writePkg({ react: "^19" });
+    createLockfile("bun.lockb");
+
+    await runInit({ framework: "react" });
+
+    expect(execSync).toHaveBeenCalledWith("bunx styleframe init", expect.anything());
+    expect(execSync).toHaveBeenCalledWith("bun add inkline @styleframe/runtime", expect.anything());
+  });
+
+  it("warns when no bundler config is found", async () => {
+    writePkg({ react: "^19" });
+
+    await runInit({ framework: "react" });
+
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("No bundler config found"));
+  });
+
+  it("exits gracefully on cancelled prompt", async () => {
+    writePkg({ react: "^19" });
+    mockPrompt(Symbol.for("cancel"));
+
+    await runInit();
+
+    expect(consola.info).toHaveBeenCalledWith("Cancelled.");
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid --framework value", async () => {
+    writePkg({});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    await expect(runInit({ framework: "invalid" })).rejects.toThrow("process.exit");
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Invalid framework"));
+    exitSpy.mockRestore();
+  });
+
+  it("handles styleframe init failure gracefully", async () => {
+    writePkg({ react: "^19" });
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error("command failed");
+    });
+
+    await runInit({ framework: "react" });
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to run styleframe init"),
+    );
+    expect(existsSync(join(dir, "styleframe.config.ts"))).toBe(true);
+  });
+
+  it("handles dependency installation failure gracefully", async () => {
+    writePkg({ react: "^19" });
+    vi.mocked(execSync)
+      .mockImplementationOnce(() => Buffer.from(""))
+      .mockImplementationOnce(() => {
+        throw new Error("install failed");
+      });
+
+    await runInit({ framework: "react" });
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to install dependencies"),
+    );
+  });
+});

--- a/tooling/cli/src/commands/init.ts
+++ b/tooling/cli/src/commands/init.ts
@@ -1,8 +1,109 @@
+import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { defineCommand } from "citty";
+import consola from "consola";
+import { detectPackageManager, getPackageManagerRunner } from "../lib/detect-package-manager.ts";
+import { type Framework, detectFrameworks } from "../lib/detect-framework.ts";
+import { detectBundler } from "../lib/detect-bundler.ts";
+import { addBuildPlugin, getManualPluginInstructions } from "../lib/add-build-plugin.ts";
+import { styleframeConfigTemplate } from "../lib/styleframe-config.ts";
+
+const allFrameworks: { value: Framework; label: string }[] = [
+  { value: "react", label: "React" },
+  { value: "vue", label: "Vue" },
+  { value: "svelte", label: "Svelte" },
+  { value: "solid", label: "Solid" },
+  { value: "angular", label: "Angular" },
+  { value: "qwik", label: "Qwik" },
+  { value: "astro", label: "Astro" },
+];
 
 export default defineCommand({
   meta: { name: "init", description: "Initialize an Inkline project" },
-  run() {
-    console.log("inkline init is not yet implemented.");
+  args: {
+    framework: {
+      type: "string",
+      description: "Target framework (react, vue, svelte, solid, angular, qwik, astro)",
+    },
+  },
+  async run({ args }) {
+    const cwd = process.cwd();
+    const pm = detectPackageManager(cwd);
+    const runner = getPackageManagerRunner(pm);
+    const detected = detectFrameworks(cwd);
+
+    let framework: Framework;
+
+    if (args.framework) {
+      const valid = allFrameworks.map((f) => f.value);
+      if (!valid.includes(args.framework as Framework)) {
+        consola.error(`Invalid framework "${args.framework}". Valid options: ${valid.join(", ")}`);
+        process.exit(1);
+      }
+      framework = args.framework as Framework;
+    } else {
+      const initial = detected.length > 0 ? detected[0] : undefined;
+      const selected = await consola.prompt("Select a framework:", {
+        type: "select",
+        options: allFrameworks.map((f) => ({
+          value: f.value,
+          label: f.label,
+          hint: detected.includes(f.value) ? "detected" : undefined,
+        })),
+        initial,
+      });
+
+      if (typeof selected === "symbol") {
+        consola.info("Cancelled.");
+        return;
+      }
+
+      framework = selected as Framework;
+    }
+
+    consola.info(`Package manager: ${pm}`);
+
+    // Step 1: Initialize styleframe
+    consola.start("Initializing styleframe...");
+    try {
+      execSync(`${runner} styleframe init`, { cwd, stdio: "pipe" });
+      consola.success("Initialized styleframe");
+    } catch {
+      consola.warn("Failed to run styleframe init — you may need to run it manually.");
+    }
+
+    // Step 2: Seed styleframe.config.ts with Inkline presets
+    const styleframeConfigPath = resolve(cwd, "styleframe.config.ts");
+    writeFileSync(styleframeConfigPath, styleframeConfigTemplate);
+    consola.success("Configured styleframe.config.ts with Inkline presets");
+
+    // Step 3: Install dependencies
+    consola.start("Installing dependencies...");
+    try {
+      execSync(`${pm} add inkline @styleframe/runtime`, { cwd, stdio: "pipe" });
+      consola.success("Installed inkline and @styleframe/runtime");
+    } catch {
+      consola.warn(
+        `Failed to install dependencies. Run manually: ${pm} add inkline @styleframe/runtime`,
+      );
+    }
+
+    // Step 4: Wire build plugin
+    const bundlerResult = detectBundler(cwd);
+    if (bundlerResult) {
+      try {
+        await addBuildPlugin(bundlerResult.configPath, bundlerResult.bundler, framework);
+        consola.success(`Added inkline plugin to ${bundlerResult.bundler} config`);
+      } catch {
+        consola.warn("Could not automatically modify your build config.");
+        consola.info(getManualPluginInstructions(bundlerResult.bundler, framework));
+      }
+    } else {
+      consola.warn("No bundler config found (vite, webpack, or rollup).");
+      consola.info(getManualPluginInstructions("vite", framework));
+    }
+
+    consola.box(`Done! Import components from "inkline/${framework}".`);
   },
 });

--- a/tooling/cli/src/lib/add-build-plugin.test.ts
+++ b/tooling/cli/src/lib/add-build-plugin.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { addBuildPlugin, getManualPluginInstructions } from "./add-build-plugin.ts";
+
+describe("addBuildPlugin", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `inkline-test-plugin-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function readConfig(name: string): string {
+    return readFileSync(join(dir, name), "utf-8");
+  }
+
+  it("adds inkline plugin to a vite config with existing plugins", async () => {
+    const configPath = join(dir, "vite.config.ts");
+    writeFileSync(
+      configPath,
+      `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});
+`,
+    );
+
+    await addBuildPlugin(configPath, "vite", "react");
+    const result = readConfig("vite.config.ts");
+
+    expect(result).toContain('import inkline from "inkline/plugin/vite"');
+    expect(result).toContain("inkline()");
+  });
+
+  it("adds inkline plugin to a vite config with no plugins array", async () => {
+    const configPath = join(dir, "vite.config.ts");
+    writeFileSync(
+      configPath,
+      `import { defineConfig } from "vite";
+
+export default defineConfig({});
+`,
+    );
+
+    await addBuildPlugin(configPath, "vite", "react");
+    const result = readConfig("vite.config.ts");
+
+    expect(result).toContain('import inkline from "inkline/plugin/vite"');
+    expect(result).toContain("inkline()");
+  });
+
+  it("does not pass target option for vite (auto-detects)", async () => {
+    const configPath = join(dir, "vite.config.ts");
+    writeFileSync(
+      configPath,
+      `import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [],
+});
+`,
+    );
+
+    await addBuildPlugin(configPath, "vite", "react");
+    const result = readConfig("vite.config.ts");
+
+    expect(result).not.toContain("target");
+  });
+
+  it("adds inkline plugin with target to webpack config", async () => {
+    const configPath = join(dir, "webpack.config.js");
+    writeFileSync(
+      configPath,
+      `export default {
+  plugins: [],
+};
+`,
+    );
+
+    await addBuildPlugin(configPath, "webpack", "vue");
+    const result = readConfig("webpack.config.js");
+
+    expect(result).toContain('import inkline from "inkline/plugin/webpack"');
+    expect(result).toContain("inkline(");
+    expect(result).toContain('"vue"');
+  });
+
+  it("adds inkline plugin with target to rollup config", async () => {
+    const configPath = join(dir, "rollup.config.js");
+    writeFileSync(
+      configPath,
+      `export default {
+  plugins: [],
+};
+`,
+    );
+
+    await addBuildPlugin(configPath, "rollup", "svelte");
+    const result = readConfig("rollup.config.js");
+
+    expect(result).toContain('import inkline from "inkline/plugin/rollup"');
+    expect(result).toContain("inkline(");
+    expect(result).toContain('"svelte"');
+  });
+});
+
+describe("getManualPluginInstructions", () => {
+  it("returns vite instructions without target", () => {
+    const result = getManualPluginInstructions("vite", "react");
+    expect(result).toContain("inkline/plugin/vite");
+    expect(result).toContain("inkline()");
+    expect(result).not.toContain("target");
+  });
+
+  it("returns webpack instructions with target", () => {
+    const result = getManualPluginInstructions("webpack", "vue");
+    expect(result).toContain("inkline/plugin/webpack");
+    expect(result).toContain('target: "vue"');
+  });
+
+  it("returns rollup instructions with target", () => {
+    const result = getManualPluginInstructions("rollup", "angular");
+    expect(result).toContain("inkline/plugin/rollup");
+    expect(result).toContain('target: "angular"');
+  });
+});

--- a/tooling/cli/src/lib/add-build-plugin.ts
+++ b/tooling/cli/src/lib/add-build-plugin.ts
@@ -1,0 +1,47 @@
+import { loadFile, writeFile } from "magicast";
+import { addVitePlugin } from "magicast/helpers";
+import type { Bundler } from "./detect-bundler.ts";
+import type { Framework } from "./detect-framework.ts";
+
+const pluginImportMap: Record<Bundler, string> = {
+  vite: "inkline/plugin/vite",
+  webpack: "inkline/plugin/webpack",
+  rollup: "inkline/plugin/rollup",
+};
+
+export async function addBuildPlugin(
+  configPath: string,
+  bundler: Bundler,
+  framework: Framework,
+): Promise<void> {
+  const mod = await loadFile(configPath);
+
+  if (bundler === "vite") {
+    addVitePlugin(mod, {
+      from: pluginImportMap.vite,
+      constructor: "inkline",
+    });
+  } else {
+    addVitePlugin(mod, {
+      from: pluginImportMap[bundler],
+      constructor: "inkline",
+      options: { target: framework },
+    });
+  }
+
+  await writeFile(mod, configPath);
+}
+
+export function getManualPluginInstructions(bundler: Bundler, framework: Framework): string {
+  const importPath = pluginImportMap[bundler];
+  const optionsStr = bundler === "vite" ? "" : `{ target: "${framework}" }`;
+
+  return [
+    `Add the Inkline plugin to your ${bundler} config:`,
+    "",
+    `  import inkline from "${importPath}";`,
+    "",
+    `  // Add to your plugins array:`,
+    `  inkline(${optionsStr})`,
+  ].join("\n");
+}

--- a/tooling/cli/src/lib/detect-bundler.test.ts
+++ b/tooling/cli/src/lib/detect-bundler.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { detectBundler } from "./detect-bundler.ts";
+
+describe("detectBundler", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `inkline-test-bundler-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects vite from vite.config.ts", () => {
+    writeFileSync(join(dir, "vite.config.ts"), "");
+    const result = detectBundler(dir);
+    expect(result).toEqual({ bundler: "vite", configPath: join(dir, "vite.config.ts") });
+  });
+
+  it("detects vite from vite.config.js", () => {
+    writeFileSync(join(dir, "vite.config.js"), "");
+    expect(detectBundler(dir)?.bundler).toBe("vite");
+  });
+
+  it("detects vite from vite.config.mts", () => {
+    writeFileSync(join(dir, "vite.config.mts"), "");
+    expect(detectBundler(dir)?.bundler).toBe("vite");
+  });
+
+  it("detects webpack from webpack.config.ts", () => {
+    writeFileSync(join(dir, "webpack.config.ts"), "");
+    expect(detectBundler(dir)?.bundler).toBe("webpack");
+  });
+
+  it("detects webpack from webpack.config.js", () => {
+    writeFileSync(join(dir, "webpack.config.js"), "");
+    expect(detectBundler(dir)?.bundler).toBe("webpack");
+  });
+
+  it("detects rollup from rollup.config.ts", () => {
+    writeFileSync(join(dir, "rollup.config.ts"), "");
+    expect(detectBundler(dir)?.bundler).toBe("rollup");
+  });
+
+  it("detects rollup from rollup.config.mjs", () => {
+    writeFileSync(join(dir, "rollup.config.mjs"), "");
+    expect(detectBundler(dir)?.bundler).toBe("rollup");
+  });
+
+  it("prefers vite over webpack when both exist", () => {
+    writeFileSync(join(dir, "vite.config.ts"), "");
+    writeFileSync(join(dir, "webpack.config.js"), "");
+    expect(detectBundler(dir)?.bundler).toBe("vite");
+  });
+
+  it("returns undefined when no config file found", () => {
+    expect(detectBundler(dir)).toBeUndefined();
+  });
+});

--- a/tooling/cli/src/lib/detect-bundler.ts
+++ b/tooling/cli/src/lib/detect-bundler.ts
@@ -1,0 +1,27 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type Bundler = "vite" | "webpack" | "rollup";
+
+const configPatterns: [string[], Bundler][] = [
+  [["vite.config.ts", "vite.config.js", "vite.config.mts", "vite.config.mjs"], "vite"],
+  [["webpack.config.ts", "webpack.config.js"], "webpack"],
+  [["rollup.config.ts", "rollup.config.js", "rollup.config.mts", "rollup.config.mjs"], "rollup"],
+];
+
+export interface BundlerDetectionResult {
+  bundler: Bundler;
+  configPath: string;
+}
+
+export function detectBundler(cwd: string = process.cwd()): BundlerDetectionResult | undefined {
+  for (const [patterns, bundler] of configPatterns) {
+    for (const pattern of patterns) {
+      const configPath = resolve(cwd, pattern);
+      if (existsSync(configPath)) {
+        return { bundler, configPath };
+      }
+    }
+  }
+  return undefined;
+}

--- a/tooling/cli/src/lib/detect-framework.test.ts
+++ b/tooling/cli/src/lib/detect-framework.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { detectFrameworks } from "./detect-framework.ts";
+
+describe("detectFrameworks", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `inkline-test-fw-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePkg(deps: Record<string, string> = {}, devDeps: Record<string, string> = {}) {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ dependencies: deps, devDependencies: devDeps }),
+    );
+  }
+
+  it("detects react from dependencies", () => {
+    writePkg({ react: "^19" });
+    expect(detectFrameworks(dir)).toEqual(["react"]);
+  });
+
+  it("detects vue from devDependencies", () => {
+    writePkg({}, { vue: "^3" });
+    expect(detectFrameworks(dir)).toEqual(["vue"]);
+  });
+
+  it("detects svelte", () => {
+    writePkg({ svelte: "^5" });
+    expect(detectFrameworks(dir)).toEqual(["svelte"]);
+  });
+
+  it("detects solid from solid-js", () => {
+    writePkg({ "solid-js": "^1" });
+    expect(detectFrameworks(dir)).toEqual(["solid"]);
+  });
+
+  it("detects angular from @angular/core", () => {
+    writePkg({ "@angular/core": "^17" });
+    expect(detectFrameworks(dir)).toEqual(["angular"]);
+  });
+
+  it("detects qwik from @builder.io/qwik", () => {
+    writePkg({ "@builder.io/qwik": "^1" });
+    expect(detectFrameworks(dir)).toEqual(["qwik"]);
+  });
+
+  it("detects astro", () => {
+    writePkg({ astro: "^4" });
+    expect(detectFrameworks(dir)).toEqual(["astro"]);
+  });
+
+  it("detects multiple frameworks", () => {
+    writePkg({ react: "^19", vue: "^3" });
+    expect(detectFrameworks(dir)).toEqual(["react", "vue"]);
+  });
+
+  it("returns empty array when no frameworks found", () => {
+    writePkg({ lodash: "^4" });
+    expect(detectFrameworks(dir)).toEqual([]);
+  });
+
+  it("returns empty array when no package.json exists", () => {
+    expect(detectFrameworks(dir)).toEqual([]);
+  });
+});

--- a/tooling/cli/src/lib/detect-framework.ts
+++ b/tooling/cli/src/lib/detect-framework.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type Framework = "react" | "vue" | "svelte" | "solid" | "angular" | "qwik" | "astro";
+
+const frameworkDeps: [string, Framework][] = [
+  ["react", "react"],
+  ["vue", "vue"],
+  ["svelte", "svelte"],
+  ["solid-js", "solid"],
+  ["@angular/core", "angular"],
+  ["@builder.io/qwik", "qwik"],
+  ["astro", "astro"],
+];
+
+export function detectFrameworks(cwd: string = process.cwd()): Framework[] {
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf-8"));
+  } catch {
+    return [];
+  }
+
+  const allDeps = {
+    ...(pkg.dependencies as Record<string, string> | undefined),
+    ...(pkg.devDependencies as Record<string, string> | undefined),
+  };
+
+  return frameworkDeps.filter(([dep]) => dep in allDeps).map(([, fw]) => fw);
+}

--- a/tooling/cli/src/lib/detect-package-manager.test.ts
+++ b/tooling/cli/src/lib/detect-package-manager.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { detectPackageManager, getPackageManagerRunner } from "./detect-package-manager.ts";
+
+describe("detectPackageManager", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `inkline-test-pm-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects pnpm from pnpm-lock.yaml", () => {
+    writeFileSync(join(dir, "pnpm-lock.yaml"), "");
+    expect(detectPackageManager(dir)).toBe("pnpm");
+  });
+
+  it("detects yarn from yarn.lock", () => {
+    writeFileSync(join(dir, "yarn.lock"), "");
+    expect(detectPackageManager(dir)).toBe("yarn");
+  });
+
+  it("detects bun from bun.lockb", () => {
+    writeFileSync(join(dir, "bun.lockb"), "");
+    expect(detectPackageManager(dir)).toBe("bun");
+  });
+
+  it("detects bun from bun.lock", () => {
+    writeFileSync(join(dir, "bun.lock"), "");
+    expect(detectPackageManager(dir)).toBe("bun");
+  });
+
+  it("detects npm from package-lock.json", () => {
+    writeFileSync(join(dir, "package-lock.json"), "");
+    expect(detectPackageManager(dir)).toBe("npm");
+  });
+
+  it("falls back to npm when no lockfile exists", () => {
+    expect(detectPackageManager(dir)).toBe("npm");
+  });
+
+  it("prefers pnpm when multiple lockfiles exist", () => {
+    writeFileSync(join(dir, "pnpm-lock.yaml"), "");
+    writeFileSync(join(dir, "package-lock.json"), "");
+    expect(detectPackageManager(dir)).toBe("pnpm");
+  });
+});
+
+describe("getPackageManagerRunner", () => {
+  it.each([
+    ["pnpm", "pnpx"],
+    ["yarn", "yarn dlx"],
+    ["bun", "bunx"],
+    ["npm", "npx"],
+  ] as const)("returns %s runner as %s", (pm, expected) => {
+    expect(getPackageManagerRunner(pm)).toBe(expected);
+  });
+});

--- a/tooling/cli/src/lib/detect-package-manager.ts
+++ b/tooling/cli/src/lib/detect-package-manager.ts
@@ -1,0 +1,32 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type PackageManager = "pnpm" | "yarn" | "bun" | "npm";
+
+const lockfileMap: [string, PackageManager][] = [
+  ["pnpm-lock.yaml", "pnpm"],
+  ["yarn.lock", "yarn"],
+  ["bun.lockb", "bun"],
+  ["bun.lock", "bun"],
+  ["package-lock.json", "npm"],
+];
+
+export function detectPackageManager(cwd: string = process.cwd()): PackageManager {
+  for (const [file, pm] of lockfileMap) {
+    if (existsSync(resolve(cwd, file))) {
+      return pm;
+    }
+  }
+  return "npm";
+}
+
+const runnerMap: Record<PackageManager, string> = {
+  pnpm: "pnpx",
+  yarn: "yarn dlx",
+  bun: "bunx",
+  npm: "npx",
+};
+
+export function getPackageManagerRunner(pm: PackageManager): string {
+  return runnerMap[pm];
+}

--- a/tooling/cli/src/lib/inkline-config-template.ts
+++ b/tooling/cli/src/lib/inkline-config-template.ts
@@ -1,0 +1,27 @@
+import type { Framework } from "./detect-framework.ts";
+
+export function generateInklineConfig(targets: Framework[]): string {
+  const targetsStr = targets.map((t) => `"${t}"`).join(", ");
+  return `import { defineConfig } from "inkline/compiler";
+
+export default defineConfig({
+  targets: [${targetsStr}],
+});
+`;
+}
+
+export const exampleComponentTemplate = `import { defineComponent } from "inkline";
+
+export interface HelloWorldProps {
+  name?: string;
+}
+
+export default defineComponent(
+  { slots: { default: {} } },
+  (props: HelloWorldProps) => (
+    <div class="hello-world">
+      <slot>{\`Hello, \${props.name ?? "World"}!\`}</slot>
+    </div>
+  ),
+);
+`;

--- a/tooling/cli/src/lib/styleframe-config.ts
+++ b/tooling/cli/src/lib/styleframe-config.ts
@@ -1,0 +1,19 @@
+export const styleframeConfigTemplate = `import {
+  useDesignTokensPreset,
+  useGlobalPreset,
+  useModifiersPreset,
+  useSanitizePreset,
+  useUtilitiesPreset,
+} from "@styleframe/theme";
+import { styleframe } from "styleframe";
+
+const s = styleframe();
+
+useDesignTokensPreset(s);
+useSanitizePreset(s);
+useGlobalPreset(s);
+useUtilitiesPreset(s);
+useModifiersPreset(s);
+
+export default s;
+`;


### PR DESCRIPTION
## Summary

Implements two new CLI commands for bootstrapping Inkline projects:

- **`inkline init`** — sets up an existing project to consume Inkline components. Detects the package manager, prompts for the target framework, runs `styleframe init`, seeds the config with Inkline theme presets, installs `inkline` + `@styleframe/runtime`, and wires the build plugin into vite/webpack/rollup configs via magicast.

- **`inkline compile init`** — scaffolds the component authoring workflow. Prompts for target framework(s) via multi-select, creates `inkline.config.ts`, generates an example `HelloWorld.ink.tsx` component, and adds `inkline:build`/`inkline:dev` scripts to package.json.

Both commands support `--framework`/`--target` flags to skip prompts, detect existing files to avoid overwriting, and gracefully handle failures with fallback instructions.

## Test plan

- [x] 109 tests pass across 14 test files (`vp test`)
- [x] Zero new type errors (`vp check` — 2 pre-existing errors in `compile-stories.ts`)
- [ ] Manual smoke test: run `inkline init --framework react` in a fresh React+Vite project
- [ ] Manual smoke test: run `inkline compile init --target react` in a fresh project