### PR TITLE
chore(github): add community health files and GitHub templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS — auto-requests review from the listed owners on matching paths.
+# Docs: https://docs.github.com/articles/about-code-owners
+#
+# Blocking enforcement additionally requires branch protection with
+# "Require review from Code Owners" enabled on the protected branch.
+
+# Global owner — every change requests review from @alexgrozav.
+* @alexgrozav

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at alex@grozav.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to Inkline
+
+The full contributing guide lives at **[docs/contributing.md](../docs/contributing.md)** — dev setup, the `vp run ready` gate, changesets, and the before-PR checklist.
+
+Quick links:
+
+- [Conventions](../docs/conventions.md) — code, file, test, and commit conventions.
+- [Architecture](../docs/architecture.md) — how the compiler emits 7 framework outputs.
+- [Release process](../docs/release-process.md) — changesets and publishing.
+
+By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [alexgrozav]
+open_collective: inkline

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,120 @@
+name: 🐛 Bug report
+description: Report a defect in the compiler, a primitive, the tooling, or a generated framework output.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill in the fields below so we can reproduce and fix it quickly.
+
+        Have a "how do I…" question instead? Use [GitHub Discussions](https://github.com/inkline/inkline/discussions) — questions filed as issues will be closed.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following before filing.
+      options:
+        - label: I searched [existing issues](https://github.com/inkline/inkline/issues) and this has not been reported.
+          required: true
+        - label: I reproduced this on the latest published version.
+          required: true
+        - label: I have included a minimal reproduction below.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: >
+        The smallest input that triggers the bug. For compiler bugs, include the authored `.ink.tsx`
+        snippet and the steps to reproduce. A link to a repository or playground is ideal.
+      placeholder: |
+        Steps / repro link, plus the authored source:
+
+        ```tsx
+        // Button.ink.tsx
+        export const Button = component(() => {
+          // …
+        });
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include any compiler diagnostics or the problematic generated output.
+    validations:
+      required: true
+  - type: dropdown
+    id: frameworks
+    attributes:
+      label: Affected output framework(s)
+      description: Which generated framework output(s) does this affect? Select all that apply.
+      multiple: true
+      options:
+        - React
+        - Vue 3
+        - Svelte 5
+        - Solid
+        - Angular
+        - Qwik
+        - Astro
+        - All / framework-agnostic (compiler/core)
+        - Not applicable
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area / package
+      description: Which part of the toolchain is involved?
+      options:
+        - Compiler (@inkline/compiler)
+        - Authoring primitives (@inkline/core)
+        - Bundler plugin (@inkline/plugin)
+        - CLI (@inkline/cli)
+        - Config loader (@inkline/config-loader)
+        - Barrel package (inkline)
+        - Components (Badge / Button / Input)
+        - A framework output package (@inkline/react, vue, …)
+        - Storybook integration (@inkline/storybook)
+        - Test utils (@inkline/test-utils)
+        - Docs / website
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Run the commands below and paste the output. Include `vp env doctor` if the issue looks tooling-related.
+      value: |
+        - Inkline: # pnpm list inkline @inkline/compiler
+        - Node:    # node -v
+        - pnpm:    # pnpm -v
+        - OS:
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help — screenshots, related issues, or workarounds you found.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/inkline/inkline#readme
+    about: Read the architecture, authoring, and conventions docs first.
+  - name: 💬 Questions & ideas
+    url: https://github.com/inkline/inkline/discussions
+    about: Ask "how do I…", request help, or float ideas here — issues are for bugs and concrete proposals.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: ✨ Feature request
+description: Suggest a new capability, API, or enhancement.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea! Please describe the problem first, then your proposed solution.
+
+        For open-ended "what if…" discussions, consider [GitHub Discussions](https://github.com/inkline/inkline/discussions) instead.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I searched [existing issues](https://github.com/inkline/inkline/issues) and [discussions](https://github.com/inkline/inkline/discussions) and this has not been proposed.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area / package
+      description: Which part of the toolchain would this touch?
+      options:
+        - Compiler (@inkline/compiler)
+        - Authoring primitives (@inkline/core)
+        - Bundler plugin (@inkline/plugin)
+        - CLI (@inkline/cli)
+        - Config loader (@inkline/config-loader)
+        - Barrel package (inkline)
+        - Components (Badge / Button / Input)
+        - A framework output package (@inkline/react, vue, …)
+        - Storybook integration (@inkline/storybook)
+        - Test utils (@inkline/test-utils)
+        - Docs / website
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you trying to do that you can't today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the API, behavior, or change you'd like. Include example `.ink.tsx` usage if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated and why you discarded them.
+    validations:
+      required: false
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you willing to submit a PR?
+      description: We welcome contributions! See the contributing guide for the dev workflow.
+      options:
+        - "Yes, I can implement this"
+        - "Yes, with guidance"
+        - "No"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, references, prior art, or screenshots.
+    validations:
+      required: false

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+We take the security of Inkline and its generated output seriously. Thank you for helping keep the project and its users safe.
+
+## Supported versions
+
+Inkline is pre-1.0 and under active development. Security fixes land on the latest published release of each package; older versions are not patched. Please upgrade to the latest version before reporting.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, report them privately through GitHub's built-in advisory workflow:
+
+1. Go to the [Security tab](https://github.com/inkline/inkline/security) of the repository.
+2. Click **"Report a vulnerability"** to open a private advisory.
+3. Include a description, the affected package(s) and version(s), and a minimal reproduction.
+
+This routes your report privately to the maintainers via [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+## What to expect
+
+- **Acknowledgement** within 5 business days.
+- An assessment and, if accepted, a fix timeline communicated through the advisory thread.
+- Credit for the discloser once a fix is released, unless you prefer to remain anonymous.
+
+Please give us a reasonable window to release a fix before any public disclosure.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+Thanks for using Inkline! Here's how to get help.
+
+## 📚 Read the docs first
+
+- [Architecture](../docs/architecture.md) — how `.ink.tsx` becomes 7 framework outputs.
+- [Authoring components](../docs/authoring-components.md) — adding or modifying a component.
+- [Language reference](../core/compiler/README.md) — primitives, control flow, and options.
+
+## 💬 Questions & ideas
+
+For "how do I…" questions, usage help, and open-ended ideas, use [GitHub Discussions](https://github.com/inkline/inkline/discussions). This keeps the issue tracker focused and makes answers searchable for everyone.
+
+## 🐛 Bugs & feature requests
+
+If you've found a reproducible bug or have a concrete proposal, [open an issue](https://github.com/inkline/inkline/issues/new/choose) using the appropriate form.
+
+## 🤝 Contributing
+
+Want to fix it yourself? See [contributing.md](../docs/contributing.md) for the dev workflow and the before-PR checklist.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # JavaScript/TypeScript dependencies across the pnpm workspace.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used in workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,29 @@
 
 <!-- One or two sentences. What changed and why. -->
 
+## Related issues
+
+<!-- Link issues this PR closes or relates to. -->
+
+- Closes #
+
+## Type of change
+
+<!-- Check all that apply; this should match your commit's conventional type. -->
+
+- [ ] `feat` — new user-facing capability or public API
+- [ ] `fix` — bug fix
+- [ ] `refactor` — internal change, no behavior change
+- [ ] `docs` — documentation only
+- [ ] `test` — tests only
+- [ ] `chore` / `ci` — tooling, dependencies, or CI
+
 ## Test plan
 
 <!-- Bulleted checklist. Include vp run ready, manual checks, etc. -->
 
 - [ ] `vp run ready` passes locally
-- [ ]
+- [ ] <!-- add manual or framework-specific checks -->
 
 ## Checklist
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,38 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - breaking-change
+        - semver:major
+    - title: 🚀 Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - fix
+        - bug
+    - title: 📚 Documentation
+      labels:
+        - docs
+        - documentation
+    - title: 🏗️ Refactors & Chores
+      labels:
+        - refactor
+        - chore
+    - title: 🧪 Tests
+      labels:
+        - test
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,18 +68,20 @@ Full release flow: [release-process.md](./release-process.md).
 
 ## Pull requests
 
-No PR template or CODEOWNERS today. Keep PRs scoped, include a changeset when applicable, ensure `vp run ready` passes locally, and write a commit message following [conventions.md](./conventions.md) → "Commit messages".
+Opening a PR fills in the [pull request template](../.github/pull_request_template.md); [`CODEOWNERS`](../.github/CODEOWNERS) auto-requests review. Keep PRs scoped, include a changeset when applicable, ensure `vp run ready` passes locally, and write a commit message following [conventions.md](./conventions.md) → "Commit messages".
 
 If your change touches public API, build flow, repo conventions, or directory structure, **also update the relevant `AGENTS.md` and/or `docs/*.md`**. See [maintenance.md](./maintenance.md) for what counts as a "doc-touching" change.
 
 ## Bug reports and issues
 
-Use GitHub issues. Include:
+Open an issue from the [issue chooser](https://github.com/inkline/inkline/issues/new/choose) — the **Bug report** and **Feature request** forms prompt for everything we need:
 
 - A minimal reproduction (a `.ink.tsx` snippet for compiler bugs).
 - Inkline version (`pnpm list inkline @inkline/compiler`).
 - `vp env doctor` output if the issue looks tooling-related.
 - Expected vs actual behavior.
+
+For "how do I…" questions and open-ended ideas, use [GitHub Discussions](https://github.com/inkline/inkline/discussions) instead.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds the full set of GitHub community health files and templates: `CODEOWNERS`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `SUPPORT.md`, `FUNDING.yml`, `dependabot.yml`, `release.yml`, structured issue templates (bug report, feature request, chooser config), and an expanded PR template with **Related issues** and **Type of change** sections. `docs/contributing.md` is updated to reference the new PR template and `CODEOWNERS`.

## Related issues

- Closes #

## Type of change

- [x] `chore` / `ci` — tooling, dependencies, or CI

## Test plan

- [ ] `vp run ready` passes locally
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template populates on new PRs

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".