### PR TITLE
chore: add SKILL for creating components

### DIFF
--- a/.claude/skills/component-document/SKILL.md
+++ b/.claude/skills/component-document/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: component-document
+description: Phase 5 of building an Inkline component — finalize docs and the release. Complete TSDoc on the prop interfaces, add a changeset for the affected framework packages, confirm exports/freshness, and stage the future docs-site page (the docs website is not built yet — TBD). Use when wrapping up a component for release.
+triggers:
+  - document a component
+  - finalize a component
+  - add a changeset for the component
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+---
+
+# Component documentation & release prep
+
+The public docs website **does not exist yet** — so the "document" phase today means: make the API self-documenting (TSDoc), prepare the release (changeset), keep the repo's own docs honest, and stage the future docs-site content without shipping anything speculative.
+
+## Read first
+
+- The spec at `.context/component-<name>-spec.md` (the source of the user-facing description and examples).
+- `docs/release-process.md` for changeset conventions; `IInput`'s prop interfaces for the TSDoc bar.
+
+## Steps
+
+### 1. TSDoc completeness pass
+
+Every prop on every public interface (headless `*BaseProps` and styled `*Props`) gets a one-line `/** … */` describing its effect — the bar is `IInput`'s interfaces. Document slots, models, and emitted events too. This is the de-facto API reference until the website exists, and it powers editor intellisense in all 7 framework packages.
+
+### 2. Changeset
+
+The component ships through the **per-framework packages**, not the private `@inkline/components`. Run `pnpm changeset` and select the affected framework packages (`@inkline/react`, `@inkline/vue`, `@inkline/svelte`, `@inkline/solid`, `@inkline/angular`, `@inkline/qwik`, `@inkline/astro`) — all 7 for a new component. Use a `minor` bump for a new component (`feat`), `patch` for a fix. Write a clear, user-facing summary (what the component is, key props).
+
+### 3. Freshness
+
+- Confirm the styled + headless exports are in `ui/components/src/components/index.ts`.
+- If any `AGENTS.md` or `docs/*.md` maintains a component list or examples, update it. **Do not** treat `docs/authoring-components.md` as a code template — it has drifted; the live source is canonical.
+- Do **not** edit generated dirs (`ui/<framework>/.inkline/`, `.styleframe/`) or `.old/`.
+
+### 4. Docs website — TBD (stage, don't ship)
+
+The website (`apps/website`) has no component-doc pages yet. Do not invent a docs framework. Instead, capture the intended page content in the spec (or `.context/component-<name>-docs.md`) so it's ready when the site lands. A component doc page will eventually carry:
+
+- a one-paragraph description and an import snippet,
+- the **anatomy** (parts + the styled composition),
+- a **props/slots/events table** (generated from the TSDoc'd interfaces),
+- **accessibility notes** (the APG pattern, keyboard map, ARIA from the spec),
+- **live examples** mirroring the Storybook variants.
+
+Leave a short note in the changeset or PR description that the website page is pending the docs-site implementation.
+
+### 5. Final verify
+
+`vp run ready` (build + check + test) from the repo root must be green. When reading `vp check`, ignore the ~290 pre-existing `TS17004` fixture errors (standing baseline — see `.../reference/verification.md`); trust `vp test`.
+
+## Exit criteria
+
+Every prop/slot/event has TSDoc, a changeset exists for the 7 framework packages with a clear summary, exports and repo docs are current, the future docs-page content is staged, and `vp run ready` is green.

--- a/.claude/skills/component-implement/SKILL.md
+++ b/.claude/skills/component-implement/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: component-implement
+description: Phase 2 of building an Inkline component — write the .ink.tsx source. Author the headless part(s) (behavior + accessibility, no styling), then one styled component that composes them and applies a styleframe recipe, then the .styleframe.ts, then register the export. Compiles to all 7 frameworks. Use when implementing a component from a spec, or adding/fixing component source.
+triggers:
+  - implement a component
+  - write the component code
+  - build the component source
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+# Component implementation — headless, styled, styleframe, register
+
+Author the `.ink.tsx` source so it compiles cleanly to all 7 targets. Mirror the live exemplar's structure exactly — do not invent new patterns.
+
+## Read first
+
+1. The spec at `.context/component-<name>-spec.md` (from `component-research`). If it's missing and you're working standalone, read the existing source and infer the contract before changing it.
+2. `.claude/skills/create-component/reference/conventions.md` and `.../reference/primitives.md` — the split, the fallthrough rule, the primitives, and the **per-target gotchas**.
+3. The matching exemplar source: `badge/` (single part), `button/` (stateful + custom styles), `input/` (multi-part family with slots + two-way).
+
+## Steps
+
+### 1. Scaffold
+
+Create `ui/components/src/components/<name>/{headless,styled}/`.
+
+### 2. Headless first — `headless/I<Name>Base.ink.tsx`
+
+Behavior, structure, slots, events, accessibility. **No styleframe classes, no design tokens.** Single host-element root (so styled's `class` falls through — see conventions). TSDoc every prop. The minimal shape (from `badge`):
+
+```tsx
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface BadgeBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+
+export default defineComponent({ slots: { default: {} } }, (props: BadgeBaseProps) => {
+  return (
+    <div class="badge">
+      <Slot>{props.label}</Slot>
+    </div>
+  );
+});
+```
+
+For stateful components, reflect state in ARIA and gate decoration with `<Show>` (from `button`):
+
+```tsx
+<button
+  class="button"
+  type={props.type ?? "button"}
+  disabled={props.disabled || props.loading}
+  aria-busy={props.loading ? "true" : "false"}
+>
+  <Show when={!!props.loading}>
+    <span class="button-spinner" aria-hidden="true" />
+  </Show>
+  <Slot>{props.label}</Slot>
+</button>
+```
+
+For a family, author one `I<Name>*Base` per structural part. Two-way state uses `defineModel` and must coalesce optional strings for Solid:
+
+```tsx
+const [value, setValue] = defineModel<string>("value");
+// ...
+<input
+  value={value() ?? ""}
+  onInput={(e: { currentTarget: HTMLInputElement }) => setValue(e.currentTarget.value)}
+/>;
+```
+
+Apply the **a11y baseline** from conventions: native element first, correct role/ARIA states, `aria-hidden` on decorative nodes, accessible name, keyboard map per the spec's APG pattern.
+
+### 3. Styled — `styled/I<Name>.ink.tsx`
+
+Compose the headless part(s) and apply the recipe class via `createMemo`. The styled props interface extends the base + the recipe's styling props:
+
+```tsx
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+import IBadgeBase, { type BadgeBaseProps } from "../headless/IBadgeBase.ink.tsx";
+import { badgeRecipe, type BadgeRecipeProps as BadgeStylingProps } from "virtual:styleframe";
+
+export interface BadgeProps extends BadgeBaseProps, BadgeStylingProps {}
+
+export default defineComponent({ slots: { default: {} } }, (props: BadgeProps) => {
+  const className = createMemo(() =>
+    badgeRecipe({ color: props.color, variant: props.variant, size: props.size }),
+  );
+  return (
+    <IBadgeBase class={className()}>
+      <Slot>{props.label}</Slot>
+    </IBadgeBase>
+  );
+});
+```
+
+- **Layout/extra flags** combine into the class list (from `button`): `[buttonRecipe({…}), props.block && "button--block"].filter(Boolean).join(" ")`.
+- **Optional addons** are gated by slot presence (from `input`): `<Show when={hasSlot("prefix")}><IInputPrefixBase class={…}><Slot name="prefix" /></IInputPrefixBase></Show>`. Expect `INK0068` on Qwik + Angular (×2) — that's why step 4 ships `:empty` rules.
+- **One styled component per family** composes every headless part; do not make one styled component per part.
+
+### 4. Styleframe — `styled/I<Name>.styleframe.ts`
+
+Register the recipe(s) and add any custom CSS. Branch on the spec's styling decision:
+
+**(a) `@styleframe/theme` exports `use<Name>Recipe`** — reuse it:
+
+```ts
+import { styleframe } from "virtual:styleframe";
+import { useBadgeRecipe } from "@styleframe/theme";
+
+const s = styleframe();
+export const badgeRecipe = useBadgeRecipe(s);
+```
+
+Layer custom, non-recipe rules in the same file (from `button` — `.button--block`, the spinner keyframes + selector):
+
+```ts
+s.selector(".button--block", { width: "100%" });
+s.keyframes("button-spin", { "100%": { transform: "rotate(360deg)" } });
+s.selector(".button-spinner", {
+  /* … */
+});
+export const buttonRecipe = useButtonRecipe(s);
+```
+
+**(b) No theme recipe exists** — author styles locally with `s.recipe(...)` / `s.selector(...)`, exporting `<name>Recipe`. Define the same `color`/`variant`/`size` axes the props expose. **Always** add `:empty` collapse rules for any slot-gated addon (Qwik/Angular render the wrapper unconditionally):
+
+```ts
+s.selector(".<name>-prefix:empty, .<name>-suffix:empty", { display: "none" });
+```
+
+Gate animations behind `prefers-reduced-motion`.
+
+### 5. Register
+
+Add the styled export and every headless part to `ui/components/src/components/index.ts`:
+
+```ts
+export { default as IBadge } from "./badge/styled/IBadge.ink.tsx";
+export { default as IBadgeBase } from "./badge/headless/IBadgeBase.ink.tsx";
+```
+
+### 6. Verify
+
+`cd ui/components && pnpm build`. The component must compile to **all 7 targets** with only the expected notices: `INK0045` (Astro two-way, if any) and `INK0068` (Qwik + Angular, if `hasSlot` is used). Anything else (`INK0120` fallthrough, `INK0060`, `INK0050`, conformance failures) is a real defect — fix it. See `.../reference/verification.md` for the noise baseline.
+
+## Exit criteria
+
+`pnpm build` is clean (only expected notices), the export is registered, every prop has TSDoc, and the source mirrors the exemplar's structure. Hand off to `component-stories` and `component-test`.

--- a/.claude/skills/component-research/SKILL.md
+++ b/.claude/skills/component-research/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: component-research
+description: Phase 1 of building an Inkline component — design the API. Survey the WAI-ARIA pattern and prior art, then write a complete component spec (props, slots, events, variants, accessibility, styling plan) to .context/ for sign-off before any code. Use when starting a new component or redesigning an existing one's API.
+triggers:
+  - research a component
+  - spec a component
+  - design a component api
+  - plan a new component
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - WebSearch
+  - WebFetch
+  - Write
+  - AskUserQuestion
+---
+
+# Component research — design the API before any code
+
+The goal of this phase is a **spec good enough that implementation is mechanical**. A great component is decided here: the right anatomy, the best prop names, the exact accessibility contract. Produce a written spec, get it signed off, then hand it to `component-implement`.
+
+## Read first
+
+1. `.claude/skills/create-component/reference/conventions.md` — naming philosophy, the prop/variant vocabulary, the a11y baseline. **The prop-naming rules there are the bar.**
+2. The nearest exemplar to what you're building (badge = simplest, button = stateful, input = multi-part family) under `ui/components/src/components/`.
+
+## Steps
+
+1. **Pin the accessibility pattern.** Identify the WAI-ARIA Authoring Practices (APG) pattern for this widget (button, dialog, combobox, tabs, switch, tooltip, …). If unsure or it's non-trivial, `WebSearch` / `WebFetch` the APG page and extract: the required role(s), the states/properties, and the **full keyboard map**. Prefer a native element (`<button>`, `<input>`, `<dialog>`, `<a href>`) — note which native element gives you the pattern for free.
+
+2. **Survey prior art for the API surface.** Look at how mature libraries name things for this component — Radix UI, Ark UI, Headless UI / Reka, MUI — and the Inkline **v0** implementation in `.old/` (read-only reference; grep it for the component name). Capture the prop/variant names worth adopting and explicitly note what you reject and why. Goal: idiomatic, unsurprising names a senior engineer wouldn't second-guess.
+
+3. **Decide the anatomy.** One part or a family? List the headless parts and the single styled composition that ties them together (Input is the model: shell + control + prefix + suffix → one `IInput`). Each structural part = one `I<Name>*Base`.
+
+4. **Design the props.** Apply the naming philosophy from `conventions.md` literally:
+   - positive boolean state adjectives, no `is`/`has` prefix;
+   - the `color` / `variant` / `size` trio only with the values the recipe supports;
+   - native attribute names mirrored exactly;
+   - a `label` + default-slot fallback for simple content, named slots for structured content;
+   - two-way state as a `defineModel`, semantic unprefixed events.
+     The zero-config case should be the common case. Give every prop a one-line rationale.
+
+5. **Check the styling source.** `@styleframe/theme` ships a broad recipe catalog (Accordion, Alert, Avatar, Badge, Breadcrumb, Calendar, Callout, Card, …), so for most components a recipe **already exists** and you reuse it. Confirm whether `use<Name>Recipe` is exported:
+
+   ```bash
+   grep -rhoE "use[A-Z][A-Za-z]+Recipe\b" node_modules/.pnpm/@styleframe+theme@*/node_modules/@styleframe/theme/ | sort -u | grep -i "<name>"
+   ```
+
+   Record the answer — it decides the implement phase's styling branch: **reuse** `use<Name>Recipe(s)` if it exists (the common case), else **author styles locally** in `.styleframe.ts`. If the grep is inconclusive, default to "author locally" (safe) and note it for sign-off.
+
+6. **Write the spec** to `.context/component-<name>-spec.md` using the template below. Fill every section. Where a decision is genuinely open, list it under "Open questions" rather than guessing.
+
+7. **Gate.** Present the spec's headline decisions (anatomy, prop table, a11y contract, styling branch) and ask for sign-off. Use `AskUserQuestion` only for genuine forks; otherwise state assumptions and proceed. Do not start implementing from this skill.
+
+## Spec template
+
+```markdown
+# Component spec: I<Name>
+
+## Purpose
+
+<one paragraph: what it is, when a consumer reaches for it>
+
+## Prior art
+
+- APG pattern: <name + key requirements>
+- Libraries reviewed: <takeaways adopted / rejected, with reasons>
+
+## Anatomy
+
+<headless parts + the single styled composition; ASCII tree>
+
+## Props
+
+| Prop | Type | Default | Required | Rationale |
+| ---- | ---- | ------- | -------- | --------- |
+
+<every prop, including the color/variant/size trio if styled>
+
+## Slots
+
+| Slot | Purpose | Gated by hasSlot? |
+
+## Events & models
+
+- models: defineModel("<name>") → …
+- emits: <event>: [payload] — when it fires
+
+## Variants
+
+- color / variant / size: <only the supported value sets>
+- state: disabled / loading / invalid / … as applicable
+
+## Accessibility contract
+
+- Native element / role:
+- APG states & properties:
+- Keyboard map: <key → action>
+- Focus management:
+- Accessible name / labelling:
+
+## Styling plan
+
+- @styleframe/theme exports use<Name>Recipe? <yes/no — checked via grep>
+- Plan: <reuse theme recipe | author locally: selectors/recipe axes + :empty rules for gated addons>
+
+## Open questions
+
+<anything needing the user's call>
+```
+
+## Exit criteria
+
+`.context/component-<name>-spec.md` exists, every section filled, styling branch decided, and the user has signed off on the API. The spec is the contract the next four phases build against.

--- a/.claude/skills/component-stories/SKILL.md
+++ b/.claude/skills/component-stories/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: component-stories
+description: Phase 3 of building an Inkline component — author single-source Storybook stories. Write a defineStories meta with typed args/argTypes and per-variant render helpers as .ink.tsx; these compile to CSF3 for all 7 frameworks. Use when adding or improving the stories for a component.
+triggers:
+  - add stories for a component
+  - write storybook stories
+  - story the component
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+# Component stories — one source, seven frameworks
+
+Stories are authored once in `.ink.tsx` and the CLI generates CSF3 per framework into `ui/<framework>/.inkline/.../stories/` (generated — never hand-edit). Good stories double as living documentation and a manual a11y/visual check across targets.
+
+## Read first
+
+1. The spec at `.context/component-<name>-spec.md` — the variant matrices and prop list drive the stories.
+2. The exemplar `stories/` dir (`badge/stories/`, `button/stories/`) and `tooling/storybook/AGENTS.md`.
+3. The `defineStories` types in `tooling/storybook/src/define.ts` — `StoryMeta` is `{ component, title, args?, argTypes? }`; a variant is `{ args? }` or `{ render: "./X.ink.tsx" }`.
+
+## Steps
+
+### 1. Meta — `stories/I<Name>.ink.stories.ts`
+
+Use `defineStories<Props>()` with the styled component's props type. Set `component: "I<Name>"`, `title: "Components/<Name>"`, sensible default `args`, and an `argTypes` entry for **every meaningful prop** (control + options + description). Pull enum options straight from the spec/recipe.
+
+```ts
+import { defineStories } from "@inkline/storybook";
+import type { ButtonProps } from "../styled/IButton.ink.tsx";
+
+const meta = defineStories<ButtonProps>({
+  component: "IButton",
+  title: "Components/Button",
+  args: { label: "Button", disabled: false, loading: false, block: false },
+  argTypes: {
+    label: { control: "text", description: "Button text content" },
+    color: {
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "error",
+        "light",
+        "dark",
+        "neutral",
+      ],
+      description: "Color variant",
+    },
+    variant: {
+      control: "select",
+      options: ["solid", "outline", "soft", "subtle", "ghost", "link"],
+      description: "Style variant",
+    },
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "Size variant",
+    },
+    disabled: { control: "boolean", description: "Disabled state" },
+    loading: { control: "boolean", description: "Loading state with spinner" },
+  },
+});
+
+export default meta;
+```
+
+### 2. Variants
+
+Two kinds, both exported from the meta file:
+
+- **State variants** — args-driven, inline: `export const Default = {};`, `export const Disabled = { args: { disabled: true } };`, `export const Loading = { args: { loading: true } };`. Cover every meaningful state from the spec.
+- **Showcase variants** — a render-helper component: `export const Colors = { render: "./ButtonColors.ink.tsx" };`. Use these to show a whole axis at once (Colors, Variants, Sizes) or a composition example (e.g. Input with prefix/suffix).
+
+### 3. Render helpers — `stories/<Variant>.ink.tsx`
+
+A plain `defineComponent` returning the showcase wrapped in `<div id="story">`:
+
+```tsx
+import { defineComponent } from "@inkline/core";
+import IBadge from "../styled/IBadge.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IBadge color="primary">Primary</IBadge>
+      <IBadge color="secondary">Secondary</IBadge>
+      <IBadge color="success">Success</IBadge>
+      {/* …one per value in the axis… */}
+    </div>
+  );
+});
+```
+
+Author one per axis you want to showcase. For composition examples, set the props/slots that demonstrate the feature (e.g. `<IInput prefix={<>$</>} suffix={<>USD</>} />`).
+
+### 4. Verify
+
+`cd ui/components && pnpm build` regenerates CSF3 for every framework — it must succeed with no new errors. Then `pnpm run storybook` (repo root) and confirm the component and all variants render across the 7 frameworks. (Per-framework: `pnpm storybook:react`, etc.)
+
+## Exit criteria
+
+A `defineStories` meta with full `argTypes`, inline variants for every meaningful state, render-helper showcases for each variant axis, `pnpm build` regenerating cleanly, and Storybook rendering across targets.

--- a/.claude/skills/component-test/SKILL.md
+++ b/.claude/skills/component-test/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: component-test
+description: Phase 4 of building an Inkline component — write colocated cross-target tests. Assert compilation to all 7 targets, expected diagnostics, conformance, output composition/imports/bindings, snapshots, and real-DOM behavior via Angular SSR. Targets ~100% line+branch coverage. Use when adding or strengthening a component's tests.
+triggers:
+  - test a component
+  - add tests for the component
+  - write component tests
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+# Component tests — compile, conform, snapshot, render
+
+Tests are colocated as `<file>.ink.test.ts` (Vitest), next to the source they cover: the headless test in `headless/`, the styled test in `styled/`. They run the real compiler in-memory via `@inkline/test-utils` and assert across all 7 targets, plus real-DOM behavior on Angular SSR. Aim for **~100% line+branch** on the component's own code.
+
+## Read first
+
+1. The **actual** `@inkline/test-utils` exports — `tooling/test-utils/src/index.ts` (the prose `runScenarioAcrossTargets` is gone). Available: `compileComponent`, `expectCompilationSuccess`, `expectNoDiagnostics`, `expectDiagnostics`, `expectCorrectFileExtensions`, `expectOutputContains`, `expectOutputNotContains`, `expectImports`, `assertConformance`, `snapshotOutput`, `resolveComponent`, plus types `ComponentTestResult`, `TargetName`.
+2. The exemplar tests: `button/headless/IButtonBase.ink.test.ts` (simple) and `input/styled/IInput.ink.test.ts` (comprehensive + Angular SSR).
+3. `ui/components/src/components/angular-ssr-helper.ts` — `mountStyledOnAngular(importMetaUrl, styledRel, headlessRels, props?)`.
+4. `.../reference/primitives.md` — the per-target lowering table and expected notices.
+
+## Headless test — the baseline every component clears
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const BADGE = resolveComponent(import.meta.url, "./IBadgeBase.ink.tsx");
+
+describe("Badge", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(BADGE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(BADGE));
+  });
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(BADGE));
+  });
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(BADGE));
+  });
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(BADGE))).toMatchSnapshot();
+  });
+});
+```
+
+If the component uses two-way binding or `hasSlot` gating, replace `expectNoDiagnostics` with an **explicit expected-notice** assertion:
+
+```ts
+it("emits only the expected notices (Astro two-way INK0045, Qwik/Angular hasSlot INK0068)", async () => {
+  const result = await compileComponent(COMPONENT);
+  const unexpected = result.diagnostics.filter((d) => d.code !== "INK0045" && d.code !== "INK0068");
+  expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+  expect(result.diagnostics.filter((d) => d.code === "INK0068")).toHaveLength(2); // Qwik + Angular
+});
+```
+
+## Styled test — add composition, imports, bindings, real DOM
+
+On top of the baseline, assert what the styled layer is responsible for. Use a small helper `const out = (r, t) => r.files[t] ?? [];`.
+
+- **Composition** — every headless part appears in the output: `expectOutputContains(out(result, target), "IInputControlBase")` across targets.
+- **Recipe imports** — `expectImports(out(result, "react"), "virtual:styleframe", ["inputRecipe", "inputPrefixRecipe", "inputSuffixRecipe"])`.
+- **Slot gating per target** — `props.prefix != null` (React/Solid), `!!$slots.prefix` (Vue), `{props.prefix}` (Qwik), `select="[slot=prefix]"` (Angular).
+- **Two-way binding per target** — `onUpdateValue` (React), `v-model:value="value"` (Vue), `bind:value={value}` (Svelte), `(valueChange)=` (Angular).
+- **Snapshot** — `expect(snapshotOutput(result)).toMatchSnapshot()`.
+
+### Real-DOM behavior — Angular SSR
+
+The strongest assertion: render the composed component and check actual HTML. List the headless parts, then assert classes, native attribute reflection, ARIA, content projection (via `__slots`), and state. Remember Angular **sorts recipe class keys alphabetically**.
+
+```ts
+import { mountStyledOnAngular } from "../../angular-ssr-helper.ts";
+
+describe("IInput (styled) on Angular SSR", () => {
+  const HEADLESS = [
+    "../headless/IInputBase.ink.tsx",
+    "../headless/IInputPrefixBase.ink.tsx",
+    "../headless/IInputSuffixBase.ink.tsx",
+    "../headless/IInputControlBase.ink.tsx",
+  ];
+  const mount = (props?: Record<string, unknown>) =>
+    mountStyledOnAngular(import.meta.url, "./IInput.ink.tsx", HEADLESS, props);
+
+  it("renders the shell with recipe classes + the native control", async () => {
+    const { html } = await mount({
+      placeholder: "Amount",
+      name: "amount",
+      size: "md",
+      color: "light",
+    });
+    expect(html).toMatch(/<div[^>]*class="input input--color-light input--size-md"/);
+    expect(html).toMatch(/<input[^>]*class="input-field"/);
+  });
+
+  it("projects slot content", async () => {
+    const { html } = await mount({ __slots: { prefix: "$", suffix: "USD" } });
+    expect(html).toMatch(/<span[^>]*class="input-prefix[^"]*">\$<\/span>/);
+  });
+
+  it("reflects disabled onto the native control", async () => {
+    expect((await mount({ disabled: true })).html).toMatch(/<input[^>]*disabled/);
+  });
+});
+```
+
+## Coverage — exercise every branch
+
+Drive ~100% line+branch on the component's executable code: every variant axis, every boolean state, every `<Show>`/`<For>`/slot branch, the `?? ""` fallbacks, and the `<textarea>`-style alternate branches. Add cases until coverage is full.
+
+## Verify
+
+`cd ui/components && vp test` green, then `vp test --coverage` and confirm ~100% line+branch on the new files. Report the coverage numbers. On the first run, review the new snapshot before committing it.
+
+## Exit criteria
+
+Headless + styled tests pass; expected notices asserted explicitly; composition/imports/bindings/real-DOM covered; coverage ~100% line+branch with the report shown.

--- a/.claude/skills/create-component/SKILL.md
+++ b/.claude/skills/create-component/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: create-component
+description: Build a new Inkline component end-to-end — research the API, implement the headless + styled .ink.tsx source, add Storybook stories, write cross-target tests, and finalize docs/changeset. Runs five phases in order with an approval gate and a commit after each. Use when the user wants to add a brand-new component (or take one through the full pipeline).
+triggers:
+  - create a component
+  - new component
+  - build a component
+  - add a component
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+  - WebSearch
+  - WebFetch
+---
+
+# create-component — the full component pipeline
+
+Take a component from idea to release-ready across all 7 Inkline frameworks. This skill **orchestrates** five focused phase skills; it does not duplicate their detail. For each phase you **Read that phase's `SKILL.md` and execute its steps at full depth**, then stop at the gate.
+
+Each phase skill is also invocable on its own (e.g. `/component-stories` to add stories to an existing component). This orchestrator is for building a new one start-to-finish.
+
+## Working agreement (applies to every phase)
+
+- **Approval gate between phases.** Finish a phase, present the result, and **wait for an explicit green-light** before starting the next. Never run the whole pipeline unattended.
+- **Commit after each phase that produces committable files**, with a conventional-commit message scoped `components`. **Never push.** (If the current branch is `main`, create a feature branch first.)
+- **~100% test coverage** by the test phase, with the coverage report shown at that gate.
+- Tooling is **Vite+ / OXLint / Oxfmt** (`vp …`), never ESLint/Prettier. Tests are colocated `<file>.ink.test.ts`.
+- **Never hand-edit** generated output (`ui/<framework>/.inkline/`, `.styleframe/`) or `.old/`. Author only in `ui/components/src/`.
+- **Anchor on live source, not prose.** The exemplars (`badge`/`button`/`input`) and `inkline.config.ts` are canonical; `docs/authoring-components.md` has drifted.
+
+## Phases
+
+| #   | Phase     | Skill file                                    | Output                                        | Commit on pass                          |
+| --- | --------- | --------------------------------------------- | --------------------------------------------- | --------------------------------------- |
+| 1   | Research  | `.claude/skills/component-research/SKILL.md`  | `.context/component-<name>-spec.md`           | — (spec is gitignored)                  |
+| 2   | Implement | `.claude/skills/component-implement/SKILL.md` | headless + styled + `.styleframe.ts` + export | `feat(components): add I<Name>`         |
+| 3   | Stories   | `.claude/skills/component-stories/SKILL.md`   | `defineStories` meta + render helpers         | `feat(components): add I<Name> stories` |
+| 4   | Test      | `.claude/skills/component-test/SKILL.md`      | colocated `.ink.test.ts` (+ Angular SSR)      | `test(components): cover I<Name>`       |
+| 5   | Document  | `.claude/skills/component-document/SKILL.md`  | TSDoc pass + changeset + freshness            | `docs(components): document I<Name>`    |
+
+Shared reference (each phase skill points into these; read them when a phase tells you to):
+`create-component/reference/{conventions,primitives,verification}.md`.
+
+## Run loop
+
+For each phase 1 → 5:
+
+1. **Read** the phase's `SKILL.md` (path above) and follow it top-to-bottom at full depth. Use its "Read first" list and run its verification.
+2. **Present** the phase output: phase 1 → the spec's headline decisions (anatomy, prop table, a11y contract, styling branch); phases 2–5 → the diff plus the verification result (compile notices / Storybook / coverage / `vp run ready`).
+3. **Gate** — wait for the user's go-ahead. Use `AskUserQuestion` only for genuine design forks; otherwise state assumptions and pause for approval.
+4. On approval, **commit** the phase's files (table above), then continue to the next phase.
+
+Phase 1 is the most important gate: do not write any component code until the API spec is signed off.
+
+## On completion
+
+Report: the files added, the per-phase commits (and that nothing was pushed), the final `vp run ready` result, the coverage numbers, and the changeset created. Note that the public docs-website page is staged but pending (the site isn't built yet — see the document phase).

--- a/.claude/skills/create-component/reference/conventions.md
+++ b/.claude/skills/create-component/reference/conventions.md
@@ -1,0 +1,96 @@
+# Inkline component conventions (source-anchored)
+
+This is the distilled, **current** practice for authoring `@inkline/components`. The prose in `docs/authoring-components.md` has drifted (it still shows lowercase `<slot>`, `badge(props)`, and a `runScenarioAcrossTargets` test helper that no longer exists). **When in doubt, the live source wins.** Open the nearest exemplar and mirror it:
+
+| Exemplar   | Path                                   | What it teaches                                                                                                                                          |
+| ---------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Badge**  | `ui/components/src/components/badge/`  | The canonical single-part pattern — copy this for a simple component.                                                                                    |
+| **Button** | `ui/components/src/components/button/` | Conditional render (`<Show>`), state→ARIA, custom styleframe rules + keyframes, a `block` layout flag.                                                   |
+| **Input**  | `ui/components/src/components/input/`  | A family: 4 headless parts composed by **one** styled component, named slots gated by `hasSlot`, two-way `value` via `defineModel`, `<textarea>` branch. |
+
+## Directory layout
+
+```
+ui/components/src/components/<name>/
+├── headless/
+│   ├── I<Name>Base.ink.tsx        # behavior, structure, slots, events, a11y — NO styling
+│   └── I<Name>Base.ink.test.ts    # colocated test (compile/conformance/snapshot)
+├── styled/
+│   ├── I<Name>.ink.tsx            # composes headless part(s) + applies styleframe recipe classes
+│   ├── I<Name>.styleframe.ts      # registers the recipe(s) + any custom CSS for this family
+│   └── I<Name>.ink.test.ts        # colocated test (+ Angular-SSR real-DOM assertions)
+└── stories/
+    ├── I<Name>.ink.stories.ts     # defineStories meta + variants
+    └── <Variant>.ink.tsx          # render-helper showcases (Colors, Sizes, …)
+```
+
+- Files are `.ink.tsx` (components/stories) and `.ink.test.ts` (tests), colocated. **Never** a separate `tests/` folder.
+- Tests sit next to the file they cover: the headless test in `headless/`, the styled test in `styled/`.
+- Compiled output lands per `targetOutDir` in `ui/components/inkline.config.ts` — **currently `ui/<framework>/.inkline/`** (the AGENTS.md/CLAUDE.md prose saying `generated/` is stale; read the config). That directory and `ui/<framework>/.styleframe/` are generated — **never hand-edit**. Same for `.old/` (archived v0, read-only reference only).
+
+## Headless / styled split
+
+Every component ships in two layers:
+
+- **Headless** (`I<Name>Base`) — structure, slots, props, events, accessibility. No design tokens, no styleframe class names. These are the testable, themable behavioral primitives consumers swap in if they ship their own styling.
+- **Styled** (`I<Name>`) — composes the headless part(s) and applies `styleframe`-generated classes from `virtual:styleframe`. This is what `@inkline/{react,vue,…}` consumers import by default.
+
+**One styled component per _family_, not per part.** When a component has multiple structural parts (shell, control, addons), author one headless part each, then compose them all in a **single** styled component. Input is the model: `headless/IInput*Base` × 4 → one `styled/IInput.ink.tsx`.
+
+## Naming
+
+- **Component**: PascalCase, `I` prefix. Headless adds `Base`: `IButton` / `IButtonBase`, `IInputControl` / `IInputControlBase`.
+- **Props interface**: `<Name>Props` (styled) / `<Name>BaseProps` (headless). The styled interface `extends` the base + the recipe's styling props: `interface BadgeProps extends BadgeBaseProps, BadgeStylingProps {}`.
+- **Recipe**: `<name>Recipe` (e.g. `badgeRecipe`), registered and re-exported from `I<Name>.styleframe.ts`.
+
+## Prop-naming philosophy — design the API from the consumer's side first
+
+The bar is "the most common usage needs zero props, and every prop reads like plain English." Rules:
+
+- **Booleans are positive state adjectives, no `is`/`has`/`should` prefix**: `disabled`, `loading`, `readonly`, `invalid`, `required`, `clearable`, `rounded`, `block`. (Keep the HTML-native sense — use `disabled`, not `enabled`.)
+- **The canonical visual trio is `color` / `variant` / `size`**, named to match the styleframe recipe parameters exactly, with the standard design-system vocabulary:
+  - `color`: `primary` `secondary` `success` `info` `warning` `error` `light` `dark` `neutral`
+  - `variant`: `solid` `outline` `soft` `subtle` `ghost` `link`
+  - `size`: `xs` `sm` `md` `lg` `xl`
+  - Only expose the values the recipe actually supports. Don't invent a fourth axis unless the design system has one.
+- **Mirror native attribute names exactly** for anything the platform already names: `type`, `name`, `id`, `placeholder`, `value`, `min`, `max`, `step`, `href`, `target`. Never rename them (`class`, not `className`).
+- **Content**: a single `label?: string` prop for simple text (with a default `<Slot>` fallback so richer content can override it). Named slots for structured content (`prefix`, `suffix`, `icon`).
+- **Two-way state** is a model: `const [value, setValue] = defineModel<string>("value")`; consumers bind `$bind:value`. Name additional models for their meaning (`defineModel<boolean>("open")`).
+- **Events** are semantic and unprefixed (the compiler maps to each target's idiom): `change`, `input`, `clear`, `open`, `close`. The model's paired event is `update:value` (emitted by `defineModel`'s setter). Type payloads: `defineEmits<{ change: [value: string] }>()`.
+- **Avoid**: abbreviations (`btn`, `lbl`), redundant prefixes (`buttonColor` → `color`), and props that exist only to pass through to one framework.
+- Give every optional prop a sensible default applied with `??` so the zero-config case is the common case.
+
+Document **every** prop with a one-line TSDoc comment (`/** Disables the control. */`) — `IInput`'s interfaces are the bar.
+
+## Accessibility baseline (every component clears this)
+
+- **Reach for a native semantic element first** (`<button>`, `<input>`, `<a href>`, `<nav>`, `<dialog>`, `<label>`). Native gives you role, keyboard operability, and focus for free. Use `<div role="…">` only when no native element fits.
+- When a native element doesn't fit, **follow the WAI-ARIA Authoring Practices (APG) pattern** for that widget — its required roles, states, properties, and keyboard map. (The research phase pins the exact pattern.)
+- **Reflect state in ARIA**: `disabled`/`aria-disabled`, `aria-busy` (loading), `aria-invalid` (invalid), plus widget states where they apply (`aria-expanded`, `aria-selected`, `aria-checked`, `aria-pressed`, `aria-current`).
+- **Hide decorative nodes** from the a11y tree: `aria-hidden="true"` on spinners and icons that merely duplicate adjacent text.
+- **Accessible name**: every interactive control has one — a visible `<label for>`/`id`, `aria-label`, or `aria-labelledby`. Icon-only controls require `aria-label`.
+- **Keyboard + focus**: all interactions operable by keyboard per the APG key bindings (Enter/Space to activate, arrows for composite widgets, Escape to dismiss). Preserve a visible focus indicator; never strip the outline without a replacement. Logical tab order; manage focus for overlays/menus.
+- **Motion**: gate animations behind `prefers-reduced-motion` in the styleframe layer.
+
+## Attribute fallthrough (how styled reaches headless)
+
+The styled→headless composition relies on **attribute fallthrough**: a parent's `class` is _merged_ onto the child's single root element, and every other non-prop attribute (`id`, `aria-*`, `data-*`, handlers) is spread onto it. That's how `<IBadgeBase class={badgeRecipe(...)}>` lands the recipe class on the headless `<div class="badge">`.
+
+Fallthrough requires a **single host-element (or single component-instance) root**. A component whose root is a fragment, a control-flow block, or multiple siblings cannot inherit attributes — passing a `class` to it emits **`INK0120`**. Keep headless roots single-element. (Angular applies the inherited `class` to the host element/selector, not the inner template root — style with `:host` if needed.)
+
+## Registration
+
+Re-export the new component from `ui/components/src/components/index.ts` so the compile step picks it up. Export the styled component and every headless part:
+
+```ts
+export { default as IBadge } from "./badge/styled/IBadge.ink.tsx";
+export { default as IBadgeBase } from "./badge/headless/IBadgeBase.ink.tsx";
+```
+
+The per-framework barrels (`index.ts`, `headless.ts`, `stories.ts`) are generated from `inkline.config.ts` → `barrels` — do not write them by hand.
+
+## Canonical references
+
+- `ui/components/AGENTS.md` — package rules (note the `generated/` path is stale; trust `inkline.config.ts`).
+- `core/compiler/README.md` — the full `.ink.tsx` language reference (primitives, control flow, slots).
+- `core/compiler/src/core/diagnostics/codes.ts` — the authoritative diagnostic-code table.

--- a/.claude/skills/create-component/reference/primitives.md
+++ b/.claude/skills/create-component/reference/primitives.md
@@ -1,0 +1,49 @@
+# `@inkline/core` primitives & per-target gotchas
+
+Everything here is **authoring-time only** — the compiler removes it from emitted output, and no `@inkline/core` runtime dependency ships to consumers. The canonical language reference is `core/compiler/README.md`; this is the working subset for component authoring.
+
+## Primitives
+
+| Need                   | Primitive                                                     | Notes                                                                                                                                                                |
+| ---------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Declare a component    | `defineComponent(setup)` or `defineComponent(options, setup)` | Sole entry point. Use the options form to declare `slots` / `events`. Props are typed via the setup parameter: `(props: FooProps) => …`.                             |
+| Reactive state         | `createSignal(initial)` → `[get, set]`                        | Call `get()` to read, `set(v)` to write.                                                                                                                             |
+| Two-way model          | `defineModel<T>("value")` → `[get, set]`                      | Adds a `value` prop **and** a paired `update:value` event. Consumers bind `$bind:value`. Name extra models (`defineModel<boolean>("open")`).                         |
+| Custom events          | `defineEmits<{ change: [value: string] }>()` → `emit`         | `emit("change", v)` maps to each target's event channel. Names are semantic, unprefixed.                                                                             |
+| Derived value          | `createMemo(() => expr)`                                      | Use for computed class names: `createMemo(() => recipe({ … }))`.                                                                                                     |
+| Side effect            | `createEffect(() => { … })`                                   | Re-runs when tracked deps change; return a cleanup fn.                                                                                                               |
+| Element ref            | `createRef()` → `{ current }`                                 | DOM-element refs only. **Component refs are deferred (`INK0070`).**                                                                                                  |
+| Lifecycle              | `onMount(fn)`, `onCleanup(fn)`                                |                                                                                                                                                                      |
+| Default / named slot   | `<Slot>` (capital, from `@inkline/core`)                      | `<Slot>{props.label}</Slot>` for default with fallback; `<Slot name="prefix" />` for named. Declare every slot in options: `{ slots: { default: {}, prefix: {} } }`. |
+| Slot presence          | `hasSlot("prefix")`                                           | Gate optional wrappers: `<Show when={hasSlot("prefix")}>…</Show>`. See per-target note below.                                                                        |
+| Conditional            | `<Show when={cond} fallback={…}>`                             | `when` is **required** (`INK0060` if missing).                                                                                                                       |
+| List                   | `<For each={items} key={…}>{(item) => …}</For>`               | Always pass `key` (`INK0050` warning if missing).                                                                                                                    |
+| Switch / match         | `<Switch><Match when={…}>…</Match></Switch>`                  |                                                                                                                                                                      |
+| Conditional transition | `<Transition name="…" appear?>`                               | Must wrap a **single** conditional element (not `<For>`, not multiple children).                                                                                     |
+
+## Control-flow & authoring gotchas (with diagnostic codes)
+
+- `<Show>` **must** have `when` → hard error **`INK0060`**.
+- `<For>` **must** have `key` → warning **`INK0050`**.
+- `<Transition>` wraps exactly one conditional element → `INK0065`-style error otherwise.
+- Component refs are not supported yet → **`INK0070`**.
+- **Dynamic reactive reads** like `obj[key()]` defeat static dependency tracking → **`INK0020`**. Prefer destructuring or a computed signal.
+- A component that needs to inherit a `class` must have a **single host-element root** → **`INK0120`** otherwise (see conventions → attribute fallthrough).
+
+## Per-target gotchas (these are the ones that bite)
+
+- **Solid coerces `undefined` → the string `"undefined"`** when binding an optional string to a native prop. Coalesce: `value={value() ?? ""}`, `placeholder={props.placeholder ?? ""}`. Always do this for optional-string → native-attribute bindings.
+- **Astro is static SSR** — two-way binding (`defineModel` / `$bind`) lowers to a one-way value and emits the info notice **`INK0045`** (one per two-way binding). This is expected, not an error.
+- **Qwik & Angular have no runtime slot-presence API** — `hasSlot("x")` is `true` there, so a `<Show when={hasSlot("x")}>` wrapper is emitted unconditionally and must be collapsed with a CSS `:empty` rule in the `.styleframe.ts`. The compiler emits the info notice **`INK0068`** once per such target (so a single gated component → **2** `INK0068` notices: Qwik + Angular).
+
+These three notices (`INK0045`, `INK0068`) are **expected** for components that use two-way binding or `hasSlot` gating. Tests assert them explicitly rather than treating them as failures (see the `component-test` skill).
+
+## How bindings & slots lower per target (useful for test assertions)
+
+| Concern               | React / Solid             | Vue                 | Svelte        | Angular                     | Qwik                        |
+| --------------------- | ------------------------- | ------------------- | ------------- | --------------------------- | --------------------------- |
+| Two-way `value`       | `value` + `onUpdateValue` | `v-model:value`     | `bind:value`  | `[value]` + `(valueChange)` | `value` + `onUpdateValue$`  |
+| Slot presence         | `props.x != null`         | `!!$slots.x` (v-if) | `$$slots.x`   | always-render + `:empty`    | always-render (`{props.x}`) |
+| Named slot projection | render-prop / children    | `<slot name>`       | `<slot name>` | `select="[slot=x]"`         | prop read                   |
+
+The authoritative diagnostic-code table is `core/compiler/src/core/diagnostics/codes.ts`. If a code here ever disagrees with that file, that file wins.

--- a/.claude/skills/create-component/reference/verification.md
+++ b/.claude/skills/create-component/reference/verification.md
@@ -1,0 +1,32 @@
+# Verification commands & known-noise caveats
+
+The toolchain is **Vite+ (`vp`)** — OXLint for lint, Oxfmt for format, Vitest for tests. **Never** ESLint or Prettier. Run package-scoped commands from `ui/components/` unless noted.
+
+## The command ladder
+
+| Goal                                           | Command                                          | Where                                   |
+| ---------------------------------------------- | ------------------------------------------------ | --------------------------------------- |
+| Compile `.ink.tsx` → all 7 targets (+ stories) | `pnpm build` (= `vp build && inkline compile …`) | `ui/components/`                        |
+| Recompile on change                            | `pnpm dev` (= `inkline compile … --watch`)       | `ui/components/`                        |
+| Run unit tests                                 | `vp test`                                        | `ui/components/` (or repo root for all) |
+| Tests with coverage                            | `vp test --coverage`                             | `ui/components/`                        |
+| Format + lint + typecheck                      | `vp check` (add `--fix` to autofix)              | repo root                               |
+| Format only / lint only                        | `vp fmt` / `vp lint`                             | repo root                               |
+| Full CI gate (build + check + test)            | `vp run ready`                                   | repo root                               |
+| All 7 framework Storybooks side-by-side        | `pnpm run storybook`                             | repo root                               |
+
+`pnpm build` runs `vp build` (compiles styleframe artifacts) first, then `inkline compile` (emits every target into `ui/<framework>/.inkline/` per `inkline.config.ts`) and regenerates per-framework CSF3 stories. A component's behavior is verified primarily by **`vp test`** (which compiles in-memory via `@inkline/test-utils`) — you do not need a full `pnpm build` to run tests, but you do need it before Storybook reflects source changes.
+
+## Known noise — do NOT chase these
+
+- **`vp check` reports ~290 pre-existing `TS17004` errors on `.ink.tsx` fixtures.** This is a standing baseline, not something your change introduced. **Trust `vp test`** for whether the component is correct; don't try to "fix" these.
+- **Expected compiler notices** for components using two-way binding or `hasSlot` gating: `INK0045` (Astro two-way, one per binding) and `INK0068` (Qwik + Angular `hasSlot`, exactly 2). Tests assert these explicitly. Anything else in `result.diagnostics` is a real problem.
+- **Compiler-internal edits** (changing codegen in `core/compiler`) require `vp pack` in `core/compiler` before `inkline compile` / Storybook reflect them. **Not relevant when only authoring a component** — only if you also touched the compiler.
+- **Angular SSR sorts recipe class keys alphabetically**, so real-DOM test regexes must expect the sorted order (e.g. `class="input input--color-light input--size-md"`).
+
+## What "verified" means per phase
+
+- **implement**: `pnpm build` emits all 7 targets with only the expected notices (`INK0045`/`INK0068`); no `INK0120`/`INK0060`/`INK0050` etc.
+- **stories**: `pnpm build` regenerates CSF3 without error; `pnpm run storybook` renders the component across targets.
+- **test**: `vp test` green; `vp test --coverage` shows ~100% line+branch on the component's own executable code.
+- **final gate**: `vp run ready` green (build + check + test). Remember the `TS17004` fixture baseline when reading `check` output.


### PR DESCRIPTION
## Summary

This pull request adds comprehensive skill documentation for each phase of the Inkline component development workflow. The new skill files provide detailed, step-by-step guides for researching, implementing, documenting, and storying components, ensuring a consistent and high-quality process across the team.

**Component Development Workflow Documentation:**

*Skill documentation for each phase:*

- **Component Research:**  
  Introduces a skill file detailing how to design a component API, including accessibility research, prior art survey, anatomy and prop design, and spec writing for sign-off before implementation. (.claude/skills/component-research/SKILL.md)

- **Component Implementation:**  
  Provides a skill file guiding the implementation phase, covering authoring headless and styled components, styleframe integration, export registration, and verification for all framework targets. (.claude/skills/component-implement/SKILL.md)

- **Component Documentation & Release Prep:**  
  Adds a skill file for finalizing documentation and preparing a component for release, including TSDoc completion, changeset creation, export verification, and staging docs-site content. (.claude/skills/component-document/SKILL.md)

- **Component Stories:**  
  Introduces a skill file for writing single-source Storybook stories, including meta definition, variant creation, render helpers, and verification across all frameworks. (.claude/skills/component-stories/SKILL.md)


## Type of change

<!-- Check all that apply; this should match your commit's conventional type. -->

- [ ] `feat` — new user-facing capability or public API
- [ ] `fix` — bug fix
- [ ] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `chore` / `ci` — tooling, dependencies, or CI

## Test plan

<!-- Bulleted checklist. Include vp run ready, manual checks, etc. -->

- [ ] `vp run ready` passes locally
- [ ] <!-- add manual or framework-specific checks -->

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [ ] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".
