### PR TITLE
fix(compiler): cross-framework named-slot consistency + Angular nullish attrs

### DIFF
--- a/.changeset/input-named-slot-consistency.md
+++ b/.changeset/input-named-slot-consistency.md
@@ -1,0 +1,24 @@
+---
+"@inkline/compiler": patch
+"@inkline/react": patch
+"@inkline/solid": patch
+"@inkline/qwik": patch
+"@inkline/angular": patch
+---
+
+fix(compiler): consistent named-slot rendering across JSX targets + Angular nullish attributes
+
+Rendering the Input "Default" story side-by-side surfaced cross-framework inconsistencies, all in codegen:
+
+- **Named slots were silently dropped on React, Solid, and Qwik.** Each emitted a named-slot fill as a
+  dead `<Tag.name>` child while consuming the slot a different way, so content (e.g. the Input's `$`
+  prefix and `USD` suffix) never rendered. All three now emit named slots as **props** — a node prop
+  (`prefix={<>$</>}`, consumed as `{props.prefix}`) when unscoped, a function prop when the slot takes
+  args — matching the authored `.ink.tsx` source with no runtime machinery. Qwik's default slot still
+  projects through its native `<Slot/>`.
+- **React emitted the invalid lowercase `readonly` DOM prop** (a React warning); `REACT_ATTR_MAP` now
+  maps `readonly` → `readOnly`.
+- **Angular rendered `id="undefined"`.** Dynamic native-element attributes were property bindings, which
+  stringify a nullish value (`[id]="id()"` → `id="undefined"`). Non-property attributes now bind via
+  `[attr.name]="(expr) ?? null"`, which Angular omits when null; boolean/value-semantic and special
+  bindings (`value`, `disabled`, `readonly`, `style`, `innerHTML`, …) stay property bindings.

--- a/core/compiler/src/codegen/shared/expr-rewrite.test.ts
+++ b/core/compiler/src/codegen/shared/expr-rewrite.test.ts
@@ -279,6 +279,14 @@ describe("rewriteAttrName", () => {
     expect(rewriteAttrName("for", react)).toBe("htmlFor");
   });
 
+  it("react: readonly → readOnly", () => {
+    expect(rewriteAttrName("readonly", react)).toBe("readOnly");
+  });
+
+  it("html: readonly passes through", () => {
+    expect(rewriteAttrName("readonly", html)).toBe("readonly");
+  });
+
   it("react: unknown passes through", () => {
     expect(rewriteAttrName("id", react)).toBe("id");
   });

--- a/core/compiler/src/codegen/shared/expr-rewrite.test.ts
+++ b/core/compiler/src/codegen/shared/expr-rewrite.test.ts
@@ -253,6 +253,14 @@ describe("rewriteEventName", () => {
   it("lower: onMouseDown → onmousedown", () => {
     expect(rewriteEventName("onMouseDown", lower)).toBe("onmousedown");
   });
+
+  it("a name without the `on` prefix is used as-is", () => {
+    expect(rewriteEventName("Click", camel)).toBe("onClick");
+  });
+
+  it("lower: a component callback keeps its camelCase (isComponent=true)", () => {
+    expect(rewriteEventName("onValueChange", lower, true)).toBe("onValueChange");
+  });
 });
 
 describe("rewriteAttrName", () => {
@@ -289,5 +297,49 @@ describe("rewriteAttrName", () => {
 
   it("react: unknown passes through", () => {
     expect(rewriteAttrName("id", react)).toBe("id");
+  });
+
+  it("no casing rule: passes through unchanged", () => {
+    const none = { ...STRIP, jsxAttrCasing: undefined } as unknown as RewriteRules;
+    expect(rewriteAttrName("className", none)).toBe("className");
+  });
+});
+
+describe("rewriteExpr — additional expression forms", () => {
+  it("object literal: property, spread, and shorthand members", () => {
+    const result = rewriteExpr(mockExpr("({ a: count(), ...other, b })"), STRIP);
+    expect(result).toContain("a: count");
+    expect(result).toContain("...other");
+    expect(result).toContain("b");
+  });
+
+  it("array literal with a spread element", () => {
+    expect(rewriteExpr(mockExpr("[count(), ...items()]"), STRIP)).toBe("[count, ...items]");
+  });
+
+  it("non-null assertion", () => {
+    expect(rewriteExpr(mockExpr("count()!"), STRIP)).toBe("count!");
+  });
+
+  it("`as` assertion unwraps to the inner expression", () => {
+    expect(rewriteExpr(mockExpr("count() as number"), STRIP)).toBe("count");
+  });
+
+  it("if/else statement inside an arrow block", () => {
+    const result = rewriteExpr(
+      mockExpr("() => { if (ok()) { setCount(count()); } else { setCount(other()); } }"),
+      STRIP,
+    );
+    expect(result).toContain("if (ok)");
+    expect(result).toContain("else");
+    expect(result).toContain("setCount(count)");
+  });
+
+  it("for-of statement inside an arrow block", () => {
+    const result = rewriteExpr(
+      mockExpr("() => { for (const i of items()) { setCount(i); } }"),
+      STRIP,
+    );
+    expect(result).toContain("for (const i of items)");
   });
 });

--- a/core/compiler/src/codegen/shared/expr-rewrite.ts
+++ b/core/compiler/src/codegen/shared/expr-rewrite.ts
@@ -382,6 +382,7 @@ const HTML_ATTR_MAP: Record<string, string> = {
 const REACT_ATTR_MAP: Record<string, string> = {
   class: "className",
   for: "htmlFor",
+  readonly: "readOnly",
 };
 
 export function rewriteAttrName(name: string, rules: RewriteRules): string {

--- a/core/compiler/src/codegen/shared/has-slot.test.ts
+++ b/core/compiler/src/codegen/shared/has-slot.test.ts
@@ -13,7 +13,7 @@ describe("foldConstTest", () => {
     expect(foldConstTest("true")).toBe(true);
     expect(foldConstTest("false")).toBe(false);
     expect(foldConstTest("!true")).toBe(false);
-    expect(foldConstTest("props.renderPrefix != null")).toBeUndefined();
+    expect(foldConstTest("props.prefix != null")).toBeUndefined();
     expect(foldConstTest("count() > 0")).toBeUndefined();
   });
 });
@@ -22,9 +22,9 @@ describe("foldConstTest", () => {
 // and the negated check (on "suffix") that must stay correct thanks to parenthesization.
 const RUNTIME_PRESENCE = {
   react: {
-    prefix: "(props.renderPrefix != null)",
+    prefix: "(props.prefix != null)",
     default: "(props.children != null)",
-    negSuffix: "!(props.renderSuffix != null)",
+    negSuffix: "!(props.suffix != null)",
   },
   solid: {
     prefix: "(props.prefix != null)",
@@ -106,7 +106,7 @@ describe("hasSlot: a fallback survives when every branch folds away", () => {
 
   it("react: keeps the real runtime conditional (fix is Angular/Qwik-local)", async () => {
     const out = await compileTo("HasSlotFallback", "react");
-    expect(out).toContain("props.renderSuffix != null");
+    expect(out).toContain("props.suffix != null");
     // React renders `class` as `className`; both branches survive (runtime presence check).
     expect(out, "both branches survive on a runtime-presence target").toContain(
       'className="no-suffix"',

--- a/core/compiler/src/codegen/targets/angular/index.test.ts
+++ b/core/compiler/src/codegen/targets/angular/index.test.ts
@@ -29,6 +29,53 @@ function emitCode(comp: IRComponent): string {
   return emitFor(angular, comp);
 }
 
+describe("Angular nullish native-element attributes", () => {
+  it("binds a plain dynamic attr via [attr.name] with ?? null so a nullish value omits it", () => {
+    const el = createElement({
+      tag: "input",
+      attrs: [
+        { name: "id", value: createExpr({ expr: mockExpr("id()") }), binding: "normal", loc },
+      ],
+    });
+    const code = emitCode(makeComp("Field", el));
+    expect(code).toContain('[attr.id]="(id()) ?? null"');
+    expect(code).not.toContain('[id]="');
+  });
+
+  it("keeps boolean / value-semantic attrs as property bindings", () => {
+    const el = createElement({
+      tag: "input",
+      attrs: [
+        { name: "value", value: createExpr({ expr: mockExpr("value()") }), binding: "normal", loc },
+        {
+          name: "disabled",
+          value: createExpr({ expr: mockExpr("disabled()") }),
+          binding: "normal",
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(makeComp("Field", el));
+    expect(code).toContain('[value]="value()"');
+    expect(code).toContain('[disabled]="disabled()"');
+    expect(code).not.toContain("[attr.value]");
+    expect(code).not.toContain("[attr.disabled]");
+  });
+
+  it("leaves component @Input bindings untouched (only native elements change)", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("Card") as ts.Identifier,
+      resolved: { module: null, name: "Card" },
+      attrs: [
+        { name: "id", value: createExpr({ expr: mockExpr("id()") }), binding: "normal", loc },
+      ],
+    });
+    const code = emitCode(makeComp("Page", ci));
+    expect(code).toContain('[id]="id()"');
+    expect(code).not.toContain("[attr.id]");
+  });
+});
+
 describe("Angular codegen fixes", () => {
   describe("ComponentInstance attrs, events, slots", () => {
     it("renders attrs on component instances", () => {

--- a/core/compiler/src/codegen/targets/angular/index.test.ts
+++ b/core/compiler/src/codegen/targets/angular/index.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
 import { DYNAMIC_DEPS, type SymbolId } from "../../../ir/reactivity.ts";
-import type { IRComponent } from "../../../ir/render/nodes.ts";
+import type { IRComponent, IRNode } from "../../../ir/render/nodes.ts";
 import {
+  createAttribute,
   createComponentInstance,
   createElement,
   createExpr,
   createIf,
+  createStaticValue,
+  createSwitch,
   createText,
 } from "../../../ir/render/builders.ts";
 import {
@@ -390,5 +393,139 @@ describe("angular emit + print", () => {
     expect(code).not.toContain("Transition");
     expect(code).toContain("@if");
     expect(code).toMatchSnapshot();
+  });
+});
+
+describe("Angular additional branch coverage", () => {
+  it("Switch with a fallback emits a trailing @else", () => {
+    const sw = createSwitch({
+      cases: [{ test: createExpr({ expr: mockExpr("x()") }), body: createText({ value: "X" }) }],
+      fallback: createText({ value: "fallback" }),
+    });
+    const code = emitCode(makeComp("Sw", createElement({ tag: "div", children: [sw] })));
+    expect(code).toContain("@else {");
+    expect(code).toContain("fallback");
+  });
+
+  it("merges a class onto a component instance via [klass] under fallthrough", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("Card") as ts.Identifier,
+      resolved: { module: null, name: "Card" },
+      acceptsAttrFallthrough: true,
+      attrs: [
+        createAttribute({
+          name: "class",
+          value: createStaticValue({ value: "badge" }),
+          binding: "class",
+        }),
+      ],
+    });
+    const code = emitCode(makeComp("Page", ci));
+    expect(code).toContain("[klass]=");
+  });
+
+  it("emits a two-way model binding as a <prop>Change output", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("Field") as ts.Identifier,
+      resolved: { module: null, name: "Field" },
+      events: [
+        {
+          name: "update:value",
+          twoWayProp: "value",
+          handler: createExpr({ expr: mockExpr("(v) => set(v)") }),
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(makeComp("Page", ci));
+    expect(code).toContain("(valueChange)=");
+  });
+
+  it("self-closes a void element that has no attributes", () => {
+    const code = emitCode(makeComp("V", createElement({ tag: "br" })));
+    expect(code).toContain("<br />");
+  });
+
+  it("a fallthrough root element merges its own class and forwards klass when it has none", () => {
+    const withClass = emitCode(
+      makeComp(
+        "C",
+        createElement({
+          tag: "div",
+          acceptsAttrFallthrough: true,
+          attrs: [
+            createAttribute({
+              name: "class",
+              value: createStaticValue({ value: "x" }),
+              binding: "class",
+            }),
+          ],
+          children: [createText({ value: "y" })],
+        }),
+      ),
+    );
+    expect(withClass).toContain("[class]=");
+    const noClass = emitCode(
+      makeComp(
+        "C",
+        createElement({
+          tag: "div",
+          acceptsAttrFallthrough: true,
+          children: [createText({ value: "y" })],
+        }),
+      ),
+    );
+    expect(noClass).toContain('[class]="klass()"');
+  });
+
+  it("binds [klass] from a component-instance class even without fallthrough", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("Card") as ts.Identifier,
+      resolved: { module: null, name: "Card" },
+      attrs: [
+        createAttribute({
+          name: "class",
+          value: createStaticValue({ value: "badge" }),
+          binding: "class",
+        }),
+      ],
+    });
+    expect(emitCode(makeComp("Page", ci))).toContain("[klass]=");
+  });
+
+  it("For with an index binding tracks via $index", () => {
+    const forNode: IRNode = {
+      kind: "For",
+      each: createExpr({ expr: mockExpr("items()") }),
+      itemBinding: "item",
+      indexBinding: "i",
+      key: createExpr({ expr: mockExpr("item.id") }),
+      syntheticKey: true,
+      body: createText({ value: "row" }),
+      loc,
+    };
+    const code = emitCode(makeComp("List", createElement({ tag: "ul", children: [forNode] })));
+    expect(code).toContain("@for");
+    expect(code).toContain("$index");
+  });
+
+  it("a real @if branch followed by a statically-true branch emits @else", () => {
+    const ifNode = createIf({
+      branches: [
+        { test: createExpr({ expr: mockExpr("x()") }), body: createText({ value: "A" }) },
+        { test: createExpr({ expr: mockExpr("true") }), body: createText({ value: "B" }) },
+      ],
+    });
+    const code = emitCode(makeComp("If", createElement({ tag: "div", children: [ifNode] })));
+    expect(code).toContain("@if (x())");
+    expect(code).toContain("@else {");
+  });
+
+  it("an element with no attributes emits a bare tag", () => {
+    const code = emitCode(
+      makeComp("D", createElement({ tag: "div", children: [createText({ value: "hi" })] })),
+    );
+    expect(code).toContain("<div>");
+    expect(code).not.toContain("<div ");
   });
 });

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -134,6 +134,34 @@ const VOID_ELEMENTS = new Set([
   "wbr",
 ]);
 
+// Native-element bindings that must stay Angular *property* bindings (`[name]="…"`). For these, a
+// property binding already does the right thing when the value is nullish (`el.disabled = undefined`
+// → not disabled; `el.value = undefined` → empty; `[style]="undefined"` → no inline style), and an
+// *attribute* binding would be wrong: `[attr.disabled]="false"` renders `disabled="false"` (still
+// disabled), `[attr.value]` sets the initial attribute not the live value, and `[attr.style]`
+// bypasses Angular's dedicated style binding. Two groups: boolean/value-semantic props, and
+// property-only/special bindings (`style`, `innerHTML`, …). Every OTHER dynamic attribute is emitted
+// as `[attr.name]="(expr) ?? null"` so a nullish value omits it instead of stringifying to
+// `"undefined"`/`"null"` (a property binding like `[id]="id()"` cannot omit — `el.id = undefined`
+// reflects as `id="undefined"`).
+const KEEP_PROPERTY = new Set([
+  "value",
+  "checked",
+  "selected",
+  "disabled",
+  "readonly",
+  "required",
+  "multiple",
+  "hidden",
+  "indeterminate",
+  "open",
+  "muted",
+  "style",
+  "innerHTML",
+  "innerText",
+  "textContent",
+]);
+
 /**
  * The class expression for a fallthrough root: the node's own class plus the `klass` input a
  * parent forwards (see the `klass` synthesis in `emit`). Angular template expressions cannot call
@@ -167,7 +195,12 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
           return `[class]="${mergedClassExpr(ownClassExpr(a, rules), rules)}"`;
         }
         if (a.value.kind === "Static") return `${name}="${a.value.value}"`;
-        return `[${name}]="${rewriteExpr(a.value.expr, rules)}"`;
+        const expr = rewriteExpr(a.value.expr, rules);
+        // Boolean/value-semantic props stay property bindings; every other dynamic attribute binds
+        // via `[attr.name]` with `?? null` so a nullish value omits it (not `id="undefined"`).
+        return KEEP_PROPERTY.has(name)
+          ? `[${name}]="${expr}"`
+          : `[attr.${name}]="(${expr}) ?? null"`;
       });
       if (fallthrough && !classBound) {
         attrParts.push(`[class]="${mergedClassExpr(undefined, rules)}"`);

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -144,6 +144,10 @@ const VOID_ELEMENTS = new Set([
 // as `[attr.name]="(expr) ?? null"` so a nullish value omits it instead of stringifying to
 // `"undefined"`/`"null"` (a property binding like `[id]="id()"` cannot omit — `el.id = undefined`
 // reflects as `id="undefined"`).
+//
+// CAVEAT: also add any presence-only boolean attribute that is NOT a reflected DOM property (e.g.
+// `autofocus`) if it's ever bound dynamically — `[attr.autofocus]="false ?? null"` renders
+// `autofocus="false"`, which the browser still treats as present. None are bound today.
 const KEEP_PROPERTY = new Set([
   "value",
   "checked",

--- a/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -170,7 +170,7 @@ const { header, children, ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
   <header>
-    <Slot name="header" />
+    {props.header}
   </header>
   <main>
     <Slot />
@@ -287,7 +287,7 @@ export const HasSlot = component$((props) =>
 const { children, prefix, suffix, ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
-  {(<><span class="prefix"><Slot name="prefix" /></span></>)}
+  {(<><span class="prefix">{props.prefix}</span></>)}
   {(<><main><Slot /></main></>)}
   {null}
 </div>
@@ -502,7 +502,7 @@ const expanded = useSignal(true)
 const { header, children, ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
-  <Slot name="header" />
+  {props.header}
   {expanded.value ? (<><Slot /></>) : null}
 </div>
 )
@@ -518,13 +518,13 @@ const { header, children, footer, ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
   <header>
-    <Slot name="header" />
+    {props.header}
   </header>
   <main>
     <Slot />
   </main>
   <footer>
-    <Slot name="footer" />
+    {props.footer}
   </footer>
 </div>
 )
@@ -540,7 +540,7 @@ const items = useSignal([{ id: 1, label: "One" }, { id: 2, label: "Two" }])
 const { item, ...__attrs } = props
 return (
 <ul {...__attrs} class={props.class}>
-  {items.value.map((item, index) => (<><li><>{index}:{item.label}</></li></>))}
+  {items.value.map((item, index) => (<><li>{props.item?.(item, index) ?? (<><>{index}:{item.label}</></>)}</li></>))}
 </ul>
 )
 });
@@ -579,11 +579,7 @@ return (
     </Slot>
   </main>
   <footer>
-    <Slot name="actions">
-      <span>
-        Action area
-      </span>
-    </Slot>
+    {props.actions ?? (<><span>Action area</span></>)}
   </footer>
 </div>
 )
@@ -598,11 +594,7 @@ export const SlotWithFallback = component$((props) =>
 const { header, children, ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
-  <Slot name="header">
-    <h1>
-      Default Header
-    </h1>
-  </Slot>
+  {props.header ?? (<><h1>Default Header</h1></>)}
   <Slot>
     Default body content
   </Slot>

--- a/core/compiler/src/codegen/targets/qwik/__tests__/slots.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/slots.test.ts
@@ -1,20 +1,20 @@
 // Real-world codegen assertions for the "slots" feature area (qwik): author `.ink.tsx` with
-// `<Slot />` / `defineSlot()` → compile → assert the ACTUAL generated Qwik code. Qwik projects
-// through its native <Slot/> (props.children is never populated); fallback content becomes the
-// <Slot>'s children.
+// `<Slot />` / `defineSlot()` → compile → assert the ACTUAL generated Qwik code. The default slot
+// projects through Qwik's native <Slot/> (props.children is never populated); named slots are props
+// (a node prop, or a function prop when scoped), with fallback via `?? <fallback>`.
 
 import { describe, it, expect } from "vitest";
 import { compileTo } from "../../../../testing/codegen.ts";
 
 // --- SlotWithDefault: declared `slots: { default, actions }` + default slot fallbacks ---------
 describe("SlotWithDefault: declared default slot + named actions slot", () => {
-  it("Qwik: default slot → <Slot> with fallback; named actions → <Slot name='actions'>", async () => {
-    // Qwik projects through its native <Slot/> (props.children is never populated). The authored
-    // fallback becomes the <Slot>'s children, and `Slot` is added to the @qwik.dev/core import.
+  it("Qwik: default slot → <Slot> with fallback; named actions → {props.actions}", async () => {
+    // The default slot projects through Qwik's native <Slot/> (props.children is never populated),
+    // and `Slot` is added to the @qwik.dev/core import. The named `actions` slot is a node prop.
     const out = await compileTo("SlotWithDefault", "qwik");
     expect(out).toContain("<Slot>");
     expect(out).toContain("Default content");
-    expect(out).toContain('<Slot name="actions">');
+    expect(out).toContain("{props.actions");
     expect(out).toContain("Action area");
     expect(out).toContain('Slot } from "@qwik.dev/core"');
     expect(out).not.toContain("props.children");

--- a/core/compiler/src/codegen/targets/qwik/index.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.test.ts
@@ -115,6 +115,27 @@ describe("Qwik codegen fixes", () => {
       expect(code).not.toContain("icon={{");
     });
 
+    it("re-projects named slot variants (scoped, fallback) via the bare read", () => {
+      const reproject = (init: Parameters<typeof createSlotPlaceholder>[0]) =>
+        emitCode(
+          makeComp(
+            "Parent",
+            createComponentInstance({
+              reference: mockExpr("IChild") as ts.Identifier,
+              resolved: { module: null, name: "IChild" },
+              slots: [{ name: "icon", body: createSlotPlaceholder(init), scopedParams: [], loc }],
+            }),
+          ),
+        );
+      const args = [createExpr({ expr: mockExpr("row") })];
+      const fb = createElement({ tag: "span", children: [createText({ value: "·" })] });
+      expect(reproject({ name: "icon", fallback: fb })).toContain("icon={props.icon ??");
+      expect(reproject({ name: "icon", scopedArgs: args })).toContain("icon={props.icon?.(row)}");
+      expect(reproject({ name: "icon", scopedArgs: args, fallback: fb })).toContain(
+        "icon={props.icon?.(row) ??",
+      );
+    });
+
     it("self-closes when no slots", () => {
       const ci = createComponentInstance({
         reference: mockExpr("Icon") as ts.Identifier,

--- a/core/compiler/src/codegen/targets/qwik/index.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.test.ts
@@ -7,6 +7,7 @@ import {
   createElement,
   createExpr,
   createFragment,
+  createSlotPlaceholder,
   createSwitch,
   createText,
 } from "../../../ir/render/builders.ts";
@@ -99,6 +100,19 @@ describe("Qwik codegen fixes", () => {
       // Matches the consumption side: `{props.header}`.
       expect(code).toContain("header={<span>title</span>}");
       expect(code).not.toContain("Card.header");
+    });
+
+    it("inlines a re-projected slot fill to the bare prop read (no double braces)", () => {
+      const ci = createComponentInstance({
+        reference: mockExpr("IButton") as ts.Identifier,
+        resolved: { module: null, name: "IButton" },
+        slots: [
+          { name: "icon", body: createSlotPlaceholder({ name: "icon" }), scopedParams: [], loc },
+        ],
+      });
+      const code = emitCode(makeComp("Parent", ci));
+      expect(code).toContain("icon={props.icon}");
+      expect(code).not.toContain("icon={{");
     });
 
     it("self-closes when no slots", () => {

--- a/core/compiler/src/codegen/targets/qwik/index.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.test.ts
@@ -81,14 +81,14 @@ describe("Qwik codegen fixes", () => {
       expect(code).not.toContain("/>");
     });
 
-    it("renders named slots as sub-elements", () => {
+    it("renders an unscoped named slot fill as a node prop, not a <Tag.name> child", () => {
       const ci = createComponentInstance({
         reference: mockExpr("Card") as ts.Identifier,
         resolved: { module: null, name: "Card" },
         slots: [
           {
             name: "header",
-            body: createText({ value: "title" }),
+            body: createElement({ tag: "span", children: [createText({ value: "title" })] }),
             scopedParams: [],
             loc,
           },
@@ -96,8 +96,9 @@ describe("Qwik codegen fixes", () => {
       });
       const comp = makeComp("Parent", ci);
       const code = emitCode(comp);
-      expect(code).toContain("Card.header");
-      expect(code).toContain("title");
+      // Matches the consumption side: `{props.header}`.
+      expect(code).toContain("header={<span>title</span>}");
+      expect(code).not.toContain("Card.header");
     });
 
     it("self-closes when no slots", () => {

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -128,6 +128,22 @@ function jsxAttrs(
   return out;
 }
 
+// The bare prop read for a named slot (no surrounding `{…}`): a node prop when unscoped, a function
+// call when scoped, with the authored fallback via `?? <fallback>`. Used both as a JSX expression
+// (`{namedSlotRead(…)}`) and as an attr-value fill, where the `{…}` comes from `name={…}` instead.
+function namedSlotRead(
+  node: Extract<IRNode, { kind: "SlotPlaceholder" }>,
+  rules: RewriteRules,
+): string {
+  const argsStr =
+    node.scopedArgs.length > 0
+      ? node.scopedArgs.map((a) => rewriteExpr(a.expr, rules)).join(", ")
+      : "";
+  const read = argsStr ? `props.${node.name}?.(${argsStr})` : `props.${node.name}`;
+  const fallback = node.fallback ? ` ?? (<>${emitNodeInline(node.fallback, rules)}</>)` : "";
+  return `${read}${fallback}`;
+}
+
 function emitNode(node: IRNode, rules: RewriteRules): Code {
   switch (node.kind) {
     case "Element": {
@@ -146,10 +162,16 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
         if (s.name === "default") {
           children.push(emitNode(s.body, rules));
         } else {
-          const value =
-            s.scopedParams.length > 0
-              ? `(${s.scopedParams.join(", ")}) => (${emitNodeInline(s.body, rules)})`
+          // A re-projected slot (`prefix={<Slot name="x"/>}`) inlines to the bare `props.x` read; any
+          // other body (an element/fragment) inlines as JSX. Either is a bare attr value — the `{…}`
+          // comes from `name={…}` — so a named-slot body must NOT go through `emitNodeInline` (which
+          // would brace it and double-wrap to `prefix={{props.x}}`).
+          const body =
+            s.body.kind === "SlotPlaceholder" && s.body.name !== "default"
+              ? namedSlotRead(s.body, rules)
               : emitNodeInline(s.body, rules);
+          const value =
+            s.scopedParams.length > 0 ? `(${s.scopedParams.join(", ")}) => (${body})` : body;
           attrs.push(
             cJsxAttr({ name: s.name, value: { kind: "expr", expr: cExpr({ text: value }) } }),
           );
@@ -204,13 +226,7 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
       // projects through Qwik's native `<Slot/>`: Qwik never populates `props.children`, so the old
       // `{props.children ?? …}` lowering would silently drop every projected child.
       if (node.name !== "default") {
-        const argsStr =
-          node.scopedArgs.length > 0
-            ? node.scopedArgs.map((a) => rewriteExpr(a.expr, rules)).join(", ")
-            : "";
-        const read = argsStr ? `props.${node.name}?.(${argsStr})` : `props.${node.name}`;
-        const fallback = node.fallback ? ` ?? (<>${emitNodeInline(node.fallback, rules)}</>)` : "";
-        return cExpr({ text: `{${read}${fallback}}` });
+        return cExpr({ text: `{${namedSlotRead(node, rules)}}` });
       }
       if (node.scopedArgs.length > 0) {
         // Qwik's `<Slot/>` can't receive scoped args. Best-effort: render the authored fallback

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -138,16 +138,23 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
     case "ComponentInstance": {
       const tag = node.resolved?.name ?? node.reference.getText();
       const attrs = jsxAttrs(node, rules);
-      const children = node.slots.map((s) =>
-        s.name === "default"
-          ? emitNode(s.body, rules)
-          : cJsxElement({
-              tag: `${tag}.${s.name}`,
-              attrs: [],
-              children: [emitNode(s.body, rules)],
-              selfClose: false,
-            }),
-      );
+      // The default slot projects through `<Slot/>` (children); a named slot is consumed as a prop
+      // (see the `SlotPlaceholder` case) — a node prop (`prefix={<>$</>}`) when unscoped, a function
+      // prop when it takes args. A `<Tag.name>` child would never reach the consumer.
+      const children: Code[] = [];
+      for (const s of node.slots) {
+        if (s.name === "default") {
+          children.push(emitNode(s.body, rules));
+        } else {
+          const value =
+            s.scopedParams.length > 0
+              ? `(${s.scopedParams.join(", ")}) => (${emitNodeInline(s.body, rules)})`
+              : emitNodeInline(s.body, rules);
+          attrs.push(
+            cJsxAttr({ name: s.name, value: { kind: "expr", expr: cExpr({ text: value }) } }),
+          );
+        }
+      }
       return cJsxElement({ tag, attrs, children, selfClose: children.length === 0 });
     }
     case "Text":
@@ -192,25 +199,30 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
       });
     }
     case "SlotPlaceholder": {
-      // Qwik projects content through its native `<Slot/>` component — NOT `props.children`, which
-      // Qwik never populates (so the old `{props.children ?? …}` lowering silently dropped every
-      // projected child). Authored fallback becomes the `<Slot>`'s children, shown when nothing is
-      // projected; named slots use `<Slot name="x"/>`.
-      const slotAttrs =
-        node.name === "default"
-          ? []
-          : [cJsxAttr({ name: "name", value: { kind: "static", text: node.name } })];
+      // A named slot is consumed as a prop — a node prop (`{props.prefix}`) when unscoped, a function
+      // prop (`{props.prefix?.(args)}`) when scoped — mirroring the fill. The default slot still
+      // projects through Qwik's native `<Slot/>`: Qwik never populates `props.children`, so the old
+      // `{props.children ?? …}` lowering would silently drop every projected child.
+      if (node.name !== "default") {
+        const argsStr =
+          node.scopedArgs.length > 0
+            ? node.scopedArgs.map((a) => rewriteExpr(a.expr, rules)).join(", ")
+            : "";
+        const read = argsStr ? `props.${node.name}?.(${argsStr})` : `props.${node.name}`;
+        const fallback = node.fallback ? ` ?? (<>${emitNodeInline(node.fallback, rules)}</>)` : "";
+        return cExpr({ text: `{${read}${fallback}}` });
+      }
       if (node.scopedArgs.length > 0) {
         // Qwik's `<Slot/>` can't receive scoped args. Best-effort: render the authored fallback
         // (default content, with its scope vars in scope); otherwise project without the args.
         return node.fallback
           ? emitNode(node.fallback, rules)
-          : cJsxElement({ tag: "Slot", attrs: slotAttrs, children: [], selfClose: true });
+          : cJsxElement({ tag: "Slot", attrs: [], children: [], selfClose: true });
       }
       const fallbackChildren = node.fallback ? [emitNode(node.fallback, rules)] : [];
       return cJsxElement({
         tag: "Slot",
-        attrs: slotAttrs,
+        attrs: [],
         children: fallbackChildren,
         selfClose: fallbackChildren.length === 0,
       });
@@ -281,6 +293,8 @@ function emitNodeInline(node: IRNode, rules: RewriteRules): string {
 function emitsQwikSlot(node: IRNode): boolean {
   switch (node.kind) {
     case "SlotPlaceholder":
+      // Named slots are props now, not `<Slot>`; only the default slot projects through `<Slot/>`.
+      if (node.name !== "default") return node.fallback ? emitsQwikSlot(node.fallback) : false;
       if (node.scopedArgs.length > 0 && node.fallback) return emitsQwikSlot(node.fallback);
       return true;
     case "Element":

--- a/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -162,13 +162,13 @@ return (
 `;
 
 exports[`react full output snapshots > DefineSlotBasic 1`] = `
-"export function DefineSlotBasic(props: { renderHeader?: (...args: any[]) => React.ReactNode; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+"export function DefineSlotBasic(props: { header?: React.ReactNode; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { renderHeader, children, ...__attrs } = props
+const { header, children, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
   <header>
-    {props.renderHeader?.()}
+    {props.header}
   </header>
   <main>
     {props.children}
@@ -278,14 +278,14 @@ return (
 `;
 
 exports[`react full output snapshots > HasSlot 1`] = `
-"export function HasSlot(props: { children?: React.ReactNode; renderPrefix?: (...args: any[]) => React.ReactNode; renderSuffix?: (...args: any[]) => React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+"export function HasSlot(props: { children?: React.ReactNode; prefix?: React.ReactNode; suffix?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { children, renderPrefix, renderSuffix, ...__attrs } = props
+const { children, prefix, suffix, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
-  {(props.renderPrefix != null) ? <span className="prefix">{props.renderPrefix?.()}</span> : null}
+  {(props.prefix != null) ? <span className="prefix">{props.prefix}</span> : null}
   {(props.children != null) ? <main>{props.children}</main> : null}
-  {!(props.renderSuffix != null) ? <span className="no-suffix">none</span> : null}
+  {!(props.suffix != null) ? <span className="no-suffix">none</span> : null}
 </div>
 )
 }
@@ -293,12 +293,12 @@ return (
 `;
 
 exports[`react full output snapshots > HasSlotFallback 1`] = `
-"export function HasSlotFallback(props: { renderSuffix?: (...args: any[]) => React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+"export function HasSlotFallback(props: { suffix?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { renderSuffix, ...__attrs } = props
+const { suffix, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
-  {!(props.renderSuffix != null) ? <span className="no-suffix">absent</span> : <span className="has-suffix">present</span>}
+  {!(props.suffix != null) ? <span className="no-suffix">absent</span> : <span className="has-suffix">present</span>}
 </div>
 )
 }
@@ -485,13 +485,13 @@ return (
 
 exports[`react full output snapshots > SlotInConditional 1`] = `
 "import { useState } from "react";
-export function SlotInConditional(props: { renderHeader?: (...args: any[]) => React.ReactNode; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+export function SlotInConditional(props: { header?: React.ReactNode; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
 const [expanded, setExpanded] = useState(true)
-const { renderHeader, children, ...__attrs } = props
+const { header, children, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
-  {props.renderHeader?.()}
+  {props.header}
   {expanded ? props.children : null}
 </div>
 )
@@ -500,19 +500,19 @@ return (
 `;
 
 exports[`react full output snapshots > SlotNamed 1`] = `
-"export function SlotNamed(props: { renderHeader?: (...args: any[]) => React.ReactNode; children?: React.ReactNode; renderFooter?: (...args: any[]) => React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+"export function SlotNamed(props: { header?: React.ReactNode; children?: React.ReactNode; footer?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { renderHeader, children, renderFooter, ...__attrs } = props
+const { header, children, footer, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
   <header>
-    {props.renderHeader?.()}
+    {props.header}
   </header>
   <main>
     {props.children}
   </main>
   <footer>
-    {props.renderFooter?.()}
+    {props.footer}
   </footer>
 </div>
 )
@@ -522,13 +522,13 @@ return (
 
 exports[`react full output snapshots > SlotScoped 1`] = `
 "import { useState, Fragment } from "react";
-export function SlotScoped(props: { renderItem?: (...args: any[]) => React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+export function SlotScoped(props: { item?: (...args: any[]) => React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
 const [items, setItems] = useState([{ id: 1, label: "One" }, { id: 2, label: "Two" }])
-const { renderItem, ...__attrs } = props
+const { item, ...__attrs } = props
 return (
 <ul {...__attrs} className={props.className}>
-  {items.map((item, index) => (<Fragment key={item.id}><li>{props.renderItem?.(item, index) ?? <>{index}:{item.label}</>}</li></Fragment>))}
+  {items.map((item, index) => (<Fragment key={item.id}><li>{props.item?.(item, index) ?? <>{index}:{item.label}</>}</li></Fragment>))}
 </ul>
 )
 }
@@ -551,16 +551,16 @@ return (
 `;
 
 exports[`react full output snapshots > SlotWithDefault 1`] = `
-"export function SlotWithDefault(props: { children?: React.ReactNode; renderActions?: (...args: any[]) => React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+"export function SlotWithDefault(props: { children?: React.ReactNode; actions?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { children, renderActions, ...__attrs } = props
+const { children, actions, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
   <main>
     {props.children ?? <p>Default content</p>}
   </main>
   <footer>
-    {props.renderActions?.() ?? <span>Action area</span>}
+    {props.actions ?? <span>Action area</span>}
   </footer>
 </div>
 )
@@ -569,12 +569,12 @@ return (
 `;
 
 exports[`react full output snapshots > SlotWithFallback 1`] = `
-"export function SlotWithFallback(props: { renderHeader?: (...args: any[]) => React.ReactNode; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+"export function SlotWithFallback(props: { header?: React.ReactNode; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { renderHeader, children, ...__attrs } = props
+const { header, children, ...__attrs } = props
 return (
 <div {...__attrs} className={props.className}>
-  {props.renderHeader?.() ?? <h1>Default Header</h1>}
+  {props.header ?? <h1>Default Header</h1>}
   {props.children ?? "Default body content"}
 </div>
 )

--- a/core/compiler/src/codegen/targets/react/__tests__/named-slot-fill.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/named-slot-fill.test.ts
@@ -1,26 +1,26 @@
-// React: parity guard for JSX-valued named-slot fills — the fill stays a JSX child
-// (`<IButton.icon><span>★</span></IButton.icon>`), unaffected by the template-target fix (UXF-12, #459).
+// React: a JSX-valued named-slot fill compiles to a node prop (`icon={<span>★</span>}`) — the form
+// the React target consumes (`{props.icon}`), not a `<IButton.icon>` child that never reaches the
+// consumer. The template-target decomposition landed in UXF-12 (#459); the JSX targets
+// (React/Solid/Qwik) were brought in line with their own consumption convention afterwards.
 import { describe, it, expect } from "vitest";
 import { compileToFiles } from "../../../../testing/codegen.ts";
 
-// NamedSlotFill emits a child (IButton) and the parent that fills the named slot; assert the parent.
+// NamedSlotFill emits a child (IButton) and the parent that fills its named slot; assert the parent.
 async function parentOutput(): Promise<string> {
   const files = await compileToFiles("NamedSlotFill", "react");
-  return (
-    files.find(
-      (f) =>
-        f.includes("template #icon") ||
-        f.includes("IButton.icon") ||
-        f.includes("snippet icon") ||
-        f.includes('slot="icon"'),
-    ) ?? files[files.length - 1]!
-  );
+  return files.find((f) => f.includes("icon={")) ?? files[files.length - 1]!;
 }
 
 describe("UXF-12: JSX-valued named-slot fills", () => {
-  it("named slot fill stays a JSX child (regression guard)", async () => {
+  it("compiles a named slot fill to a node prop", async () => {
     const out = await parentOutput();
-    expect(out).toContain("<IButton.icon>");
-    expect(out).toContain("<span>");
+    expect(out).toContain("icon={<span>★</span>}");
+    expect(out).not.toContain("<IButton.icon>");
+    expect(out).not.toContain("renderIcon");
+  });
+
+  it("re-projects a parent slot through the node prop", async () => {
+    const out = await parentOutput();
+    expect(out).toContain("icon={props.icon}");
   });
 });

--- a/core/compiler/src/codegen/targets/react/__tests__/scoped-slots.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/scoped-slots.test.ts
@@ -31,12 +31,12 @@ describe("ScopedSlot: For render-prop child inlined per target", () => {
 // Vue/Svelte bind named slot props, Angular/Astro drop them.
 // ---------------------------------------------------------------------------
 describe("SlotScoped: named scoped slot with args={[item, index]}", () => {
-  it("React: named slot → optional render prop `renderItem`, called with (item, index)", async () => {
+  it("React: named scoped slot → optional function prop `item`, called with (item, index)", async () => {
     const out = await compileTo("SlotScoped", "react");
-    expect(out).toContain("renderItem?: (...args: any[]) => React.ReactNode");
-    expect(out).toContain("const { renderItem, ...__attrs } = props");
-    // render prop is invoked with the scope args, falling back to the authored content
-    expect(out).toContain("{props.renderItem?.(item, index) ?? <>{index}:{item.label}</>}");
+    expect(out).toContain("item?: (...args: any[]) => React.ReactNode");
+    expect(out).toContain("const { item, ...__attrs } = props");
+    // a scoped slot is a function prop, invoked with the scope args, falling back to authored content
+    expect(out).toContain("{props.item?.(item, index) ?? <>{index}:{item.label}</>}");
   });
 });
 

--- a/core/compiler/src/codegen/targets/react/__tests__/slots.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/slots.test.ts
@@ -1,6 +1,7 @@
 // Real-world codegen assertions for the "slots" feature area (React target): author `.ink.tsx`
 // with `<Slot />` / `defineSlot()` → compile → assert the ACTUAL generated React code. Focus: the
-// default slot (→ `children`), named slots (→ render props), and slot fallback content.
+// default slot (→ `children`), named slots (→ node props, or function props when scoped), and slot
+// fallback content.
 
 import { describe, it, expect } from "vitest";
 import { compileTo } from "../../../../testing/codegen.ts";
@@ -16,28 +17,28 @@ describe("SlotBasic: default slot", () => {
 
 // --- SlotNamed: header (named) + default + footer (named) ------------------------------------
 describe("SlotNamed: named slots alongside the default", () => {
-  it("React: named slots become render props; default stays children", async () => {
+  it("React: named slots become node props; default stays children", async () => {
     const out = await compileTo("SlotNamed", "react");
-    expect(out).toContain("{props.renderHeader?.()}");
+    expect(out).toContain("{props.header}");
     expect(out).toContain("{props.children}");
-    expect(out).toContain("{props.renderFooter?.()}");
+    expect(out).toContain("{props.footer}");
   });
 });
 
 // --- SlotWithFallback: <Slot name="header"><h1/></Slot> + <Slot>text</Slot> ------------------
 describe("SlotWithFallback: slot fallback content", () => {
-  it("React: fallback emitted via ?? after the render prop / children", async () => {
+  it("React: fallback emitted via ?? after the node prop / children", async () => {
     const out = await compileTo("SlotWithFallback", "react");
-    expect(out).toContain("{props.renderHeader?.() ?? <h1>Default Header</h1>}");
+    expect(out).toContain("{props.header ?? <h1>Default Header</h1>}");
     expect(out).toContain('{props.children ?? "Default body content"}');
   });
 });
 
 // --- DefineSlotBasic: defineSlot("header") + defineSlot() rendered via {expr} -----------------
 describe("DefineSlotBasic: defineSlot() bindings", () => {
-  it("React: defineSlot('header') → renderHeader prop; defineSlot() → children", async () => {
+  it("React: defineSlot('header') → header node prop; defineSlot() → children", async () => {
     const out = await compileTo("DefineSlotBasic", "react");
-    expect(out).toContain("{props.renderHeader?.()}");
+    expect(out).toContain("{props.header}");
     expect(out).toContain("{props.children}");
   });
 });
@@ -46,7 +47,7 @@ describe("DefineSlotBasic: defineSlot() bindings", () => {
 describe("SlotInConditional: default slot inside a Show/conditional", () => {
   it("React: header slot + ternary-gated default slot", async () => {
     const out = await compileTo("SlotInConditional", "react");
-    expect(out).toContain("{props.renderHeader?.()}");
+    expect(out).toContain("{props.header}");
     expect(out).toContain("{expanded ? props.children : null}");
   });
 });

--- a/core/compiler/src/codegen/targets/react/index.test.ts
+++ b/core/compiler/src/codegen/targets/react/index.test.ts
@@ -6,6 +6,7 @@ import { type SymbolId } from "../../../ir/reactivity.ts";
 import type { IRNode } from "../../../ir/render/nodes.ts";
 import {
   createAttribute,
+  createComponentInstance,
   createElement,
   createExpr,
   createSlotPlaceholder,
@@ -13,6 +14,7 @@ import {
   createSwitch,
   createText,
 } from "../../../ir/render/builders.ts";
+import * as ts from "typescript";
 import { cRaw } from "../../code-ir/builders.ts";
 import {
   counterRender,
@@ -290,6 +292,61 @@ describe("react emit + print", () => {
   it("emits no transition helper when there is no transition", () => {
     const code = emitCode(react, richComp("Plain", createElement({ tag: "div" })));
     expect(code).not.toContain("__InkTransition");
+  });
+});
+
+describe("react ComponentInstance slot fills", () => {
+  it("emits an unscoped named slot fill as a node prop, not a <Tag.name> child", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("IInput") as ts.Identifier,
+      resolved: { module: null, name: "IInput" },
+      slots: [
+        {
+          name: "prefix",
+          body: createElement({ tag: "span", children: [createText({ value: "$" })] }),
+          scopedParams: [],
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(react, makeComp("Parent", ci));
+    // Matches the consumption side: `{props.prefix}` gated by `props.prefix != null`.
+    expect(code).toContain("prefix={<span>$</span>}");
+    expect(code).not.toContain("IInput.prefix");
+    expect(code).not.toContain("renderPrefix");
+    // No default slot → component self-closes.
+    expect(code).toContain("/>");
+  });
+
+  it("emits a scoped named slot fill as a function prop, threading scopedParams", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("IList") as ts.Identifier,
+      resolved: { module: null, name: "IList" },
+      slots: [
+        {
+          name: "item",
+          body: createElement({ tag: "span", children: [createText({ value: "row" })] }),
+          scopedParams: ["item"],
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(react, makeComp("Parent", ci));
+    expect(code).toContain("item={(item) => (<span>row</span>)}");
+  });
+
+  it("keeps the default slot as children", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("ICard") as ts.Identifier,
+      resolved: { module: null, name: "ICard" },
+      slots: [
+        { name: "default", body: createText({ value: "card content" }), scopedParams: [], loc },
+      ],
+    });
+    const code = emitCode(react, makeComp("Parent", ci));
+    expect(code).toContain("card content");
+    expect(code).not.toContain("renderDefault");
+    expect(code).not.toContain("/>");
   });
 });
 

--- a/core/compiler/src/codegen/targets/react/index.test.ts
+++ b/core/compiler/src/codegen/targets/react/index.test.ts
@@ -348,6 +348,43 @@ describe("react ComponentInstance slot fills", () => {
     expect(code).not.toContain("renderDefault");
     expect(code).not.toContain("/>");
   });
+
+  // A fill whose body is itself a <Slot/> (re-projection) inlines the slot read; cover every variant
+  // of that bare read (scoped/unscoped × named/default × with/without fallback).
+  const reproject = (init: Parameters<typeof createSlotPlaceholder>[0]) =>
+    emitCode(
+      react,
+      makeComp(
+        "Parent",
+        createComponentInstance({
+          reference: mockExpr("IChild") as ts.Identifier,
+          resolved: { module: null, name: "IChild" },
+          slots: [{ name: "icon", body: createSlotPlaceholder(init), scopedParams: [], loc }],
+        }),
+      ),
+    );
+
+  it("re-projects a named slot with fallback as `props.x ?? fallback`", () => {
+    expect(reproject({ name: "icon", fallback: createText({ value: "·" }) })).toContain(
+      'icon={props.icon ?? "·"}',
+    );
+  });
+
+  it("re-projects a scoped named slot as `props.x?.(args)` (with and without fallback)", () => {
+    const args = [createExpr({ expr: mockExpr("row") })];
+    expect(reproject({ name: "icon", scopedArgs: args })).toContain("icon={props.icon?.(row)}");
+    expect(
+      reproject({ name: "icon", scopedArgs: args, fallback: createText({ value: "·" }) }),
+    ).toContain('icon={props.icon?.(row) ?? "·"}');
+  });
+
+  it("re-projects the default slot as `props.children` / `renderDefault?.(args)`", () => {
+    expect(reproject({ fallback: createText({ value: "·" }) })).toContain(
+      'icon={props.children ?? "·"}',
+    );
+    const args = [createExpr({ expr: mockExpr("row") })];
+    expect(reproject({ scopedArgs: args })).toContain("icon={props.renderDefault?.(row)}");
+  });
 });
 
 // Merged from the former react/fallthrough.test.ts.

--- a/core/compiler/src/codegen/targets/react/index.ts
+++ b/core/compiler/src/codegen/targets/react/index.ts
@@ -43,10 +43,9 @@ const REWRITES: RewriteRules = {
     props: { strip: false },
     slots: { strip: true, rename: { default: "children" } },
   },
-  // A named slot is a `renderX` prop; the default slot is `children`. Filled iff non-null.
+  // A named slot is a plain node/function prop (default → `children`); filled iff non-null.
   // Parenthesized so it composes safely under `!`, `&&`, etc.
-  hasSlotCheck: (name) =>
-    name === "default" ? "(props.children != null)" : `(props.render${capitalize(name)} != null)`,
+  hasSlotCheck: (name) => `(props.${name === "default" ? "children" : name} != null)`,
 };
 
 /** Capitalize the first character (for deriving `useState` setter names: `data` → `setData`). */
@@ -68,7 +67,7 @@ function fallthroughRestBindings(component: IRComponent, rules: RewriteRules): s
     if (slot.name === "default") {
       names.add(slot.isScoped ? "renderDefault" : "children");
     } else {
-      names.add(`render${slot.name.charAt(0).toUpperCase()}${slot.name.slice(1)}`);
+      names.add(slot.name);
     }
   }
   for (const p of component.props) {
@@ -194,17 +193,23 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
     case "ComponentInstance": {
       const tag = node.resolved?.name ?? node.reference.getText();
       const attrs = jsxAttrs(node, rules);
-      const children = node.slots.map((s) =>
-        s.name === "default"
-          ? emitNode(s.body, rules)
-          : cJsxElement({
-              tag: `${tag}.${s.name}`,
-              attrs: [],
-              children: [emitNode(s.body, rules)],
-              selfClose: false,
-              span: s.loc,
-            }),
-      );
+      // The default slot is `children`; a named slot is consumed as a prop (see the `SlotPlaceholder`
+      // case) — a node prop (`prefix={<>$</>}`) when unscoped, a function prop (`item={(row) => …}`)
+      // when it takes args. A `<Tag.name>` child would never reach the consumer.
+      const children: Code[] = [];
+      for (const s of node.slots) {
+        if (s.name === "default") {
+          children.push(emitNode(s.body, rules));
+        } else {
+          const value =
+            s.scopedParams.length > 0
+              ? `(${s.scopedParams.join(", ")}) => (${inlineNode(s.body, rules)})`
+              : inlineNode(s.body, rules);
+          attrs.push(
+            cJsxAttr({ name: s.name, value: { kind: "expr", expr: cExpr({ text: value }) } }),
+          );
+        }
+      }
       return cJsxElement({ tag, attrs, children, selfClose: children.length === 0, span });
     }
     case "Text":
@@ -253,13 +258,18 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
           ? cExpr({ text: `{props.children ?? ${inlineNode(node.fallback, rules)}}`, span })
           : cExpr({ text: "{props.children}", span });
       }
-      const prop = `render${node.name.charAt(0).toUpperCase()}${node.name.slice(1)}`;
+      // A named slot is a node prop (unscoped) or a function prop (scoped), mirroring the fill.
+      if (node.scopedArgs.length > 0) {
+        return node.fallback
+          ? cExpr({
+              text: `{props.${node.name}?.(${argsStr}) ?? ${inlineNode(node.fallback, rules)}}`,
+              span,
+            })
+          : cExpr({ text: `{props.${node.name}?.(${argsStr})}`, span });
+      }
       return node.fallback
-        ? cExpr({
-            text: `{props.${prop}?.(${argsStr}) ?? ${inlineNode(node.fallback, rules)}}`,
-            span,
-          })
-        : cExpr({ text: `{props.${prop}?.(${argsStr})}`, span });
+        ? cExpr({ text: `{props.${node.name} ?? ${inlineNode(node.fallback, rules)}}`, span })
+        : cExpr({ text: `{props.${node.name}}`, span });
     }
     case "Transition": {
       const attrs = [cJsxAttr({ name: "name", value: { kind: "static", text: node.name } })];
@@ -353,10 +363,14 @@ function inlineNode(node: IRNode, rules: RewriteRules): string {
         ? `props.children ?? ${inlineNode(node.fallback, rules)}`
         : "props.children";
     }
-    const prop = `render${node.name.charAt(0).toUpperCase()}${node.name.slice(1)}`;
+    if (node.scopedArgs.length > 0) {
+      return node.fallback
+        ? `props.${node.name}?.(${argsStr}) ?? ${inlineNode(node.fallback, rules)}`
+        : `props.${node.name}?.(${argsStr})`;
+    }
     return node.fallback
-      ? `props.${prop}?.(${argsStr}) ?? ${inlineNode(node.fallback, rules)}`
-      : `props.${prop}?.(${argsStr})`;
+      ? `props.${node.name} ?? ${inlineNode(node.fallback, rules)}`
+      : `props.${node.name}`;
   }
   return inlineCode(emitNode(node, rules));
 }
@@ -399,8 +413,8 @@ function buildPropsType(component: IRComponent): string {
         slotFields.push("children?: React.ReactNode");
       }
     } else {
-      const prop = `render${slot.name.charAt(0).toUpperCase()}${slot.name.slice(1)}`;
-      slotFields.push(`${prop}?: (...args: any[]) => React.ReactNode`);
+      const type = slot.isScoped ? "(...args: any[]) => React.ReactNode" : "React.ReactNode";
+      slotFields.push(`${slot.name}?: ${type}`);
     }
   }
   if (slotFields.length > 0) {

--- a/core/compiler/src/codegen/targets/solid/index.test.ts
+++ b/core/compiler/src/codegen/targets/solid/index.test.ts
@@ -72,6 +72,56 @@ describe("ComponentInstance event casing", () => {
   });
 });
 
+describe("solid ComponentInstance slot fills", () => {
+  it("emits an unscoped named slot fill as a node prop, not a <Tag.name> child", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("IInput") as ts.Identifier,
+      resolved: { module: null, name: "IInput" },
+      slots: [
+        {
+          name: "prefix",
+          body: createElement({ tag: "span", children: [createText({ value: "$" })] }),
+          scopedParams: [],
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(solid, makeComp("Parent", ci));
+    // Matches the consumption side: `{props.prefix}`.
+    expect(code).toContain("prefix={<span>$</span>}");
+    expect(code).not.toContain("IInput.prefix");
+  });
+
+  it("emits a scoped named slot fill as a function prop, threading scopedParams", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("IList") as ts.Identifier,
+      resolved: { module: null, name: "IList" },
+      slots: [
+        {
+          name: "item",
+          body: createElement({ tag: "span", children: [createText({ value: "row" })] }),
+          scopedParams: ["item"],
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(solid, makeComp("Parent", ci));
+    expect(code).toContain("item={(item) => (<span>row</span>)}");
+  });
+
+  it("keeps the default slot as children", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("ICard") as ts.Identifier,
+      resolved: { module: null, name: "ICard" },
+      slots: [
+        { name: "default", body: createText({ value: "card content" }), scopedParams: [], loc },
+      ],
+    });
+    const code = emitCode(solid, makeComp("Parent", ci));
+    expect(code).toContain("card content");
+  });
+});
+
 describe("solid conformance", () => {
   it("uses oxlint with the solid jsPlugin and native control-flow imports", () => {
     expect(solid.conformance).toBeDefined();

--- a/core/compiler/src/codegen/targets/solid/index.test.ts
+++ b/core/compiler/src/codegen/targets/solid/index.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
+import type { IRNode } from "../../../ir/render/nodes.ts";
 import {
   createComponentInstance,
   createElement,
@@ -133,6 +134,33 @@ describe("solid ComponentInstance slot fills", () => {
     expect(code).toContain("icon={props.icon}");
     expect(code).not.toContain("icon={{");
   });
+
+  const reproject = (init: Parameters<typeof createSlotPlaceholder>[0]) =>
+    emitCode(
+      solid,
+      makeComp(
+        "Parent",
+        createComponentInstance({
+          reference: mockExpr("IChild") as ts.Identifier,
+          resolved: { module: null, name: "IChild" },
+          slots: [{ name: "icon", body: createSlotPlaceholder(init), scopedParams: [], loc }],
+        }),
+      ),
+    );
+
+  it("re-projects slot variants (scoped/unscoped, named/default, fallback) as bare reads", () => {
+    const args = [createExpr({ expr: mockExpr("row") })];
+    expect(reproject({ name: "icon", fallback: createText({ value: "·" }) })).toContain(
+      'icon={props.icon ?? "·"}',
+    );
+    expect(reproject({ name: "icon", scopedArgs: args })).toContain("icon={props.icon?.(row)}");
+    expect(
+      reproject({ name: "icon", scopedArgs: args, fallback: createText({ value: "·" }) }),
+    ).toContain('icon={props.icon?.(row) ?? "·"}');
+    expect(reproject({ fallback: createText({ value: "·" }) })).toContain(
+      'icon={props.children ?? "·"}',
+    );
+  });
 });
 
 describe("solid conformance", () => {
@@ -256,5 +284,57 @@ describe("solid emit + print", () => {
     expect(code).toContain("__InkTransition");
     expect(code).toContain("transitionend");
     expect(code).toMatchSnapshot();
+  });
+});
+
+describe("solid additional branch coverage", () => {
+  const forNode = (body: IRNode): IRNode => ({
+    kind: "For",
+    each: createExpr({ expr: mockExpr("items()") }),
+    itemBinding: "item",
+    key: createExpr({ expr: mockExpr("item.id") }),
+    syntheticKey: true,
+    body,
+    loc,
+  });
+
+  it("For with a non-block arrow body inlines the returned expression", () => {
+    const code = emitCode(
+      solid,
+      makeComp(
+        "List",
+        createElement({
+          tag: "ul",
+          children: [forNode(createExpr({ expr: mockExpr("(item) => item.label") }))],
+        }),
+      ),
+    );
+    expect(code).toContain("<For");
+    expect(code).toContain("item.label");
+  });
+
+  it("For with a block arrow body keeps the block", () => {
+    const code = emitCode(
+      solid,
+      makeComp(
+        "List",
+        createElement({
+          tag: "ul",
+          children: [forNode(createExpr({ expr: mockExpr("(item) => { return item.label; }") }))],
+        }),
+      ),
+    );
+    expect(code).toContain("<For");
+  });
+
+  it("default slot without fallback reads props.children", () => {
+    const comp = richComp(
+      "Slotted",
+      createElement({ tag: "div", children: [createSlotPlaceholder({})] }),
+      {
+        slots: [{ name: "default", isScoped: false, scopedProps: [], required: false, loc }],
+      },
+    );
+    expect(emitCode(solid, comp)).toContain("{props.children}");
   });
 });

--- a/core/compiler/src/codegen/targets/solid/index.test.ts
+++ b/core/compiler/src/codegen/targets/solid/index.test.ts
@@ -120,6 +120,19 @@ describe("solid ComponentInstance slot fills", () => {
     const code = emitCode(solid, makeComp("Parent", ci));
     expect(code).toContain("card content");
   });
+
+  it("inlines a re-projected slot fill to the bare prop read (no double braces)", () => {
+    const ci = createComponentInstance({
+      reference: mockExpr("IButton") as ts.Identifier,
+      resolved: { module: null, name: "IButton" },
+      slots: [
+        { name: "icon", body: createSlotPlaceholder({ name: "icon" }), scopedParams: [], loc },
+      ],
+    });
+    const code = emitCode(solid, makeComp("Parent", ci));
+    expect(code).toContain("icon={props.icon}");
+    expect(code).not.toContain("icon={{");
+  });
 });
 
 describe("solid conformance", () => {

--- a/core/compiler/src/codegen/targets/solid/index.ts
+++ b/core/compiler/src/codegen/targets/solid/index.ts
@@ -326,6 +326,21 @@ function inlineNode(node: IRNode, rules: RewriteRules): string {
   if (node.kind === "Expression") {
     return rewriteExpr(node.expr, rules);
   }
+  // A slot read as a BARE expression (no surrounding `{…}`) — for arrow bodies and attr values where
+  // the braces come from the caller. Without this, `inlineCode(emitNode())` returns `{props.x}` and a
+  // fill like `prefix={<Slot name="x"/>}` would double-wrap to `prefix={{props.x}}` (a parse error).
+  if (node.kind === "SlotPlaceholder") {
+    if (node.scopedArgs.length > 0) {
+      const argsStr = node.scopedArgs.map((a) => rewriteExpr(a.expr, rules)).join(", ");
+      return node.fallback
+        ? `props.${node.name}?.(${argsStr}) ?? ${inlineNode(node.fallback, rules)}`
+        : `props.${node.name}?.(${argsStr})`;
+    }
+    const propName = node.name === "default" ? "children" : node.name;
+    return node.fallback
+      ? `props.${propName} ?? ${inlineNode(node.fallback, rules)}`
+      : `props.${propName}`;
+  }
   return inlineCode(emitNode(node, rules));
 }
 

--- a/core/compiler/src/codegen/targets/solid/index.ts
+++ b/core/compiler/src/codegen/targets/solid/index.ts
@@ -142,16 +142,23 @@ function emitNode(node: IRNode, rules: RewriteRules): Code {
     case "ComponentInstance": {
       const tag = node.resolved?.name ?? node.reference.getText();
       const attrs = jsxAttrs(node, rules, true);
-      const children = node.slots.map((s) =>
-        s.name === "default"
-          ? emitNode(s.body, rules)
-          : cJsxElement({
-              tag: `${tag}.${s.name}`,
-              attrs: [],
-              children: [emitNode(s.body, rules)],
-              selfClose: false,
-            }),
-      );
+      // The default slot is `children`; a named slot is consumed as a prop (see the `SlotPlaceholder`
+      // case) — a node prop (`prefix={<>$</>}`) when unscoped, a function prop (`item={(row) => …}`)
+      // when it takes args. A `<Tag.name>` child would never reach the consumer.
+      const children: Code[] = [];
+      for (const s of node.slots) {
+        if (s.name === "default") {
+          children.push(emitNode(s.body, rules));
+        } else {
+          const value =
+            s.scopedParams.length > 0
+              ? `(${s.scopedParams.join(", ")}) => (${inlineNode(s.body, rules)})`
+              : inlineNode(s.body, rules);
+          attrs.push(
+            cJsxAttr({ name: s.name, value: { kind: "expr", expr: cExpr({ text: value }) } }),
+          );
+        }
+      }
       return cJsxElement({ tag, attrs, children, selfClose: children.length === 0 });
     }
     case "Text":

--- a/ui/components/src/components/button/headless/__snapshots__/IButtonBase.ink.test.ts.snap
+++ b/ui/components/src/components/button/headless/__snapshots__/IButtonBase.ink.test.ts.snap
@@ -9,7 +9,7 @@ export interface ButtonBaseProps {
   disabled?: boolean;
   loading?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-button-base', template: \`<button [class]="'button' + (klass() ? ' ' + klass() : '')" [type]="type() ?? 'button'" [disabled]="disabled() || loading()" [aria-busy]="loading() ? 'true' : 'false'">
+@Component({ standalone: true, selector: 'ink-button-base', template: \`<button [class]="'button' + (klass() ? ' ' + klass() : '')" [attr.type]="(type() ?? 'button') ?? null" [disabled]="disabled() || loading()" [attr.aria-busy]="(loading() ? 'true' : 'false') ?? null">
 @if (!!loading()) {
 <span class="button-spinner" aria-hidden="true"></span>
 }

--- a/ui/components/src/components/input/headless/__snapshots__/IInputBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputBase.ink.test.ts.snap
@@ -7,7 +7,7 @@ export interface InputBaseProps {
   /** Id of the field shell element. */
   id?: string;
 }
-@Component({ standalone: true, selector: 'ink-input-base', template: \`<div [class]="'input' + (klass() ? ' ' + klass() : '')" [id]="id()">
+@Component({ standalone: true, selector: 'ink-input-base', template: \`<div [class]="'input' + (klass() ? ' ' + klass() : '')" [attr.id]="(id()) ?? null">
 <ng-content></ng-content>
 </div>\` })
 export class IInputBaseComponent

--- a/ui/components/src/components/input/headless/__snapshots__/IInputControlBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputControlBase.ink.test.ts.snap
@@ -18,9 +18,9 @@ export interface InputControlBaseProps {
   readonly?: boolean;
 }
 @Component({ standalone: true, selector: 'ink-input-control-base', template: \`@if (type() === 'textarea') {
-<textarea class="input-field" [id]="id()" [name]="name()" [value]="value()" [placeholder]="placeholder()" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)"></textarea>
+<textarea class="input-field" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [value]="value()" [attr.placeholder]="(placeholder()) ?? null" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)"></textarea>
 } @else {
-<input class="input-field" [id]="id()" [name]="name()" [type]="type()" [value]="value()" [placeholder]="placeholder()" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)" />
+<input class="input-field" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [attr.type]="(type()) ?? null" [value]="value()" [attr.placeholder]="(placeholder()) ?? null" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)" />
 }\` })
 export class IInputControlBaseComponent
 {
@@ -93,7 +93,7 @@ props.type === "textarea" ? (<><textarea class="input-field" id={props.id} name=
 export function IInputControlBase(props: InputControlBaseProps & { value?: string; onUpdateValue?: (value: string) => void })
 {
 return (
-props.type === "textarea" ? <textarea className="input-field" id={props.id} name={props.name} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onInput={(e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue?.(e.currentTarget.value)} /> : <input className="input-field" id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onInput={(e: { currentTarget: HTMLInputElement }) => props.onUpdateValue?.(e.currentTarget.value)} />)
+props.type === "textarea" ? <textarea className="input-field" id={props.id} name={props.name} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onInput={(e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue?.(e.currentTarget.value)} /> : <input className="input-field" id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onInput={(e: { currentTarget: HTMLInputElement }) => props.onUpdateValue?.(e.currentTarget.value)} />)
 }
 ",
   "solid/IInputControlBase.tsx": "import { Show } from "solid-js";

--- a/ui/components/src/components/input/headless/__snapshots__/IInputGroupBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputGroupBase.ink.test.ts.snap
@@ -7,7 +7,7 @@ export interface InputGroupBaseProps {
   /** Id of the input group element. */
   id?: string;
 }
-@Component({ standalone: true, selector: 'ink-input-group-base', template: \`<div [class]="'input-group' + (klass() ? ' ' + klass() : '')" [id]="id()">
+@Component({ standalone: true, selector: 'ink-input-group-base', template: \`<div [class]="'input-group' + (klass() ? ' ' + klass() : '')" [attr.id]="(id()) ?? null">
 <ng-content></ng-content>
 </div>\` })
 export class IInputGroupBaseComponent

--- a/ui/components/src/components/input/styled/IInput.ink.test.ts
+++ b/ui/components/src/components/input/styled/IInput.ink.test.ts
@@ -69,9 +69,9 @@ describe("IInput (styled)", () => {
 
   it("gates each addon by slot presence on targets with a runtime API", async () => {
     const result = await compileComponent(IINPUT);
-    // React: render-prop presence check.
-    expectOutputContains(out(result, "react"), "props.renderPrefix != null");
-    expectOutputContains(out(result, "react"), "props.renderAppend != null");
+    // React: node-prop presence check.
+    expectOutputContains(out(result, "react"), "props.prefix != null");
+    expectOutputContains(out(result, "react"), "props.append != null");
     // Vue: `$slots` presence check via v-if.
     expectOutputContains(out(result, "vue"), "!!$slots.prefix");
     expectOutputContains(out(result, "vue"), "!!$slots.append");
@@ -82,8 +82,8 @@ describe("IInput (styled)", () => {
   it("always renders the addon wrappers on Qwik/Angular (no runtime slot presence)", async () => {
     const result = await compileComponent(IINPUT);
     // No `true ?` / `@if (true)` constant condition — the wrapper is emitted unconditionally and
-    // collapses via CSS :empty.
-    expectOutputContains(out(result, "qwik"), '<Slot name="prefix" />');
+    // collapses via CSS :empty. The named slot is read from props (Qwik) / projected (Angular).
+    expectOutputContains(out(result, "qwik"), "{props.prefix}");
     expectOutputContains(out(result, "angular"), 'select="[slot=prefix]"');
   });
 

--- a/ui/components/src/components/input/styled/__snapshots__/IInput.ink.test.ts.snap
+++ b/ui/components/src/components/input/styled/__snapshots__/IInput.ink.test.ts.snap
@@ -117,7 +117,7 @@ const shellClassName = inputRecipe({ color: color, variant: variant, size: size,
 </IInputAppendBase>) : null}
 </IInputGroupBase>
 ",
-  "qwik/IInput.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL, Slot } from "@qwik.dev/core";
+  "qwik/IInput.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
 import { IInputGroupBase } from "../headless/IInputGroupBase";
 import { IInputBase } from "../headless/IInputBase";
 import { IInputPrefixBase } from "../headless/IInputPrefixBase";
@@ -151,15 +151,15 @@ const { prefix, suffix, prepend, append, color, variant, size, invalid, id, name
 return (
 <IInputGroupBase {...__attrs} class={[groupClassName.value, props.class].filter(Boolean).join(" ")}>
   <>
-    {(<><IInputPrependBase><Slot name="prepend" /></IInputPrependBase></>)}
+    {(<><IInputPrependBase>{props.prepend}</IInputPrependBase></>)}
     <IInputBase class={shellClassName.value}>
       <>
-        {(<><IInputPrefixBase class={inputPrefixRecipe({ size: props.size })}><Slot name="prefix" /></IInputPrefixBase></>)}
+        {(<><IInputPrefixBase class={inputPrefixRecipe({ size: props.size })}>{props.prefix}</IInputPrefixBase></>)}
         <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue$={$(v => props.onUpdateValue$?.(v))} />
-        {(<><IInputSuffixBase class={inputSuffixRecipe({ size: props.size })}><Slot name="suffix" /></IInputSuffixBase></>)}
+        {(<><IInputSuffixBase class={inputSuffixRecipe({ size: props.size })}>{props.suffix}</IInputSuffixBase></>)}
       </>
     </IInputBase>
-    {(<><IInputAppendBase><Slot name="append" /></IInputAppendBase></>)}
+    {(<><IInputAppendBase>{props.append}</IInputAppendBase></>)}
   </>
 </IInputGroupBase>
 )
@@ -191,23 +191,23 @@ export interface InputProps extends InputControlBaseProps {
   /** Invalid-state styling. */
   invalid?: InputStylingProps["invalid"];
 }
-export function IInput(props: InputProps & { renderPrefix?: (...args: any[]) => React.ReactNode; renderSuffix?: (...args: any[]) => React.ReactNode; renderPrepend?: (...args: any[]) => React.ReactNode; renderAppend?: (...args: any[]) => React.ReactNode } & { value?: string; onUpdateValue?: (value: string) => void } & React.HTMLAttributes<HTMLElement>)
+export function IInput(props: InputProps & { prefix?: React.ReactNode; suffix?: React.ReactNode; prepend?: React.ReactNode; append?: React.ReactNode } & { value?: string; onUpdateValue?: (value: string) => void } & React.HTMLAttributes<HTMLElement>)
 {
 const groupClassName = useMemo(() => inputGroupRecipe({ size: props.size }), [props.size])
 const shellClassName = useMemo(() => inputRecipe({ color: props.color, variant: props.variant, size: props.size, invalid: props.invalid, disabled: props.disabled, readonly: props.readonly }), [props.color, props.variant, props.size, props.invalid, props.disabled, props.readonly])
-const { renderPrefix, renderSuffix, renderPrepend, renderAppend, color, variant, size, invalid, id, name, type, placeholder, disabled, readonly, value, onUpdateValue, ...__attrs } = props
+const { prefix, suffix, prepend, append, color, variant, size, invalid, id, name, type, placeholder, disabled, readonly, value, onUpdateValue, ...__attrs } = props
 return (
 <IInputGroupBase {...__attrs} className={[groupClassName, props.className].filter(Boolean).join(" ")}>
   <>
-    {(props.renderPrepend != null) ? <IInputPrependBase>{props.renderPrepend?.()}</IInputPrependBase> : null}
+    {(props.prepend != null) ? <IInputPrependBase>{props.prepend}</IInputPrependBase> : null}
     <IInputBase className={shellClassName}>
       <>
-        {(props.renderPrefix != null) ? <IInputPrefixBase className={inputPrefixRecipe({ size: props.size })}>{props.renderPrefix?.()}</IInputPrefixBase> : null}
-        <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} />
-        {(props.renderSuffix != null) ? <IInputSuffixBase className={inputSuffixRecipe({ size: props.size })}>{props.renderSuffix?.()}</IInputSuffixBase> : null}
+        {(props.prefix != null) ? <IInputPrefixBase className={inputPrefixRecipe({ size: props.size })}>{props.prefix}</IInputPrefixBase> : null}
+        <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} />
+        {(props.suffix != null) ? <IInputSuffixBase className={inputSuffixRecipe({ size: props.size })}>{props.suffix}</IInputSuffixBase> : null}
       </>
     </IInputBase>
-    {(props.renderAppend != null) ? <IInputAppendBase>{props.renderAppend?.()}</IInputAppendBase> : null}
+    {(props.append != null) ? <IInputAppendBase>{props.append}</IInputAppendBase> : null}
   </>
 </IInputGroupBase>
 )


### PR DESCRIPTION
## Summary

Rendering the Input "Default" story across all 7 framework Storybooks surfaced codegen inconsistencies: React, Solid, and Qwik silently dropped named-slot content (the `$`/`USD` addons) and Angular rendered a literal `id="undefined"`. All JSX targets now emit named slots as props — a node prop (`prefix={<>$</>}` ↔ `{props.prefix}`), or a function prop when scoped — matching their own consumption convention; React also maps `readonly → readOnly`, and Angular binds non-property native attributes via `[attr.name]="(expr) ?? null"` (omitting nullish) while keeping boolean/value props as property bindings. All 7 frameworks now render the Default Input story identically (`$ 0.00 USD`).

## Test plan

- [ ] `vp run ready` passes locally — note: the pre-existing `→ astro` oxlint and Angular-SSR `@angular/compiler` mount failures are unrelated to this PR (identical on a clean baseline)
- [x] `vp test core/compiler` green except the 74 pre-existing Astro lint failures
- [x] `vp test ui/components` green except the pre-existing Angular-SSR mount tests (local `@angular/compiler` temp-dir resolution)
- [x] Manually verified all 7 Storybook Default stories render `$ 0.00 USD`; Angular has no `id="undefined"`; React has no DOM-prop console warning

## Checklist

- [x] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references". (Codegen bug fix — no public API/convention/structure change.)
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".
