### PR TITLE
chore: add Linear MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear-server": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Register the Linear MCP server (https://mcp.linear.app/mcp) as a project-scoped server via repo-root .mcp.json, so every Conductor workspace and contributor inherits it (Conductor agents inherit MCP servers from a repo-root .mcp.json).

## Summary

<!-- One or two sentences. What changed and why. -->

## Test plan

<!-- Bulleted checklist. Include vp run ready, manual checks, etc. -->

- [ ] `vp run ready` passes locally
- [ ]

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [ ] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".
