### PR TITLE
fix(storybook): co-locate stories in generated dir with relative imports

### DIFF
--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -122,12 +122,12 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
       if (node.scopedArgs.length > 0) {
         return node.fallback
           ? cExpr({
-              text: `{props.${propName}?.(${argsStr}) ?? ${emitNodeInline(node.fallback, rules)}}`,
+              text: `{props.${propName}?.(${argsStr}) ?? ${emitFallback(node.fallback, rules)}}`,
             })
           : cExpr({ text: `{props.${propName}?.(${argsStr})}` });
       }
       if (node.fallback) {
-        return cExpr({ text: `{props.${propName} ?? ${emitNodeInline(node.fallback, rules)}}` });
+        return cExpr({ text: `{props.${propName} ?? ${emitFallback(node.fallback, rules)}}` });
       }
       return cExpr({ text: `{props.${propName}}` });
     }
@@ -188,6 +188,12 @@ function emitNodeInline(node: IRNode, rules: RewriteRules): string {
   if (node.kind === "Text") {
     return `"${node.value}"`;
   }
+  return inlineCode(emitNode(node, rules));
+}
+
+function emitFallback(node: IRNode, rules: RewriteRules): string {
+  if (node.kind === "Text") return `"${node.value}"`;
+  if (node.kind === "Expression") return rewriteExpr(node.expr, rules);
   return inlineCode(emitNode(node, rules));
 }
 

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -337,7 +337,10 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       ...(needsTransition ? [cRaw({ text: "" }), cRaw({ text: QWIK_TRANSITION_HELPER })] : []),
       cRaw({ text: "" }),
       cStmt({
-        body: `export const ${component.name} = component$((props) =>`,
+        body:
+          component.props.length > 0 || component.slots.length > 0
+            ? `export const ${component.name} = component$((props) =>`
+            : `export const ${component.name} = component$(() =>`,
       }),
       cRaw({ text: "{" }),
       cGroup({

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -337,10 +337,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       ...(needsTransition ? [cRaw({ text: "" }), cRaw({ text: QWIK_TRANSITION_HELPER })] : []),
       cRaw({ text: "" }),
       cStmt({
-        body:
-          component.props.length > 0 || component.slots.length > 0
-            ? `export const ${component.name} = component$((props) =>`
-            : `export const ${component.name} = component$(() =>`,
+        body: `export const ${component.name} = component$((props) =>`,
       }),
       cRaw({ text: "{" }),
       cGroup({

--- a/core/compiler/src/codegen/targets/solid/index.ts
+++ b/core/compiler/src/codegen/targets/solid/index.ts
@@ -257,6 +257,9 @@ function inlineNode(node: IRNode, rules: RewriteRules): string {
   if (node.kind === "Text") {
     return `"${node.value}"`;
   }
+  if (node.kind === "Expression") {
+    return rewriteExpr(node.expr, rules);
+  }
   return inlineCode(emitNode(node, rules));
 }
 

--- a/tooling/cli/src/commands/compile-stories.test.ts
+++ b/tooling/cli/src/commands/compile-stories.test.ts
@@ -48,6 +48,7 @@ describe("compile-stories", () => {
     expect(mockedGenerate).toHaveBeenCalledWith({
       srcDir: expect.any(String),
       rootDir: expect.any(String),
+      storiesDir: "generated",
     });
     expect(logSpy).toHaveBeenCalledWith("Generated 1 story file(s) for 1 component(s).");
   });
@@ -78,6 +79,7 @@ describe("compile-stories", () => {
     expect(mockedGenerate).toHaveBeenCalledWith({
       srcDir: resolve("/custom/src"),
       rootDir: resolve("/custom/root"),
+      storiesDir: "generated",
     });
   });
 

--- a/tooling/cli/src/commands/compile-stories.ts
+++ b/tooling/cli/src/commands/compile-stories.ts
@@ -13,7 +13,7 @@ export default defineCommand({
   async run({ args }) {
     const srcDir = resolve(args["src-dir"] ?? "../../ui/components/src/components");
     const rootDir = resolve(args["root-dir"] ?? "../../ui");
-    const options = { srcDir, rootDir };
+    const options = { srcDir, rootDir, storiesDir: "generated" };
 
     if (!args.watch) {
       try {

--- a/tooling/storybook/src/generator/config.ts
+++ b/tooling/storybook/src/generator/config.ts
@@ -100,8 +100,8 @@ export const FRAMEWORKS: readonly FrameworkConfig[] = [
     template: "csf3",
     compiledExtension: ".tsx",
     renderStory: {
-      frameworkImport: 'import { createElement } from "qwik";',
-      expression: "createElement({name})",
+      frameworkImport: 'import { jsx } from "@qwik.dev/core/jsx-runtime";',
+      expression: "jsx({name}, {})",
     },
     hasDefaultExport: false,
   },

--- a/tooling/storybook/src/generator/index.test.ts
+++ b/tooling/storybook/src/generator/index.test.ts
@@ -129,6 +129,15 @@ describe("resolveRenderImports", () => {
 
     expect(imports).toEqual([]);
   });
+
+  it("produces relative imports when story output is co-located with generated", async () => {
+    const mod = await loadStoryModule(join(STORIES_DIR, "Badge.stories.ts"));
+    const react = frameworkByTarget("react")!;
+    const imports = resolveRenderImports(mod, STORIES_DIR, react, "generated", "generated");
+
+    expect(imports[0]!.importPath).toBe("./colors.tsx");
+    expect(imports[1]!.importPath).toBe("./sizes.tsx");
+  });
 });
 
 describe("generate", () => {
@@ -187,5 +196,17 @@ describe("generate", () => {
     const result = await generate({ srcDir: STORIES_DIR, rootDir: outDir });
     expect(result.files).toHaveLength(7 * 3);
     expect(result.files.some((f) => f.target === "astro")).toBe(true);
+  });
+
+  it("outputs into generated dir with relative imports when storiesDir is generated", async () => {
+    const frameworks = [frameworkByTarget("react")!];
+    await generate({ srcDir: STORIES_DIR, rootDir: outDir, frameworks, storiesDir: "generated" });
+
+    const reactBadge = readFileSync(
+      join(outDir, "react", "generated", "IBadge.stories.ts"),
+      "utf-8",
+    );
+    expect(reactBadge).toContain('from "./colors.tsx"');
+    expect(reactBadge).toContain('from "./sizes.tsx"');
   });
 });

--- a/tooling/storybook/src/generator/index.ts
+++ b/tooling/storybook/src/generator/index.ts
@@ -110,6 +110,8 @@ export function resolveRenderImports(
   storyModule: LoadedStoryModule,
   srcDir: string,
   framework: FrameworkConfig,
+  storyOutputRelDir = "stories",
+  generatedDir = "generated",
 ): ResolvedRenderImport[] {
   const imports: ResolvedRenderImport[] = [];
   const storyDir = dirname(storyModule.sourcePath);
@@ -122,7 +124,9 @@ export function resolveRenderImports(
     const relToCompilerRoot = relative(compilerRoot, absRenderPath);
     const withoutInkExt = relToCompilerRoot.replace(/\.ink\.tsx$/, "");
     const compiledRel = withoutInkExt + framework.compiledExtension;
-    const importPath = "../generated/" + compiledRel.split("/").join("/");
+    const renderOutputPath = join(generatedDir, compiledRel);
+    const rel = relative(storyOutputRelDir, renderOutputPath);
+    const importPath = rel.startsWith(".") ? rel : "./" + rel;
 
     const baseName = withoutInkExt.split("/").pop()!;
     const exportedName = baseName + (framework.exportedNameSuffix ?? "");
@@ -137,23 +141,33 @@ export function resolveRenderImports(
 export async function generate(options: GenerateOptions): Promise<GenerateResult> {
   const frameworks = options.frameworks ?? activeFrameworks();
   const definitionFiles = discoverDefinitionFiles(options.srcDir);
+  const compilerRoot = computeCompilerRoot(options.srcDir);
 
   const components: string[] = [];
   const files: GeneratedFile[] = [];
   const storiesDir = options.storiesDir ?? "stories";
+  const generatedDir = options.generatedDir ?? "generated";
 
   for (const definitionFile of definitionFiles) {
     const storyModule = await loadStoryModule(definitionFile);
     components.push(storyModule.meta.component);
 
+    const relDir = relative(compilerRoot, dirname(definitionFile));
+    const storyOutputRelDir = join(storiesDir, relDir);
     const keysByTarget = new Map<string, StoryKeys>();
 
     for (const framework of frameworks) {
-      const renderImports = resolveRenderImports(storyModule, options.srcDir, framework);
+      const renderImports = resolveRenderImports(
+        storyModule,
+        options.srcDir,
+        framework,
+        storyOutputRelDir,
+        generatedDir,
+      );
       const source = renderStory(storyModule, framework, renderImports);
       keysByTarget.set(framework.target, extractStoryKeys(source));
 
-      const outDir = join(options.rootDir, framework.target, storiesDir);
+      const outDir = join(options.rootDir, framework.target, storiesDir, relDir);
       const outPath = join(outDir, `${storyModule.meta.component}.stories.ts`);
       mkdirSync(outDir, { recursive: true });
       writeFileSync(outPath, source, "utf-8");

--- a/ui/angular/.gitignore
+++ b/ui/angular/.gitignore
@@ -1,5 +1,4 @@
 generated/
-stories/
 storybook-static/
 .angular/
 .styleframe/

--- a/ui/angular/.storybook/main.ts
+++ b/ui/angular/.storybook/main.ts
@@ -6,6 +6,7 @@ export default createStorybookConfig({
   framework: "@analogjs/storybook-angular",
   componentPackage: "@inkline/angular",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
   frameworkOptions: {
     tsconfig: resolve(import.meta.dirname, "..", "tsconfig.storybook.json"),
   },

--- a/ui/astro/.gitignore
+++ b/ui/astro/.gitignore
@@ -1,5 +1,4 @@
 generated/
-stories/
 storybook-static/
 storybook-server/
 .styleframe/

--- a/ui/astro/.storybook/main.ts
+++ b/ui/astro/.storybook/main.ts
@@ -6,4 +6,5 @@ export default createStorybookConfig({
   framework: "@storybook-astro/framework",
   componentPackage: "@inkline/astro",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
 });

--- a/ui/components/src/components/badge/headless/IBadgeBase.ink.test.ts
+++ b/ui/components/src/components/badge/headless/IBadgeBase.ink.test.ts
@@ -6,7 +6,6 @@ import {
   expectNoDiagnostics,
   assertConformance,
   snapshotOutput,
-  expectOutputContains,
   resolveComponent,
 } from "@inkline/test-utils";
 
@@ -32,13 +31,6 @@ describe("Badge", () => {
   it("passes conformance invariants for all targets", async () => {
     const result = await compileComponent(BADGE);
     assertConformance(result);
-  });
-
-  it("generates disabled attribute in all targets", async () => {
-    const result = await compileComponent(BADGE);
-    for (const target of ["react", "vue", "solid", "svelte"] as const) {
-      expectOutputContains(result.filesFor(target), "disabled");
-    }
   });
 
   it("output matches snapshots", async () => {

--- a/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
+++ b/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
@@ -2,7 +2,6 @@ import { defineComponent, Slot } from "@inkline/core";
 
 export interface BadgeBaseProps {
   label?: string;
-  disabled?: boolean;
 }
 
 export default defineComponent(
@@ -11,7 +10,7 @@ export default defineComponent(
   },
   (props: BadgeBaseProps) => {
     return (
-      <div class="badge" disabled={props.disabled}>
+      <div class="badge">
         <Slot>{props.label}</Slot>
       </div>
     );

--- a/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
+++ b/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
@@ -1,4 +1,4 @@
-import { defineComponent } from "@inkline/core";
+import { defineComponent, Slot } from "@inkline/core";
 
 export interface BadgeBaseProps {
   label?: string;
@@ -12,7 +12,7 @@ export default defineComponent(
   (props: BadgeBaseProps) => {
     return (
       <div class="badge" disabled={props.disabled}>
-        <slot>{props.label}</slot>
+        <Slot>{props.label}</Slot>
       </div>
     );
   },

--- a/ui/components/src/components/badge/headless/__snapshots__/IBadgeBase.ink.test.ts.snap
+++ b/ui/components/src/components/badge/headless/__snapshots__/IBadgeBase.ink.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Badge > output matches snapshots 1`] = `
 {
   "angular/IBadgeBase.component.ts": "import { Component, signal, computed, effect } from "@angular/core";
-@Component({ standalone: true, selector: 'IBadgeBase', template: \`<div class="badge" [disabled]="disabled">
+@Component({ standalone: true, selector: 'IBadgeBase', template: \`<div class="badge">
 <ng-content />
 </div>\` })
 export class IBadgeBaseComponent
@@ -12,7 +12,7 @@ export class IBadgeBaseComponent
 ",
   "astro/IBadgeBase.astro": "---
 ---
-<div class="badge" disabled={disabled}>
+<div class="badge">
 <slot />
 </div>
 ",
@@ -20,7 +20,7 @@ export class IBadgeBaseComponent
 export const IBadgeBase = component$((props) =>
 {
 return (
-<div class="badge" disabled={props.disabled}>
+<div class="badge">
   {props.children ?? props.label}
 </div>
 )
@@ -29,7 +29,7 @@ return (
   "react/IBadgeBase.tsx": "export function IBadgeBase(props: { children?: React.ReactNode })
 {
 return (
-<div className="badge" disabled={props.disabled}>
+<div className="badge">
   {props.children ?? props.label}
 </div>
 )
@@ -38,7 +38,7 @@ return (
   "solid/IBadgeBase.tsx": "export default function IBadgeBase(props: { default?: any })
 {
 return (
-<div class="badge" disabled={props.disabled}>
+<div class="badge">
   {props.default ?? props.label}
 </div>
 )
@@ -46,7 +46,7 @@ return (
 ",
   "svelte/IBadgeBase.svelte": "<script lang="ts">
 </script>
-<div class="badge" disabled={disabled}>
+<div class="badge">
   <slot>
     {label}
   </slot>
@@ -55,7 +55,7 @@ return (
   "vue/IBadgeBase.vue": "<script setup lang="ts">
 </script>
 <template>
-<div class="badge" :disabled="disabled">
+<div class="badge">
   <slot>
     {{ label }}
   </slot>

--- a/ui/components/src/components/badge/headless/__snapshots__/IBadgeBase.ink.test.ts.snap
+++ b/ui/components/src/components/badge/headless/__snapshots__/IBadgeBase.ink.test.ts.snap
@@ -4,9 +4,7 @@ exports[`Badge > output matches snapshots 1`] = `
 {
   "angular/IBadgeBase.component.ts": "import { Component, signal, computed, effect } from "@angular/core";
 @Component({ standalone: true, selector: 'IBadgeBase', template: \`<div class="badge" [disabled]="disabled">
-<slot>
-{{ label }}
-</slot>
+<ng-content />
 </div>\` })
 export class IBadgeBaseComponent
 {
@@ -15,9 +13,7 @@ export class IBadgeBaseComponent
   "astro/IBadgeBase.astro": "---
 ---
 <div class="badge" disabled={disabled}>
-<slot>
-{label}
-</slot>
+<slot />
 </div>
 ",
   "qwik/IBadgeBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $ } from "@qwik.dev/core";
@@ -25,9 +21,7 @@ export const IBadgeBase = component$((props) =>
 {
 return (
 <div class="badge" disabled={props.disabled}>
-  <slot>
-    {props.label}
-  </slot>
+  {props.children ?? props.label}
 </div>
 )
 });
@@ -36,9 +30,7 @@ return (
 {
 return (
 <div className="badge" disabled={props.disabled}>
-  <slot>
-    {props.label}
-  </slot>
+  {props.children ?? props.label}
 </div>
 )
 }
@@ -47,9 +39,7 @@ return (
 {
 return (
 <div class="badge" disabled={props.disabled}>
-  <slot>
-    {props.label}
-  </slot>
+  {props.default ?? props.label}
 </div>
 )
 }

--- a/ui/components/src/components/badge/styled/IBadge.ink.tsx
+++ b/ui/components/src/components/badge/styled/IBadge.ink.tsx
@@ -1,9 +1,13 @@
-import { defineComponent } from "@inkline/core";
+import { defineComponent, Slot } from "@inkline/core";
 import IBadgeBase, { type BadgeBaseProps } from "../headless/IBadgeBase.ink.tsx";
 import { badge, type BadgeProps as BadgeStylingProps } from "virtual:styleframe";
 
 export interface BadgeProps extends BadgeBaseProps, BadgeStylingProps {}
 
-export default defineComponent((props: BadgeProps) => {
-  return <IBadgeBase class={badge(props as BadgeStylingProps)}>{props.label}</IBadgeBase>;
+export default defineComponent({ slots: { default: {} } }, (props: BadgeProps) => {
+  return (
+    <IBadgeBase class={badge(props as BadgeStylingProps)} {...props}>
+      <Slot>{props.label}</Slot>
+    </IBadgeBase>
+  );
 });

--- a/ui/qwik/.gitignore
+++ b/ui/qwik/.gitignore
@@ -1,4 +1,3 @@
 generated/
-stories/
 storybook-static/
 .styleframe/

--- a/ui/qwik/.storybook/main.ts
+++ b/ui/qwik/.storybook/main.ts
@@ -6,4 +6,5 @@ export default createStorybookConfig({
   framework: "storybook-framework-qwik",
   componentPackage: "@inkline/qwik",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
 });

--- a/ui/react/.gitignore
+++ b/ui/react/.gitignore
@@ -1,4 +1,3 @@
 generated/
-stories/
 storybook-static/
 .styleframe/

--- a/ui/react/.storybook/main.ts
+++ b/ui/react/.storybook/main.ts
@@ -6,4 +6,5 @@ export default createStorybookConfig({
   framework: "@storybook/react-vite",
   componentPackage: "@inkline/react",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
 });

--- a/ui/solid/.gitignore
+++ b/ui/solid/.gitignore
@@ -1,4 +1,3 @@
 generated/
-stories/
 storybook-static/
 .styleframe/

--- a/ui/solid/.storybook/main.ts
+++ b/ui/solid/.storybook/main.ts
@@ -6,4 +6,5 @@ export default createStorybookConfig({
   framework: "storybook-solidjs-vite",
   componentPackage: "@inkline/solid",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
 });

--- a/ui/svelte/.gitignore
+++ b/ui/svelte/.gitignore
@@ -1,4 +1,3 @@
 generated/
-stories/
 storybook-static/
 .styleframe/

--- a/ui/svelte/.storybook/main.ts
+++ b/ui/svelte/.storybook/main.ts
@@ -6,4 +6,5 @@ export default createStorybookConfig({
   framework: "@storybook/svelte-vite",
   componentPackage: "@inkline/svelte",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
 });

--- a/ui/vue/.gitignore
+++ b/ui/vue/.gitignore
@@ -1,4 +1,3 @@
 generated/
-stories/
 storybook-static/
 .styleframe/

--- a/ui/vue/.storybook/main.ts
+++ b/ui/vue/.storybook/main.ts
@@ -6,4 +6,5 @@ export default createStorybookConfig({
   framework: "@storybook/vue3-vite",
   componentPackage: "@inkline/vue",
   sourceEntry: resolve(import.meta.dirname, "..", "generated", "index.ts"),
+  stories: ["../generated/**/*.stories.ts"],
 });


### PR DESCRIPTION
Move generated story files from `ui/<fw>/stories/` into `ui/<fw>/generated/<relDir>/` so they live alongside the compiled component output. Import paths in generated stories now use relative references instead of hardcoded `../generated/` prefixes. All Storybook `main.ts` configs are updated to resolve stories from `../generated/**/*.stories.ts`, and `stories/` is removed from each framework's `.gitignore` (now covered by the existing `generated/` rule). Fixes the Qwik codegen to always emit `component$(props =>)` regardless of prop count, and drops the unused `disabled` prop from `IBadgeBase` while adding proper `Slot` support to `IBadge`.