### PR TITLE
chore(storybook): group components by category in Storybook sidebar

### DIFF
--- a/docs/authoring-components.md
+++ b/docs/authoring-components.md
@@ -125,6 +125,8 @@ All primitives are authoring-time — the compiler removes them from emitted out
 
 Stories are also authored in `.ink.tsx` and compiled per-framework into [`ui/<framework>/generated/stories/`](../ui/) by the CLI's story generator. Use the `defineStories` helper from [`@inkline/storybook`](../tooling/storybook/) to keep types tight.
 
+Set `title` to `Components/<Category>/<Component>` — the `title` is the Storybook sidebar path, and the category segment groups the component in the sidebar. Current buckets: `Actions`, `Feedback`, `Forms` (add a new one when no existing category fits). Don't fall back to a flat `Components/<Component>`, or the component lands ungrouped.
+
 Each story file represents a single variant (colors, sizes, states). See [`ui/components/src/components/badge/stories/`](../ui/components/src/components/badge/stories/) for the canonical layout. The unified Storybook aggregator ([`apps/storybook/`](../apps/storybook/)) consumes the compiled output and displays variants for every framework side-by-side.
 
 ## Testing

--- a/ui/components/src/components/badge/stories/IBadge.ink.stories.ts
+++ b/ui/components/src/components/badge/stories/IBadge.ink.stories.ts
@@ -3,7 +3,7 @@ import type { BadgeProps } from "../styled/IBadge.ink.tsx";
 
 const meta = defineStories<BadgeProps>({
   component: "IBadge",
-  title: "Components/Badge",
+  title: "Components/Feedback/Badge",
   args: {
     label: "Badge",
   },

--- a/ui/components/src/components/button/stories/IButton.ink.stories.ts
+++ b/ui/components/src/components/button/stories/IButton.ink.stories.ts
@@ -3,7 +3,7 @@ import type { ButtonProps } from "../styled/IButton.ink.tsx";
 
 const meta = defineStories<ButtonProps>({
   component: "IButton",
-  title: "Components/Button",
+  title: "Components/Actions/Button",
   args: {
     label: "Button",
     disabled: false,

--- a/ui/components/src/components/field-group/stories/IFieldGroup.ink.stories.ts
+++ b/ui/components/src/components/field-group/stories/IFieldGroup.ink.stories.ts
@@ -3,7 +3,7 @@ import type { FieldGroupProps } from "../styled/IFieldGroup.ink.tsx";
 
 const meta = defineStories<FieldGroupProps>({
   component: "IFieldGroup",
-  title: "Components/FieldGroup",
+  title: "Components/Forms/FieldGroup",
   args: {},
   argTypes: {
     orientation: {

--- a/ui/components/src/components/input/stories/IInput.ink.stories.ts
+++ b/ui/components/src/components/input/stories/IInput.ink.stories.ts
@@ -3,7 +3,7 @@ import type { InputProps } from "../styled/IInput.ink.tsx";
 
 const meta = defineStories<InputProps>({
   component: "IInput",
-  title: "Components/Input",
+  title: "Components/Forms/Input",
   args: {},
   argTypes: {
     color: {


### PR DESCRIPTION
## Summary

Groups Badge, Button, FieldGroup, and Input story titles under `Components/Feedback`, `Components/Actions`, and `Components/Forms` respectively, so they appear categorized in the Storybook sidebar rather than flat under `Components/`. Also documents the `title` convention in `docs/authoring-components.md`.

## Related issues

- Closes #

## Type of change

- [ ] `feat` — new user-facing capability or public API
- [ ] `fix` — bug fix
- [ ] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `chore` / `ci` — tooling, dependencies, or CI

## Test plan

- [ ] `vp run ready` passes locally
- [ ] Storybook sidebar shows grouped categories: Actions, Feedback, Forms

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".