### PR TITLE
fix(compiler): decompose JSX-valued named-slot fills in lowering

### DIFF
--- a/.changeset/vue-jsx-named-slot-fill.md
+++ b/.changeset/vue-jsx-named-slot-fill.md
@@ -1,0 +1,21 @@
+---
+"@inkline/compiler": patch
+"@inkline/vue": patch
+"@inkline/svelte": patch
+"@inkline/astro": patch
+---
+
+fix(compiler): JSX-valued named-slot fills mis-compiled on template targets
+
+Filling a child component's named slot with JSX content (`<IButton icon={<span>★</span>}>`,
+and slot re-projection `icon={<Slot name="icon" />}`) emitted invalid output on template
+targets. The fill was kept as an opaque `Expression` IR node, so Vue/Svelte/Astro routed it
+through the text-interpolation path — Vue produced `<template #icon>{{ <span>★</span> }}</template>`
+instead of slot template content. JSX targets (React/Solid/Qwik) and Angular were unaffected
+because they re-emit the expression natively.
+
+The `slots` lowering pass now decomposes the JSX fill into real render nodes (the same
+`parseExpression` decomposition already used for `<Show>` fallbacks), so every target receives a
+structural subtree. Vue emits `<template #icon><span>★</span></template>`, Svelte a named
+`{#snippet}`, and Astro a `<Fragment slot="icon">`; re-projected `<Slot>` fills lower to the
+target's native slot node. Named slots other than `default` are now usable on the Vue target.

--- a/core/compiler/src/__fixtures__/NamedSlotFill.ink.tsx
+++ b/core/compiler/src/__fixtures__/NamedSlotFill.ink.tsx
@@ -1,0 +1,19 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+const IButton = defineComponent((props: { label: string }) => {
+  return (
+    <button>
+      <Slot name="icon" />
+      <span>{props.label}</span>
+    </button>
+  );
+});
+
+export default defineComponent(() => {
+  return (
+    <div>
+      <IButton label="Star" icon={<span>★</span>} />
+      <IButton label="Proxy" icon={<Slot name="icon" />} />
+    </div>
+  );
+});

--- a/core/compiler/src/codegen/targets/__tests__/named-slot-fill.test.ts
+++ b/core/compiler/src/codegen/targets/__tests__/named-slot-fill.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compileFixture } from "../../../testing/harness.ts";
+import type { TargetName } from "../../context.ts";
+
+async function code(fixture: string, target: TargetName): Promise<string> {
+  const result = await compileFixture(fixture, [target]);
+  const files = result.files[target];
+  expect(files, `${fixture} should produce ${target} output`).toBeDefined();
+  // NamedSlotFill defines both a child (IButton) and the parent; the parent file is the
+  // one filling the named slot.
+  const parent = files!.find(
+    (f) =>
+      f.contents.includes("template #icon") ||
+      f.contents.includes("IButton.icon") ||
+      f.contents.includes("snippet icon") ||
+      f.contents.includes('slot="icon"'),
+  );
+  return (parent ?? files![files!.length - 1]!).contents;
+}
+
+// ---------------------------------------------------------------------------
+// UXF-12: filling a child component's named slot with JSX content
+// (`<IButton icon={<span>★</span>}>`) must emit structural slot content, not a
+// text interpolation. The bug surfaced on Vue (`{{ <span>★</span> }}`) but the
+// root cause — keeping the fill as an opaque Expression IR node — affected every
+// template target. Fixed by decomposing the JSX in the slots lowering pass so all
+// targets receive real render nodes.
+// ---------------------------------------------------------------------------
+describe("UXF-12: JSX-valued named-slot fills", () => {
+  it("Vue: emits <template #icon> with structural content, not a mustache", async () => {
+    const out = await code("NamedSlotFill", "vue");
+    expect(out).toContain("<template #icon>");
+    expect(out).toContain("<span>");
+    expect(out).toContain("★");
+    // The regression: JSX wrapped in a text interpolation.
+    expect(out).not.toContain("{{ <span");
+    expect(out).not.toMatch(/\{\{\s*<\/?span/);
+  });
+
+  it('Vue: re-projection (`icon={<Slot name="icon"/>}`) emits a nested <slot>', async () => {
+    const out = await code("NamedSlotFill", "vue");
+    expect(out).toContain('<slot name="icon"');
+    expect(out).not.toMatch(/\{\{\s*<Slot/);
+  });
+
+  it("Svelte: emits a named {#snippet} with structural content, not a mustache", async () => {
+    const out = await code("NamedSlotFill", "svelte");
+    expect(out).toContain("{#snippet icon()}");
+    expect(out).toContain("<span>");
+    expect(out).not.toContain("{<span");
+  });
+
+  it('Astro: emits a slotted <Fragment slot="icon"> with structural content', async () => {
+    const out = await code("NamedSlotFill", "astro");
+    expect(out).toContain('<Fragment slot="icon">');
+    expect(out).toContain("<span>");
+  });
+
+  it("React: parity — named slot fill stays a JSX child (regression guard)", async () => {
+    const out = await code("NamedSlotFill", "react");
+    expect(out).toContain("<IButton.icon>");
+    expect(out).toContain("<span>");
+  });
+});

--- a/core/compiler/src/pipeline/passes/03-lower/slots.test.ts
+++ b/core/compiler/src/pipeline/passes/03-lower/slots.test.ts
@@ -77,6 +77,46 @@ describe("slots", () => {
     expect(out.slots[1]!.name).toBe("fallback");
   });
 
+  it("decomposes a JSX-valued attr into structural render nodes (not an opaque Expression)", () => {
+    const ci = createComponentInstance({
+      reference: ident("IButton"),
+      attrs: [
+        {
+          name: "icon",
+          value: createExpr({ expr: mockExpr("<span>star</span>") }),
+          binding: "normal",
+          loc: UNKNOWN_LOCATION,
+        },
+      ],
+      slots: [],
+    });
+    const out = slots(makeComp(ci)).render as IRComponentInstance;
+    expect(out.slots).toHaveLength(1);
+    expect(out.slots[0]!.name).toBe("icon");
+    // Must be a real Element, not an `Expression` wrapping the JSX. An opaque Expression
+    // makes template targets emit a text interpolation (`{{ <span/> }}`). See UXF-12.
+    expect(out.slots[0]!.body.kind).toBe("Element");
+  });
+
+  it("decomposes a JSX component fill (`<Slot/>` re-projection) into a ComponentInstance", () => {
+    const ci = createComponentInstance({
+      reference: ident("IButton"),
+      attrs: [
+        {
+          name: "icon",
+          value: createExpr({ expr: mockExpr('<Slot name="icon" />') }),
+          binding: "normal",
+          loc: UNKNOWN_LOCATION,
+        },
+      ],
+      slots: [],
+    });
+    const out = slots(makeComp(ci)).render as IRComponentInstance;
+    // The control-flow pass (which runs after `slots`) lowers this `Slot` instance to a
+    // SlotPlaceholder; here we only assert `slots` decomposed it past an Expression.
+    expect(out.slots[0]!.body.kind).toBe("ComponentInstance");
+  });
+
   it("keeps non-JSX attrs unchanged", () => {
     const ci = createComponentInstance({
       reference: ident("Button"),

--- a/core/compiler/src/pipeline/passes/03-lower/slots.ts
+++ b/core/compiler/src/pipeline/passes/03-lower/slots.ts
@@ -7,6 +7,7 @@ import type {
   IRSlotContent,
 } from "../../../ir/render/nodes.ts";
 import { transformComponent } from "../../../ir/render/transform.ts";
+import { parseExpression } from "../02-parse/jsx/index.ts";
 
 function isJsxExpression(expr: ts.Expression): boolean {
   return ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr);
@@ -25,9 +26,13 @@ export function slots(component: IRComponent): IRComponent {
       for (const attr of ci.attrs) {
         if (attr.value.kind === "Expression" && isJsxExpression(attr.value.expr)) {
           slotsChanged = true;
+          // Decompose the JSX into real render nodes so every target emits slot content
+          // structurally. Left as an opaque Expression, template targets (Vue/Svelte/Astro)
+          // wrap it in a text interpolation (`{{ <span/> }}`) instead of slot template content.
+          const sf = attr.value.expr.getSourceFile();
           newSlots.push({
             name: attr.name,
-            body: attr.value as IRNode,
+            body: sf ? parseExpression(attr.value.expr, sf) : (attr.value as IRNode),
             scopedParams: [],
             loc: attr.loc,
           });


### PR DESCRIPTION
## Summary

JSX-valued named-slot fills (`<IButton icon={<span>★</span>}>` and re-projection `icon={<Slot name="icon"/>}`) were kept as opaque `Expression` IR nodes, so template targets routed them through the text-interpolation path — Vue emitted `<template #icon>{{ <span>★</span> }}</template>` instead of slot content (same latent bug on Svelte/Astro). The `slots` lowering pass now decomposes the JSX into real render nodes via `parseExpression` (the same decomposition used for `<Show>` fallbacks), so every target receives a structural subtree. Fixes UXF-12.

## Test plan

- [x] `vp test` — full compiler suite passes (2403 tests)
- [x] `vp check` / `vp lint` / `vp fmt` clean (pre-existing fixture TS noise unchanged)
- [x] New unit tests (`slots.test.ts`) assert the slot body is decomposed, not an `Expression`
- [x] New end-to-end codegen test (`named-slot-fill.test.ts`) verifies Vue `<template #icon>`, Svelte `{#snippet}`, Astro `<Fragment slot="icon">`, and React parity
- [ ] `vp run ready` passes locally

## Checklist

- [x] Added a changeset (`@inkline/compiler` + `@inkline/vue`/`svelte`/`astro`, patch)
- [x] No public API / build flow / convention / structure changes — no docs update needed
- [x] Commit messages follow the conventional format (`fix(compiler): …`)