### PR TITLE
ci: run unit tests in 2 parallel shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,14 @@ jobs:
         run: npx vp check --no-fmt --no-lint
 
   test:
-    name: Unit Tests
+    name: Unit Tests (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -239,7 +243,15 @@ jobs:
           name: build-artifacts
 
       - name: Run tests
-        run: pnpm run test -- --coverage
+        # Each shard runs only part of the suite, so per-package coverage is partial. Disable the
+        # 100% coverage thresholds for the sharded run (Codecov merges the two shard uploads); the
+        # gate still applies to full local `vp test --coverage` runs. A CLI flag is used rather than
+        # an env var because `vp run` executes tasks in a clean environment that strips ad-hoc vars.
+        run: >-
+          pnpm run test --
+          --coverage --shard=${{ matrix.shard }}/2 --passWithNoTests
+          --coverage.thresholds.lines=0 --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0 --coverage.thresholds.statements=0
         env:
           NODE_ENV: test
 
@@ -248,6 +260,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          flags: shard-${{ matrix.shard }}
 
   ci-success:
     name: CI Success


### PR DESCRIPTION
## Summary

Splits the CI **Unit Tests** job into a 2-way matrix using Vitest's native `--shard`, running each half in parallel. Each shard uploads its partial coverage to Codecov (merged server-side) under a per-shard flag, and the per-package 100% coverage gate is disabled for sharded runs via forwarded CLI flags (because `vp run` executes tasks in a clean environment that strips ad-hoc env vars) while still applying to full local `vp test --coverage` runs.

> Note: wall-clock gain is currently minimal — one file (`core/compiler/src/testing/typecheck.test.ts`, ~125s) dominates the suite and `--shard` cannot split within a file. This PR is the sharding infrastructure; the typecheck/lint conformance harness perf is a separate follow-up.

## Test plan

- [ ] `vp run ready` passes locally
- [x] Both shards run green and together cover the full suite (2652 tests = 870 + 1782, no gaps/overlap)
- [x] Full local `vp test --coverage` still enforces the storybook 100% gate

## Checklist

- [x] Added a changeset — N/A (CI-only change, no published package behavior/API/types)
- [x] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated — N/A
- [x] Commit messages follow the conventional format (`ci: …`)