### PR TITLE
test(core,plugin): add unit tests for authoring primitives and unplugin factory

### DIFF
--- a/core/core/package.json
+++ b/core/core/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "typescript": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/core/core/src/index.test.ts
+++ b/core/core/src/index.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  defineComponent,
+  createSignal,
+  defineModel,
+  defineEmits,
+  createMemo,
+  createEffect,
+  createRef,
+  createResource,
+  onMount,
+  onCleanup,
+  batch,
+  untrack,
+  defineSlot,
+  hasSlot,
+  Slot,
+  Show,
+  For,
+  Switch,
+  Match,
+  Transition,
+} from "./index.ts";
+
+describe("defineComponent", () => {
+  it("returns the setup function unchanged when called with a single setup arg", () => {
+    const setup = (props: { value: number }) => props.value;
+    const Component = defineComponent(setup);
+    expect(Component).toBe(setup);
+    expect(Component({ value: 42 })).toBe(42);
+  });
+
+  it("returns the setup function when called with (options, setup)", () => {
+    const setup = vi.fn((props: { value: number }) => props.value);
+    const Component = defineComponent({ name: "Demo", runtime: "client" }, setup);
+    expect(Component).toBe(setup);
+    Component({ value: 7 });
+    expect(setup).toHaveBeenCalledWith({ value: 7 });
+  });
+});
+
+describe("createSignal", () => {
+  it("getter returns the initial value", () => {
+    const [get] = createSignal(123);
+    expect(get()).toBe(123);
+  });
+
+  it("setter updates the value the getter reads", () => {
+    const [get, set] = createSignal("a");
+    set("b");
+    expect(get()).toBe("b");
+  });
+
+  it("preserves reference identity for object values", () => {
+    const initial = { count: 0 };
+    const next = { count: 1 };
+    const [get, set] = createSignal(initial);
+    expect(get()).toBe(initial);
+    set(next);
+    expect(get()).toBe(next);
+  });
+});
+
+describe("defineModel", () => {
+  it("getter is undefined until set (default name)", () => {
+    const [get, set] = defineModel<string>();
+    expect(get()).toBeUndefined();
+    set("hello");
+    expect(get()).toBe("hello");
+  });
+
+  it("accepts an explicit model name", () => {
+    const [get, set] = defineModel<number>("count");
+    expect(get()).toBeUndefined();
+    set(5);
+    expect(get()).toBe(5);
+  });
+});
+
+describe("defineEmits", () => {
+  it("returns a no-op emitter when called without names", () => {
+    const emit = defineEmits();
+    expect(emit("change", 1)).toBeUndefined();
+  });
+
+  it("returns a no-op emitter when called with declared event names", () => {
+    const emit = defineEmits<{ change: [number] }>(["change"]);
+    expect(() => emit("change", 1)).not.toThrow();
+  });
+});
+
+describe("createMemo", () => {
+  it("returns the provided function and forwards its result", () => {
+    const fn = () => 42;
+    const memo = createMemo(fn);
+    expect(memo).toBe(fn);
+    expect(memo()).toBe(42);
+  });
+});
+
+describe("createEffect", () => {
+  it("invokes the effect immediately", () => {
+    const fn = vi.fn();
+    createEffect(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts an effect that returns a cleanup without throwing", () => {
+    const cleanup = vi.fn();
+    expect(() => createEffect(() => cleanup)).not.toThrow();
+  });
+});
+
+describe("createRef", () => {
+  it("returns a ref object with a null current", () => {
+    expect(createRef()).toEqual({ current: null });
+  });
+});
+
+describe("createResource", () => {
+  it("returns a loading tuple without invoking the fetcher", () => {
+    const fetcher = vi.fn(async () => "data");
+    const [data, meta] = createResource(fetcher);
+    expect(data).toBeUndefined();
+    expect(meta).toEqual({ loading: true, error: undefined });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("lifecycle stubs", () => {
+  it("onMount does not invoke its callback and returns undefined", () => {
+    const fn = vi.fn();
+    expect(onMount(fn)).toBeUndefined();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("onCleanup does not invoke its callback and returns undefined", () => {
+    const fn = vi.fn();
+    expect(onCleanup(fn)).toBeUndefined();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe("batch / untrack", () => {
+  it("batch invokes the callback", () => {
+    const fn = vi.fn();
+    batch(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("untrack invokes the callback and returns its result", () => {
+    expect(untrack(() => 7)).toBe(7);
+  });
+});
+
+describe("slot stubs", () => {
+  it("defineSlot returns null with and without a name", () => {
+    expect(defineSlot()).toBeNull();
+    expect(defineSlot("footer")).toBeNull();
+  });
+
+  it("hasSlot returns false with and without a name", () => {
+    expect(hasSlot()).toBe(false);
+    expect(hasSlot("footer")).toBe(false);
+  });
+});
+
+describe("control-flow components", () => {
+  it("all render to null at authoring time", () => {
+    expect(Slot({ name: "footer" })).toBeNull();
+    expect(Show({ when: true })).toBeNull();
+    expect(For({ each: [1, 2], children: (item) => item })).toBeNull();
+    expect(Switch({})).toBeNull();
+    expect(Match({ when: false })).toBeNull();
+    expect(Transition({ name: "fade", appear: true })).toBeNull();
+  });
+});

--- a/core/core/src/jsx-runtime.test.ts
+++ b/core/core/src/jsx-runtime.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { jsx, jsxs, Fragment } from "./jsx-runtime.ts";
+
+describe("jsx", () => {
+  it("wraps type and props into an element record", () => {
+    expect(jsx("div", { id: "a" })).toEqual({ type: "div", props: { id: "a" } });
+  });
+
+  it("ignores the optional key argument", () => {
+    expect(jsx("div", { id: "a" }, "key-1")).toEqual({ type: "div", props: { id: "a" } });
+  });
+});
+
+describe("jsxs", () => {
+  it("wraps type and props for multi-child elements", () => {
+    const props = { children: ["x", "y"] };
+    expect(jsxs("ul", props)).toEqual({ type: "ul", props });
+  });
+
+  it("ignores the optional key argument", () => {
+    expect(jsxs("ul", { children: [] }, "key-2")).toEqual({ type: "ul", props: { children: [] } });
+  });
+});
+
+describe("Fragment", () => {
+  it("is the shared registered inkline fragment symbol", () => {
+    expect(Fragment).toBe(Symbol.for("inkline.fragment"));
+  });
+});

--- a/core/core/vite.config.ts
+++ b/core/core/vite.config.ts
@@ -8,4 +8,17 @@ export default defineConfig({
     },
     dts: true,
   },
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+      thresholds: {
+        lines: 100,
+        branches: 100,
+        functions: 100,
+        statements: 100,
+      },
+    },
+  },
 });

--- a/core/plugin/package.json
+++ b/core/plugin/package.json
@@ -62,7 +62,8 @@
     "unplugin": "^3.0.0"
   },
   "devDependencies": {
-    "unbuild": "^3.6.1"
+    "unbuild": "^3.6.1",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "@farmfe/core": ">=1",

--- a/core/plugin/src/index.test.ts
+++ b/core/plugin/src/index.test.ts
@@ -1,0 +1,354 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("@inkline/compiler", () => ({
+  createIncrementalState: vi.fn(),
+  compileIncremental: vi.fn(),
+}));
+
+import type { UnpluginContextMeta } from "unplugin";
+import { compileIncremental, createIncrementalState } from "@inkline/compiler";
+import type {
+  Diagnostic,
+  DiagnosticSeverity,
+  GeneratedFile,
+  IncrementalCompileResult,
+  IncrementalState,
+} from "@inkline/compiler";
+import { type InklinePluginOptions, unplugin, unpluginFactory } from ".";
+import vitePlugin from "./vite";
+import webpackPlugin from "./webpack";
+import rollupPlugin from "./rollup";
+import esbuildPlugin from "./esbuild";
+import rspackPlugin from "./rspack";
+import farmPlugin from "./farm";
+
+const compileIncrementalMock = vi.mocked(compileIncremental);
+const createIncrementalStateMock = vi.mocked(createIncrementalState);
+
+/** Minimal view of the plugin surface this suite drives directly. */
+interface TransformContext {
+  error: (message: string) => void;
+  warn: (message: string) => void;
+}
+interface PluginShape {
+  transform: {
+    handler: (
+      this: TransformContext,
+      code: string,
+      id: string,
+    ) => Promise<{ code: string; map: unknown } | null>;
+  };
+  vite: {
+    configResolved: (config: { plugins: readonly { name: string }[] }) => void;
+    handleHotUpdate: (ctx: { file: string }) => Promise<void>;
+  };
+}
+
+const META = { framework: "vite" } as UnpluginContextMeta;
+
+function build(options?: InklinePluginOptions): PluginShape {
+  return unpluginFactory(options, META) as unknown as PluginShape;
+}
+
+function makeCtx(): TransformContext {
+  return { error: vi.fn(), warn: vi.fn() };
+}
+
+function makeState(tag: string): IncrementalState {
+  return { sourceHashes: new Map([[tag, tag]]), results: new Map() };
+}
+
+function makeFile(path: string, contents = "CODE", sourceMap?: string): GeneratedFile {
+  return { path, contents, sourceMap };
+}
+
+function makeDiagnostic(severity: DiagnosticSeverity, title: string): Diagnostic {
+  return {
+    code: "INK0001",
+    severity,
+    title,
+    url: "https://inkline.dev",
+    loc: { file: "x.ink.tsx", line: 1, column: 1, offset: 0, length: 0 },
+  };
+}
+
+function makeResult(over: Partial<IncrementalCompileResult> = {}): IncrementalCompileResult {
+  return {
+    files: {},
+    diagnostics: [],
+    nextState: makeState("next"),
+    changed: [],
+    skipped: [],
+    ...over,
+  };
+}
+
+const ID = "/project/Button.ink.tsx";
+
+let tmpDir: string;
+let inkFile: string;
+const INK_SOURCE = "export const x = 1;\n";
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "inkline-plugin-"));
+  inkFile = join(tmpDir, "Hot.ink.tsx");
+  writeFileSync(inkFile, INK_SOURCE, "utf-8");
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createIncrementalStateMock.mockImplementation(() => makeState("init"));
+  compileIncrementalMock.mockResolvedValue(makeResult());
+});
+
+describe("transform handler", () => {
+  it("errors and emits nothing when no target is set", async () => {
+    const ctx = makeCtx();
+    const out = await build().transform.handler.call(ctx, "SRC", ID);
+
+    expect(ctx.error).toHaveBeenCalledWith(
+      'No target specified. Set the "target" option or use the Vite plugin for auto-detection.',
+    );
+    expect(out).toBeNull();
+    expect(compileIncrementalMock).not.toHaveBeenCalled();
+  });
+
+  it("compiles the file and returns the main file with a null map by default", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({ files: { react: [makeFile("Button.tsx", "OUTPUT")] } }),
+    );
+
+    const out = await build({ target: "react" }).transform.handler.call(makeCtx(), "SRC", ID);
+
+    expect(out).toEqual({ code: "OUTPUT", map: null });
+    expect(compileIncrementalMock).toHaveBeenCalledTimes(1);
+    expect(compileIncrementalMock.mock.calls[0]![0]).toBe(
+      createIncrementalStateMock.mock.results[0]!.value,
+    );
+    expect(compileIncrementalMock.mock.calls[0]![1]).toEqual([{ fileName: ID, source: "SRC" }]);
+    expect(compileIncrementalMock.mock.calls[0]![2]).toMatchObject({
+      targets: ["react"],
+      sourceMap: "inline",
+    });
+  });
+
+  it("parses an inline source map when the main file carries one", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({
+        files: {
+          react: [makeFile("Button.tsx", "OUTPUT", JSON.stringify({ version: 3, sources: [] }))],
+        },
+      }),
+    );
+
+    const out = await build({ target: "react" }).transform.handler.call(makeCtx(), "SRC", ID);
+
+    expect(out).toEqual({ code: "OUTPUT", map: { version: 3, sources: [] } });
+  });
+
+  it("selects the main file, ignoring emitted .css and .map siblings", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({
+        files: {
+          react: [
+            makeFile("Button.css", "CSS"),
+            makeFile("Button.js.map", "MAP"),
+            makeFile("Button.tsx", "REAL"),
+          ],
+        },
+      }),
+    );
+
+    const out = await build({ target: "react" }).transform.handler.call(makeCtx(), "SRC", ID);
+
+    expect(out).toEqual({ code: "REAL", map: null });
+  });
+
+  it("returns null when the target produced no files", async () => {
+    compileIncrementalMock.mockResolvedValue(makeResult({ files: {} }));
+    const out = await build({ target: "react" }).transform.handler.call(makeCtx(), "SRC", ID);
+    expect(out).toBeNull();
+  });
+
+  it("returns null when the target produced an empty file list", async () => {
+    compileIncrementalMock.mockResolvedValue(makeResult({ files: { react: [] } }));
+    const out = await build({ target: "react" }).transform.handler.call(makeCtx(), "SRC", ID);
+    expect(out).toBeNull();
+  });
+
+  it("returns null when only non-main (.css/.map) files were produced", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({ files: { react: [makeFile("Button.css"), makeFile("Button.js.map")] } }),
+    );
+    const out = await build({ target: "react" }).transform.handler.call(makeCtx(), "SRC", ID);
+    expect(out).toBeNull();
+  });
+
+  it('maps sourceMap:false to the compiler\'s "none" mode', async () => {
+    await build({ target: "react", sourceMap: false }).transform.handler.call(makeCtx(), "SRC", ID);
+    expect(compileIncrementalMock.mock.calls[0]![2]).toMatchObject({ sourceMap: "none" });
+  });
+
+  it('maps sourceMap:true to "inline"', async () => {
+    await build({ target: "react", sourceMap: true }).transform.handler.call(makeCtx(), "SRC", ID);
+    expect(compileIncrementalMock.mock.calls[0]![2]).toMatchObject({ sourceMap: "inline" });
+  });
+
+  it("merges inline config but forces the plugin's own target and sourceMap", async () => {
+    await build({
+      target: "react",
+      config: { verbose: true, targets: ["vue"] },
+    }).transform.handler.call(makeCtx(), "SRC", ID);
+
+    expect(compileIncrementalMock.mock.calls[0]![2]).toMatchObject({
+      verbose: true,
+      targets: ["react"],
+      sourceMap: "inline",
+    });
+  });
+
+  it("forwards error diagnostics to this.error", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({ diagnostics: [makeDiagnostic("error", "boom")] }),
+    );
+    const ctx = makeCtx();
+    await build({ target: "react" }).transform.handler.call(ctx, "SRC", ID);
+    expect(ctx.error).toHaveBeenCalledWith("INK0001: boom");
+    expect(ctx.warn).not.toHaveBeenCalled();
+  });
+
+  it("forwards warning diagnostics to this.warn", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({ diagnostics: [makeDiagnostic("warning", "heads up")] }),
+    );
+    const ctx = makeCtx();
+    await build({ target: "react" }).transform.handler.call(ctx, "SRC", ID);
+    expect(ctx.warn).toHaveBeenCalledWith("INK0001: heads up");
+    expect(ctx.error).not.toHaveBeenCalled();
+  });
+
+  it("ignores info diagnostics", async () => {
+    compileIncrementalMock.mockResolvedValue(
+      makeResult({ diagnostics: [makeDiagnostic("info", "fyi")] }),
+    );
+    const ctx = makeCtx();
+    await build({ target: "react" }).transform.handler.call(ctx, "SRC", ID);
+    expect(ctx.error).not.toHaveBeenCalled();
+    expect(ctx.warn).not.toHaveBeenCalled();
+  });
+
+  it("threads nextState into the following compile call", async () => {
+    const plugin = build({ target: "react" });
+    const first = makeState("after-first");
+    compileIncrementalMock.mockResolvedValueOnce(
+      makeResult({ files: { react: [makeFile("A.tsx")] }, nextState: first }),
+    );
+    await plugin.transform.handler.call(makeCtx(), "A", ID);
+
+    compileIncrementalMock.mockResolvedValueOnce(
+      makeResult({ files: { react: [makeFile("B.tsx")] } }),
+    );
+    await plugin.transform.handler.call(makeCtx(), "B", ID);
+
+    expect(compileIncrementalMock.mock.calls[1]![0]).toBe(first);
+  });
+});
+
+describe("vite.configResolved target auto-detection", () => {
+  async function detectedTargetFor(pluginNames: string[]): Promise<unknown> {
+    const plugin = build();
+    plugin.vite.configResolved({ plugins: pluginNames.map((name) => ({ name })) });
+    await plugin.transform.handler.call(makeCtx(), "SRC", ID);
+    return (compileIncrementalMock.mock.calls[0]![2] as { targets: unknown[] }).targets[0];
+  }
+
+  it("detects react", async () => {
+    expect(await detectedTargetFor(["vite:react-babel"])).toBe("react");
+  });
+
+  it("detects solid", async () => {
+    expect(await detectedTargetFor(["vite-plugin-solid"])).toBe("solid");
+  });
+
+  it("detects vue", async () => {
+    expect(await detectedTargetFor(["vite:vue"])).toBe("vue");
+  });
+
+  it("detects svelte", async () => {
+    expect(await detectedTargetFor(["vite-plugin-svelte"])).toBe("svelte");
+  });
+
+  it("falls back to react when no framework plugin is present", async () => {
+    expect(await detectedTargetFor(["vite:define", "vite:esbuild"])).toBe("react");
+  });
+
+  it("keeps an explicitly configured target over detection", async () => {
+    const plugin = build({ target: "vue" });
+    plugin.vite.configResolved({ plugins: [{ name: "vite:react-babel" }] });
+    await plugin.transform.handler.call(makeCtx(), "SRC", ID);
+    expect(compileIncrementalMock.mock.calls[0]![2]).toMatchObject({ targets: ["vue"] });
+  });
+});
+
+describe("vite.handleHotUpdate", () => {
+  it("ignores non-.ink.tsx files", async () => {
+    await build({ target: "react" }).vite.handleHotUpdate({ file: "/project/app.tsx" });
+    expect(compileIncrementalMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for an .ink.tsx file when no target is set", async () => {
+    await build().vite.handleHotUpdate({ file: inkFile });
+    expect(compileIncrementalMock).not.toHaveBeenCalled();
+  });
+
+  it("recompiles the changed file and threads state into later compiles", async () => {
+    const plugin = build({ target: "react" });
+    const afterHmr = makeState("after-hmr");
+    compileIncrementalMock.mockResolvedValueOnce(makeResult({ nextState: afterHmr }));
+
+    await plugin.vite.handleHotUpdate({ file: inkFile });
+
+    expect(compileIncrementalMock).toHaveBeenCalledTimes(1);
+    expect(compileIncrementalMock.mock.calls[0]![1]).toEqual([
+      { fileName: inkFile, source: INK_SOURCE },
+    ]);
+    expect(compileIncrementalMock.mock.calls[0]![2]).toMatchObject({
+      targets: ["react"],
+      sourceMap: "inline",
+    });
+
+    await plugin.transform.handler.call(makeCtx(), "SRC", ID);
+    expect(compileIncrementalMock.mock.calls[1]![0]).toBe(afterHmr);
+  });
+});
+
+describe("bundler adapters", () => {
+  it("each subpath default-exports a plugin factory", () => {
+    for (const plugin of [
+      vitePlugin,
+      webpackPlugin,
+      rollupPlugin,
+      esbuildPlugin,
+      rspackPlugin,
+      farmPlugin,
+    ]) {
+      expect(typeof plugin).toBe("function");
+    }
+  });
+
+  it("the raw unplugin instance exposes every per-bundler factory", () => {
+    expect(typeof unplugin.vite).toBe("function");
+    expect(typeof unplugin.rollup).toBe("function");
+    expect(typeof unplugin.webpack).toBe("function");
+    expect(typeof unplugin.esbuild).toBe("function");
+    expect(typeof unplugin.rspack).toBe("function");
+    expect(typeof unplugin.farm).toBe("function");
+  });
+});

--- a/core/plugin/vite.config.ts
+++ b/core/plugin/vite.config.ts
@@ -9,4 +9,17 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+      thresholds: {
+        lines: 100,
+        branches: 100,
+        functions: 100,
+        statements: 100,
+      },
+    },
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       unbuild:
         specifier: ^3.6.1
         version: 3.6.1(sass@1.97.3)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@latest
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)'
 
   tooling/agents-check:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.24(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(svelte@5.55.5(@typescript-eslint/types@8.59.3))(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@latest
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)'
 
   core/inkline:
     dependencies:
@@ -11926,8 +11929,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.4:
-    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -16512,7 +16515,7 @@ snapshots:
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.24(@types/node@25.9.1)(esbuild@0.27.7)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(svelte@5.55.5(@typescript-eslint/types@8.59.3))(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4))
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.3)
-      vue-component-type-helpers: 3.3.4
+      vue-component-type-helpers: 3.3.5
     optional: true
 
   '@storybook/vue3@10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.24(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(svelte@5.55.5(@typescript-eslint/types@8.59.3))(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4)))(vue@3.5.34(typescript@6.0.3))':
@@ -16521,7 +16524,7 @@ snapshots:
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.24(@types/node@25.9.1)(esbuild@0.28.0)(happy-dom@15.11.7)(jiti@2.7.0)(jsdom@29.1.1)(less@4.4.2)(sass@1.97.3)(svelte@5.55.5(@typescript-eslint/types@8.59.3))(terser@5.47.1)(tsx@4.22.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.47.1)(tsx@4.22.0)(yaml@2.8.4))(yaml@2.8.4))
       type-fest: 2.19.0
       vue: 3.5.34(typescript@6.0.3)
-      vue-component-type-helpers: 3.3.4
+      vue-component-type-helpers: 3.3.5
 
   '@styleframe/cli@4.1.0(@styleframe/license@2.0.2)(@styleframe/loader@3.0.2(@styleframe/core@3.6.0(@styleframe/license@2.0.2))(@styleframe/license@2.0.2)(@styleframe/transpiler@3.4.0(@styleframe/core@3.6.0(@styleframe/license@2.0.2))(@styleframe/license@2.0.2)))':
     dependencies:
@@ -25586,7 +25589,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.4: {}
+  vue-component-type-helpers@3.3.5: {}
 
   vue-docgen-api@4.79.2(vue@3.5.34(typescript@6.0.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Adds comprehensive unit test suites for `@inkline/core` (authoring primitives and JSX runtime) and `@inkline/plugin` (unplugin factory orchestration across Vite, webpack, Rollup, esbuild, Rspack, and Farm), bringing both packages to near-100% line and branch coverage.

## Related issues

- Closes #

## Type of change

- [x] `test` — tests only

## Test plan

- [x] `vp run ready` passes locally
- [x] `@inkline/core` unit tests pass with ~100% coverage
- [x] `@inkline/plugin` unit tests pass with ~100% coverage

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".