### PR TITLE
feat(components): add IHamburgerMenu + fix React model memo/effect deps

### DIFF
--- a/.changeset/add-hamburger-menu.md
+++ b/.changeset/add-hamburger-menu.md
@@ -1,0 +1,20 @@
+---
+"@inkline/react": minor
+"@inkline/vue": minor
+"@inkline/svelte": minor
+"@inkline/solid": minor
+"@inkline/angular": minor
+"@inkline/qwik": minor
+"@inkline/astro": minor
+---
+
+feat(components): add HamburgerMenu component
+
+Add `IHamburgerMenu` (and its headless `IHamburgerMenuBase`), an accessible animated three-line
+toggle button styled with the Styleframe `hamburger-menu` recipe. It follows the WAI-ARIA
+**Disclosure** pattern on a native `<button>`: a two-way `open` model drives `aria-expanded` and the
+recipe's `active` morph, while the consumer renders and links their own navigation region via
+`ariaControls`. Supports `color` (`light` / `dark` / `neutral`), `size` (`sm` / `md` / `lg`), and an
+`animation` axis (`close` / `arrow-up` / `arrow-down` / `arrow-left` / `arrow-right` / `minus` /
+`plus`) for the open-state shape. The icon-only control carries a defaulted `ariaLabel`
+(`"Toggle menu"`) so every instance has an accessible name out of the box.

--- a/.changeset/react-model-memo-deps.md
+++ b/.changeset/react-model-memo-deps.md
@@ -1,0 +1,13 @@
+---
+"@inkline/compiler": patch
+"@inkline/react": patch
+---
+
+fix(react): reference `props.<name>` for model getters in `useMemo`/`useEffect` deps
+
+A `createMemo`/`createEffect` that read a `defineModel` getter emitted the getter's bare local name in
+the React dependency array (e.g. `[open]`) while the body was rewritten to `props.open`. Since the
+props destructuring is emitted after the memo, the bare name hit the temporal dead zone — a runtime
+`ReferenceError: Cannot access 'open' before initialization`. Model-getter dependencies now render as
+their prop read (`props.open`), matching the body; signal locals stay bare (`useState`) and prop reads
+are unchanged.

--- a/core/compiler/src/__fixtures__/MemoModel.ink.tsx
+++ b/core/compiler/src/__fixtures__/MemoModel.ink.tsx
@@ -1,0 +1,10 @@
+import { defineComponent, defineModel, createMemo } from "@inkline/core";
+
+// A `createMemo` that reads a `defineModel` getter. On React the memo body and the `useMemo` deps
+// array must both reference the model prop (`props.open`); a bare `open` in the deps array is a
+// temporal-dead-zone ReferenceError (the props destructuring is emitted after the memo).
+export default defineComponent(() => {
+  const [open, setOpen] = defineModel<boolean>("open");
+  const label = createMemo(() => (open() ? "Open" : "Closed"));
+  return <button onClick={() => setOpen(!open())}>{label()}</button>;
+});

--- a/core/compiler/src/codegen/targets/react/__tests__/reactivity.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/reactivity.test.ts
@@ -52,3 +52,15 @@ describe("LateSignal: memo declared before the signal it reads", () => {
     expect(out).toContain("const doubled = useMemo(() => count * 2, [count])");
   });
 });
+
+describe("MemoModel: memo reading a defineModel getter", () => {
+  it("React: useMemo deps reference props.<name>, not a temporal-dead-zone bare local", async () => {
+    const out = await compileTo("MemoModel", "react");
+    // Body and deps must agree on `props.open`; a bare `open` in the deps array references the
+    // props destructuring emitted *after* the memo → ReferenceError at runtime.
+    expect(out).toContain(
+      'const label = useMemo(() => (props.open ? "Open" : "Closed"), [props.open])',
+    );
+    expect(out).not.toContain(", [open])");
+  });
+});

--- a/core/compiler/src/codegen/targets/react/index.ts
+++ b/core/compiler/src/codegen/targets/react/index.ts
@@ -375,15 +375,24 @@ function inlineNode(node: IRNode, rules: RewriteRules): string {
   return inlineCode(emitNode(node, rules));
 }
 
-function depRef(d: { readonly name: string; readonly path: readonly string[] }): string {
-  return d.path.length > 0 ? `${d.name}.${d.path.join(".")}` : d.name;
+function depRef(
+  d: { readonly name: string; readonly path: readonly string[] },
+  modelReads?: ReadonlyMap<string, string>,
+): string {
+  // A model getter dep is `{ name: "<getter>", path: [] }` (models are minted as signals), so map it
+  // to the same prop read the body uses (`props.<prop>`); otherwise the deps array would reference a
+  // bare local declared by the later props destructuring — a temporal-dead-zone ReferenceError.
+  // Signals stay bare (they're `useState` locals) and props stay `props.x` (no modelReads entry).
+  const root = modelReads?.get(d.name) ?? d.name;
+  return d.path.length > 0 ? `${root}.${d.path.join(".")}` : root;
 }
 
 function depsList(
   deps: readonly { readonly name: string; readonly path: readonly string[] }[],
+  modelReads?: ReadonlyMap<string, string>,
 ): string {
   // Dedupe: the same reactive value may be read more than once in the body.
-  const refs = [...new Set(deps.map(depRef))];
+  const refs = [...new Set(deps.map((d) => depRef(d, modelReads)))];
   return `[${refs.join(", ")}]`;
 }
 
@@ -560,7 +569,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     reactImports.push("useMemo");
     body.push(
       cStmt({
-        body: `const ${m.name} = useMemo(() => ${rewriteExpr(m.expr.expr, rules)}, ${depsList(m.expr.deps)})`,
+        body: `const ${m.name} = useMemo(() => ${rewriteExpr(m.expr.expr, rules)}, ${depsList(m.expr.deps, rules.modelReads)})`,
         span: m.loc,
       }),
     );
@@ -568,7 +577,10 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   for (const e of component.effects) {
     reactImports.push("useEffect");
     body.push(
-      cStmt({ body: `useEffect(${rewriteExpr(e.body, rules)}, ${depsList(e.deps)})`, span: e.loc }),
+      cStmt({
+        body: `useEffect(${rewriteExpr(e.body, rules)}, ${depsList(e.deps, rules.modelReads)})`,
+        span: e.loc,
+      }),
     );
   }
   for (const res of component.resources) {

--- a/ui/components/src/components/hamburger-menu/headless/IHamburgerMenuBase.ink.test.ts
+++ b/ui/components/src/components/hamburger-menu/headless/IHamburgerMenuBase.ink.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const HAMBURGER = resolveComponent(import.meta.url, "./IHamburgerMenuBase.ink.tsx");
+
+describe("HamburgerMenuBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(HAMBURGER);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("emits only the expected Astro two-way notice (INK0045)", async () => {
+    // The `open` model is two-way; on the static Astro target it lowers to a one-way value and emits
+    // an info notice (INK0045). There are no slots, so no INK0068. Every other target is clean.
+    const result = await compileComponent(HAMBURGER);
+    const unexpected = result.diagnostics.filter((d) => d.code !== "INK0045");
+    expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+    expect(result.diagnostics.filter((d) => d.code === "INK0068")).toHaveLength(0);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(HAMBURGER));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(HAMBURGER));
+  });
+
+  it("renders a native button with the disclosure ARIA contract and decorative bars", async () => {
+    const result = await compileComponent(HAMBURGER);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      const files = result.files[target] ?? [];
+      expectOutputContains(files, "hamburger-menu-inner");
+      expectOutputContains(files, "aria-expanded");
+    }
+  });
+
+  it('Solid coalesces the optional ARIA strings so unset props never render "undefined"', async () => {
+    // Solid's runtime assigns optional string bindings with no nullish guard, so the binding coalesces
+    // to a string. (React/Vue drop nullish bindings; the coalesce is harmless there.)
+    const result = await compileComponent(HAMBURGER);
+    expectOutputContains(result.files.solid ?? [], 'aria-controls={props.ariaControls ?? ""}');
+    expectOutputContains(result.files.solid ?? [], 'aria-label={props.ariaLabel ?? "Toggle menu"}');
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(HAMBURGER))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/hamburger-menu/headless/IHamburgerMenuBase.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/headless/IHamburgerMenuBase.ink.tsx
@@ -1,0 +1,29 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+export interface HamburgerMenuBaseProps {
+  /** Accessible name for the icon-only toggle; sets `aria-label`. */
+  ariaLabel?: string;
+  /** Id of the region the toggle shows/hides; sets `aria-controls`. */
+  ariaControls?: string;
+  /** Disables the toggle. */
+  disabled?: boolean;
+}
+
+export default defineComponent((props: HamburgerMenuBaseProps) => {
+  // Two-way disclosure state: an `open` prop + paired `update:open` event, so a parent can `$bind:open`.
+  const [open, setOpen] = defineModel<boolean>("open");
+
+  return (
+    <button
+      class="hamburger-menu"
+      type="button"
+      aria-expanded={open() ? "true" : "false"}
+      aria-controls={props.ariaControls ?? ""}
+      aria-label={props.ariaLabel ?? "Toggle menu"}
+      disabled={props.disabled}
+      onClick={() => setOpen(!open())}
+    >
+      <span class="hamburger-menu-inner" aria-hidden="true" />
+    </button>
+  );
+});

--- a/ui/components/src/components/hamburger-menu/headless/__snapshots__/IHamburgerMenuBase.ink.test.ts.snap
+++ b/ui/components/src/components/hamburger-menu/headless/__snapshots__/IHamburgerMenuBase.ink.test.ts.snap
@@ -1,0 +1,135 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`HamburgerMenuBase > output matches snapshots 1`] = `
+{
+  "angular/IHamburgerMenuBase.component.ts": "import { Component, signal, computed, effect, input, model } from "@angular/core";
+export interface HamburgerMenuBaseProps {
+  /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+  ariaLabel?: string;
+  /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+  ariaControls?: string;
+  /** Disables the toggle. */
+  disabled?: boolean;
+}
+@Component({ standalone: true, selector: 'ink-hamburger-menu-base', template: \`<button [class]="'hamburger-menu' + (klass() ? ' ' + klass() : '')" type="button" [attr.aria-expanded]="(open() ? 'true' : 'false') ?? null" [attr.aria-controls]="(ariaControls() ?? '') ?? null" [attr.aria-label]="(ariaLabel() ?? 'Toggle menu') ?? null" [disabled]="disabled()" (click)="open.set(!open())">
+<span class="hamburger-menu-inner" aria-hidden="true"></span>
+</button>\` })
+export class IHamburgerMenuBaseComponent
+{
+klass = input<string>()
+ariaLabel = input<string>()
+ariaControls = input<string>()
+disabled = input<boolean>()
+open = model<boolean>()
+}
+",
+  "astro/IHamburgerMenuBase.astro": "---
+export interface HamburgerMenuBaseProps {
+  /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+  ariaLabel?: string;
+  /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+  ariaControls?: string;
+  /** Disables the toggle. */
+  disabled?: boolean;
+}
+type Props = HamburgerMenuBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ariaLabel, ariaControls, disabled, ...__attrs } = props;
+let open = props.open
+---
+<button {...__attrs} class={["hamburger-menu", __attrs.class].filter(Boolean).join(" ")} type="button" aria-expanded={open ? "true" : "false"} aria-controls={ariaControls ?? ""} aria-label={ariaLabel ?? "Toggle menu"} disabled={disabled} onClick={() => open = !open}>
+<span class="hamburger-menu-inner" aria-hidden="true" />
+</button>
+",
+  "qwik/IHamburgerMenuBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
+export interface HamburgerMenuBaseProps {
+  /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+  ariaLabel?: string;
+  /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+  ariaControls?: string;
+  /** Disables the toggle. */
+  disabled?: boolean;
+}
+export const IHamburgerMenuBase = component$((props: HamburgerMenuBaseProps & { open?: boolean; onUpdateOpen$?: QRL<(value: boolean) => void> } & Record<string, any>) =>
+{
+const { ariaLabel, ariaControls, disabled, open, onUpdateOpen$, ...__attrs } = props
+return (
+<button {...__attrs} class={["hamburger-menu", props.class].filter(Boolean).join(" ")} type="button" aria-expanded={props.open ? "true" : "false"} aria-controls={props.ariaControls ?? ""} aria-label={props.ariaLabel ?? "Toggle menu"} disabled={props.disabled} onClick={$(() => props.onUpdateOpen$?.(!props.open))}>
+  <span class="hamburger-menu-inner" aria-hidden="true" />
+</button>
+)
+});
+",
+  "react/IHamburgerMenuBase.tsx": "export interface HamburgerMenuBaseProps {
+  /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+  ariaLabel?: string;
+  /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+  ariaControls?: string;
+  /** Disables the toggle. */
+  disabled?: boolean;
+}
+export function IHamburgerMenuBase(props: HamburgerMenuBaseProps & { open?: boolean; onUpdateOpen?: (value: boolean) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const { ariaLabel, ariaControls, disabled, open, onUpdateOpen, ...__attrs } = props
+return (
+<button {...__attrs} className={["hamburger-menu", props.className].filter(Boolean).join(" ")} type="button" aria-expanded={props.open ? "true" : "false"} aria-controls={props.ariaControls ?? ""} aria-label={props.ariaLabel ?? "Toggle menu"} disabled={props.disabled} onClick={() => props.onUpdateOpen?.(!props.open)}>
+  <span className="hamburger-menu-inner" aria-hidden="true" />
+</button>
+)
+}
+",
+  "solid/IHamburgerMenuBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface HamburgerMenuBaseProps {
+  /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+  ariaLabel?: string;
+  /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+  ariaControls?: string;
+  /** Disables the toggle. */
+  disabled?: boolean;
+}
+export default function IHamburgerMenuBase(props: HamburgerMenuBaseProps & { open?: boolean; onUpdateOpen?: (value: boolean) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["ariaLabel", "ariaControls", "disabled", "open", "onUpdateOpen"])
+return (
+<button {...__attrs} class={["hamburger-menu", props.class].filter(Boolean).join(" ")} type="button" aria-expanded={props.open ? "true" : "false"} aria-controls={props.ariaControls ?? ""} aria-label={props.ariaLabel ?? "Toggle menu"} disabled={props.disabled} onclick={() => props.onUpdateOpen?.(!props.open)}>
+  <span class="hamburger-menu-inner" aria-hidden="true" />
+</button>
+)
+}
+",
+  "svelte/IHamburgerMenuBase.svelte": "<script lang="ts">
+  export interface HamburgerMenuBaseProps {
+    /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+    ariaLabel?: string;
+    /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+    ariaControls?: string;
+    /** Disables the toggle. */
+    disabled?: boolean;
+  }
+  let { ariaLabel, ariaControls, disabled, open = $bindable(), ...__attrs }: HamburgerMenuBaseProps & { open?: boolean } & Record<string, any> = $props()
+</script>
+<button {...__attrs} class={["hamburger-menu", __attrs.class].filter(Boolean).join(" ")} type="button" aria-expanded={open ? "true" : "false"} aria-controls={ariaControls ?? ""} aria-label={ariaLabel ?? "Toggle menu"} disabled={disabled} onclick={() => open = !open}>
+  <span class="hamburger-menu-inner" aria-hidden="true"></span>
+</button>
+",
+  "vue/IHamburgerMenuBase.vue": "<script setup lang="ts">
+  export interface HamburgerMenuBaseProps {
+    /** Accessible name for the icon-only toggle; sets \`aria-label\`. */
+    ariaLabel?: string;
+    /** Id of the region the toggle shows/hides; sets \`aria-controls\`. */
+    ariaControls?: string;
+    /** Disables the toggle. */
+    disabled?: boolean;
+  }
+  const props = defineProps<HamburgerMenuBaseProps>()
+  const open = defineModel<boolean>("open")
+</script>
+<template>
+<button class="hamburger-menu" type="button" :aria-expanded='open ? "true" : "false"' :aria-controls='ariaControls ?? ""' :aria-label='ariaLabel ?? "Toggle menu"' :disabled="disabled" @click="() => open = !open">
+  <span class="hamburger-menu-inner" aria-hidden="true" />
+</button>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/hamburger-menu/stories/HamburgerMenuAnimations.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/stories/HamburgerMenuAnimations.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent } from "@inkline/core";
+import IHamburgerMenu from "../styled/IHamburgerMenu.ink.tsx";
+
+// Each toggle is rendered open so its morph target (the `animation` axis) is visible.
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IHamburgerMenu animation="close" open={true} ariaLabel="Close morph" />
+      <IHamburgerMenu animation="arrow-up" open={true} ariaLabel="Arrow-up morph" />
+      <IHamburgerMenu animation="arrow-down" open={true} ariaLabel="Arrow-down morph" />
+      <IHamburgerMenu animation="arrow-left" open={true} ariaLabel="Arrow-left morph" />
+      <IHamburgerMenu animation="arrow-right" open={true} ariaLabel="Arrow-right morph" />
+      <IHamburgerMenu animation="minus" open={true} ariaLabel="Minus morph" />
+      <IHamburgerMenu animation="plus" open={true} ariaLabel="Plus morph" />
+    </div>
+  );
+});

--- a/ui/components/src/components/hamburger-menu/stories/HamburgerMenuColors.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/stories/HamburgerMenuColors.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent } from "@inkline/core";
+import IHamburgerMenu from "../styled/IHamburgerMenu.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IHamburgerMenu color="light" ariaLabel="Light menu" />
+      <IHamburgerMenu color="dark" ariaLabel="Dark menu" />
+      <IHamburgerMenu color="neutral" ariaLabel="Neutral menu" />
+    </div>
+  );
+});

--- a/ui/components/src/components/hamburger-menu/stories/HamburgerMenuSizes.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/stories/HamburgerMenuSizes.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent } from "@inkline/core";
+import IHamburgerMenu from "../styled/IHamburgerMenu.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IHamburgerMenu size="sm" ariaLabel="Small menu" />
+      <IHamburgerMenu size="md" ariaLabel="Medium menu" />
+      <IHamburgerMenu size="lg" ariaLabel="Large menu" />
+    </div>
+  );
+});

--- a/ui/components/src/components/hamburger-menu/stories/HamburgerMenuToggle.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/stories/HamburgerMenuToggle.ink.tsx
@@ -1,0 +1,20 @@
+import { createSignal, defineComponent, Show } from "@inkline/core";
+import IHamburgerMenu from "../styled/IHamburgerMenu.ink.tsx";
+
+// The full disclosure pattern: clicking the toggle flips `open` (morphing the icon) and shows/hides
+// the navigation it controls, linked via `aria-controls`.
+export default defineComponent(() => {
+  const [open, _setOpen] = createSignal(false);
+  return (
+    <div id="story">
+      <IHamburgerMenu ariaControls="primary-nav" ariaLabel="Toggle navigation" $bind:open={open} />
+      <Show when={open()}>
+        <nav id="primary-nav">
+          <a href="#home">Home</a>
+          <a href="#about">About</a>
+          <a href="#contact">Contact</a>
+        </nav>
+      </Show>
+    </div>
+  );
+});

--- a/ui/components/src/components/hamburger-menu/stories/IHamburgerMenu.ink.stories.ts
+++ b/ui/components/src/components/hamburger-menu/stories/IHamburgerMenu.ink.stories.ts
@@ -1,0 +1,48 @@
+import { defineStories } from "@inkline/storybook";
+import type { HamburgerMenuProps } from "../styled/IHamburgerMenu.ink.tsx";
+
+// `open` is the two-way model prop (added by `defineModel`, so not a member of `HamburgerMenuProps`).
+// Include it explicitly to expose it as a control and drive the `Open` variant.
+const meta = defineStories<HamburgerMenuProps & { open?: boolean }>({
+  component: "IHamburgerMenu",
+  title: "Components/Navigation/HamburgerMenu",
+  args: {
+    ariaLabel: "Toggle menu",
+    open: false,
+    disabled: false,
+  },
+  argTypes: {
+    open: { control: "boolean", description: "Open (expanded) state" },
+    ariaLabel: { control: "text", description: "Accessible name (aria-label)" },
+    ariaControls: {
+      control: "text",
+      description: "Id of the controlled region (aria-controls)",
+    },
+    color: {
+      control: "select",
+      options: ["light", "dark", "neutral"],
+      description: "Color variant",
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+      description: "Size variant",
+    },
+    animation: {
+      control: "select",
+      options: ["close", "arrow-up", "arrow-down", "arrow-left", "arrow-right", "minus", "plus"],
+      description: "Icon morph shown while open",
+    },
+    disabled: { control: "boolean", description: "Disabled state" },
+  },
+});
+
+export default meta;
+
+export const Default = {};
+export const Open = { args: { open: true } };
+export const Disabled = { args: { disabled: true } };
+export const Colors = { render: "./HamburgerMenuColors.ink.tsx" };
+export const Sizes = { render: "./HamburgerMenuSizes.ink.tsx" };
+export const Animations = { render: "./HamburgerMenuAnimations.ink.tsx" };
+export const Toggle = { render: "./HamburgerMenuToggle.ink.tsx" };

--- a/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.test.ts
+++ b/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  expectImports,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+  type ComponentTestResult,
+  type TargetName,
+} from "@inkline/test-utils";
+import { mountStyledOnAngular } from "../../angular-ssr-helper.ts";
+
+const IHAMBURGER = resolveComponent(import.meta.url, "./IHamburgerMenu.ink.tsx");
+
+const out = (result: ComponentTestResult, target: TargetName) => result.files[target] ?? [];
+
+describe("IHamburgerMenu (styled)", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(IHAMBURGER);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("emits only the expected Astro two-way notice (INK0045); no hasSlot INK0068", async () => {
+    const result = await compileComponent(IHAMBURGER);
+    const unexpected = result.diagnostics.filter((d) => d.code !== "INK0045");
+    expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+    expect(result.diagnostics.filter((d) => d.code === "INK0068")).toHaveLength(0);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(IHAMBURGER));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(IHAMBURGER));
+  });
+
+  it("composes the headless base part across targets", async () => {
+    const result = await compileComponent(IHAMBURGER);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      expectOutputContains(out(result, target), "IHamburgerMenuBase");
+    }
+  });
+
+  it("pulls the hamburger-menu recipe from virtual:styleframe", async () => {
+    const result = await compileComponent(IHAMBURGER);
+    for (const target of ["react", "vue", "solid"] as const) {
+      expectImports(out(result, target), "virtual:styleframe", ["hamburgerMenuRecipe"]);
+    }
+  });
+
+  it("derives the recipe `active` axis from the open model (React memo body + deps)", async () => {
+    const result = await compileComponent(IHAMBURGER);
+    // Body and useMemo deps must both reference props.open — the regression guarded by the
+    // @inkline/compiler model-dep fix (a bare `open` in the deps array is a TDZ ReferenceError).
+    expectOutputContains(out(result, "react"), 'active: props.open ? "true" : "false"');
+    expectOutputContains(
+      out(result, "react"),
+      "[props.color, props.size, props.animation, props.open]",
+    );
+  });
+
+  it("forwards a two-way `open` to the base per target", async () => {
+    const result = await compileComponent(IHAMBURGER);
+    expectOutputContains(out(result, "react"), "onUpdateOpen");
+    expectOutputContains(out(result, "vue"), 'v-model:open="open"');
+    expectOutputContains(out(result, "svelte"), "bind:open={open}");
+    expectOutputContains(out(result, "angular"), "(openChange)=");
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(IHAMBURGER))).toMatchSnapshot();
+  });
+});
+
+// Real-DOM verification on the Angular target (SSR via @angular/platform-server): the recipe classes
+// land on the native button, the open state drives aria-expanded + the recipe `active` axis, the
+// controlled region is linked, and the decorative bars are hidden from assistive tech.
+describe("IHamburgerMenu (styled) on Angular SSR", () => {
+  const HEADLESS = ["../headless/IHamburgerMenuBase.ink.tsx"];
+  const mount = (props?: Record<string, unknown>) =>
+    mountStyledOnAngular(import.meta.url, "./IHamburgerMenu.ink.tsx", HEADLESS, props);
+
+  it("renders a native button with sorted recipe classes + the decorative inner bars", async () => {
+    const { html } = await mount({
+      open: true,
+      animation: "close",
+      color: "dark",
+      size: "md",
+      ariaLabel: "Open navigation",
+      ariaControls: "nav",
+    });
+    expect(html).toMatch(
+      /<button[^>]*class="hamburger-menu hamburger-menu--active-true hamburger-menu--animation-close hamburger-menu--color-dark hamburger-menu--size-md"/,
+    );
+    expect(html).toContain('class="hamburger-menu-inner"');
+    expect(html).toMatch(/<span[^>]*aria-hidden="true"/);
+  });
+
+  it("reflects the open state in aria-expanded and links the controlled region", async () => {
+    const { html } = await mount({ open: true, ariaLabel: "Open navigation", ariaControls: "nav" });
+    expect(html).toMatch(/<button[^>]*aria-expanded="true"/);
+    expect(html).toMatch(/<button[^>]*aria-controls="nav"/);
+    expect(html).toMatch(/<button[^>]*aria-label="Open navigation"/);
+  });
+
+  it("renders aria-expanded=false and the active-false recipe class when closed", async () => {
+    const { html } = await mount({ ariaLabel: "Open navigation" });
+    expect(html).toMatch(/<button[^>]*aria-expanded="false"/);
+    expect(html).toContain("hamburger-menu--active-false");
+  });
+
+  it("reflects the disabled state onto the native button", async () => {
+    const { html } = await mount({ disabled: true, ariaLabel: "Open navigation" });
+    expect(html).toMatch(/<button[^>]*disabled/);
+  });
+
+  it("falls back to the default accessible name and an empty aria-controls when unset", async () => {
+    // Exercises the `ariaLabel ?? "Toggle menu"` and `ariaControls ?? ""` fallbacks at the DOM level.
+    const { html } = await mount({});
+    expect(html).toMatch(/<button[^>]*aria-label="Toggle menu"/);
+    expect(html).toMatch(/<button[^>]*aria-controls=""/);
+  });
+});

--- a/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.tsx
@@ -1,0 +1,43 @@
+import { defineComponent, defineModel, createMemo } from "@inkline/core";
+import IHamburgerMenuBase, {
+  type HamburgerMenuBaseProps,
+} from "../headless/IHamburgerMenuBase.ink.tsx";
+import {
+  hamburgerMenuRecipe,
+  type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+} from "virtual:styleframe";
+
+// `active` is intentionally omitted from the public props: it's derived from `open()` below, never
+// set by the consumer. The remaining axes reference the recipe's types so they stay a single source
+// of truth (and the compiler only enumerates members of this directly-named interface).
+export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+  /** Color variant. */
+  color?: HamburgerMenuStylingProps["color"];
+  /** Size variant. */
+  size?: HamburgerMenuStylingProps["size"];
+  /** Shape the bars morph into while open. */
+  animation?: HamburgerMenuStylingProps["animation"];
+}
+
+export default defineComponent((props: HamburgerMenuProps) => {
+  const [open, _setOpen] = defineModel<boolean>("open");
+
+  const className = createMemo(() =>
+    hamburgerMenuRecipe({
+      color: props.color,
+      size: props.size,
+      animation: props.animation,
+      active: open() ? "true" : "false",
+    }),
+  );
+
+  return (
+    <IHamburgerMenuBase
+      class={className()}
+      $bind:open={open}
+      ariaLabel={props.ariaLabel}
+      ariaControls={props.ariaControls}
+      disabled={props.disabled}
+    />
+  );
+});

--- a/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.styleframe.ts
+++ b/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.styleframe.ts
@@ -1,0 +1,6 @@
+import { styleframe } from "virtual:styleframe";
+import { useHamburgerMenuRecipe } from "@styleframe/theme";
+
+const s = styleframe();
+
+export const hamburgerMenuRecipe = useHamburgerMenuRecipe(s);

--- a/ui/components/src/components/hamburger-menu/styled/__snapshots__/IHamburgerMenu.ink.test.ts.snap
+++ b/ui/components/src/components/hamburger-menu/styled/__snapshots__/IHamburgerMenu.ink.test.ts.snap
@@ -1,0 +1,172 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IHamburgerMenu (styled) > output matches snapshots 1`] = `
+{
+  "angular/IHamburgerMenu.component.ts": "import { Component, signal, computed, effect, input, model } from "@angular/core";
+import { IHamburgerMenuBaseComponent as IHamburgerMenuBase } from "../headless/IHamburgerMenuBase.component";
+import { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase.component";
+import {
+  hamburgerMenuRecipe,
+  type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+} from "virtual:styleframe";
+export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+  /** Color variant. */
+  color?: HamburgerMenuStylingProps["color"];
+  /** Size variant. */
+  size?: HamburgerMenuStylingProps["size"];
+  /** Shape the bars morph into while open. */
+  animation?: HamburgerMenuStylingProps["animation"];
+}
+@Component({ standalone: true, selector: 'ink-hamburger-menu', imports: [IHamburgerMenuBase], template: \`<ink-hamburger-menu-base [klass]="(className()) + (klass() ? ' ' + klass() : '')" [open]="open()" [ariaLabel]="ariaLabel()" [ariaControls]="ariaControls()" [disabled]="disabled()" (openChange)="open.set($event)"></ink-hamburger-menu-base>\` })
+export class IHamburgerMenuComponent
+{
+hamburgerMenuRecipe = hamburgerMenuRecipe
+klass = input<string>()
+className = computed(() => hamburgerMenuRecipe({ color: this.color(), size: this.size(), animation: this.animation(), active: this.open() ? 'true' : 'false' }))
+color = input<HamburgerMenuStylingProps["color"]>()
+size = input<HamburgerMenuStylingProps["size"]>()
+animation = input<HamburgerMenuStylingProps["animation"]>()
+ariaLabel = input<string>()
+ariaControls = input<string>()
+disabled = input<boolean>()
+open = model<boolean>()
+}
+",
+  "astro/IHamburgerMenu.astro": "---
+import IHamburgerMenuBase, { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase.astro";
+import {
+  hamburgerMenuRecipe,
+  type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+} from "virtual:styleframe";
+export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+  /** Color variant. */
+  color?: HamburgerMenuStylingProps["color"];
+  /** Size variant. */
+  size?: HamburgerMenuStylingProps["size"];
+  /** Shape the bars morph into while open. */
+  animation?: HamburgerMenuStylingProps["animation"];
+}
+type Props = HamburgerMenuProps & Record<string, any>
+const props = Astro.props as Props;
+const { color, size, animation, ariaLabel, ariaControls, disabled, ...__attrs } = props;
+let open = props.open
+const className = hamburgerMenuRecipe({ color: color, size: size, animation: animation, active: open ? "true" : "false" })
+---
+<IHamburgerMenuBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")} open={open} ariaLabel={ariaLabel} ariaControls={ariaControls} disabled={disabled} />
+",
+  "qwik/IHamburgerMenu.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
+import { IHamburgerMenuBase } from "../headless/IHamburgerMenuBase";
+import { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase";
+import {
+  hamburgerMenuRecipe,
+  type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+} from "virtual:styleframe";
+export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+  /** Color variant. */
+  color?: HamburgerMenuStylingProps["color"];
+  /** Size variant. */
+  size?: HamburgerMenuStylingProps["size"];
+  /** Shape the bars morph into while open. */
+  animation?: HamburgerMenuStylingProps["animation"];
+}
+export const IHamburgerMenu = component$((props: HamburgerMenuProps & { open?: boolean; onUpdateOpen$?: QRL<(value: boolean) => void> } & Record<string, any>) =>
+{
+const className = useComputed$(() => hamburgerMenuRecipe({ color: props.color, size: props.size, animation: props.animation, active: props.open ? "true" : "false" }))
+const { color, size, animation, ariaLabel, ariaControls, disabled, open, onUpdateOpen$, ...__attrs } = props
+return (
+<IHamburgerMenuBase {...__attrs} class={[className.value, props.class].filter(Boolean).join(" ")} open={props.open} ariaLabel={props.ariaLabel} ariaControls={props.ariaControls} disabled={props.disabled} onUpdateOpen$={$(v => props.onUpdateOpen$?.(v))} />
+)
+});
+",
+  "react/IHamburgerMenu.tsx": "import { useMemo } from "react";
+import { IHamburgerMenuBase } from "../headless/IHamburgerMenuBase";
+import { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase";
+import {
+  hamburgerMenuRecipe,
+  type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+} from "virtual:styleframe";
+export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+  /** Color variant. */
+  color?: HamburgerMenuStylingProps["color"];
+  /** Size variant. */
+  size?: HamburgerMenuStylingProps["size"];
+  /** Shape the bars morph into while open. */
+  animation?: HamburgerMenuStylingProps["animation"];
+}
+export function IHamburgerMenu(props: HamburgerMenuProps & { open?: boolean; onUpdateOpen?: (value: boolean) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const className = useMemo(() => hamburgerMenuRecipe({ color: props.color, size: props.size, animation: props.animation, active: props.open ? "true" : "false" }), [props.color, props.size, props.animation, props.open])
+const { color, size, animation, ariaLabel, ariaControls, disabled, open, onUpdateOpen, ...__attrs } = props
+return (
+<IHamburgerMenuBase {...__attrs} className={[className, props.className].filter(Boolean).join(" ")} open={props.open} ariaLabel={props.ariaLabel} ariaControls={props.ariaControls} disabled={props.disabled} onUpdateOpen={v => props.onUpdateOpen?.(v)} />
+)
+}
+",
+  "solid/IHamburgerMenu.tsx": "import { createMemo, splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+import IHamburgerMenuBase, { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase";
+import {
+  hamburgerMenuRecipe,
+  type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+} from "virtual:styleframe";
+export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+  /** Color variant. */
+  color?: HamburgerMenuStylingProps["color"];
+  /** Size variant. */
+  size?: HamburgerMenuStylingProps["size"];
+  /** Shape the bars morph into while open. */
+  animation?: HamburgerMenuStylingProps["animation"];
+}
+export default function IHamburgerMenu(props: HamburgerMenuProps & { open?: boolean; onUpdateOpen?: (value: boolean) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const className = createMemo(() => hamburgerMenuRecipe({ color: props.color, size: props.size, animation: props.animation, active: props.open ? "true" : "false" }))
+const [, __attrs] = splitProps(props, ["color", "size", "animation", "ariaLabel", "ariaControls", "disabled", "open", "onUpdateOpen"])
+return (
+<IHamburgerMenuBase {...__attrs} class={[className(), props.class].filter(Boolean).join(" ")} open={props.open} ariaLabel={props.ariaLabel} ariaControls={props.ariaControls} disabled={props.disabled} onUpdateOpen={v => props.onUpdateOpen?.(v)} />
+)
+}
+",
+  "svelte/IHamburgerMenu.svelte": "<script lang="ts">
+  import IHamburgerMenuBase, { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase.svelte";
+  import {
+    hamburgerMenuRecipe,
+    type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+  } from "virtual:styleframe";
+  export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+    /** Color variant. */
+    color?: HamburgerMenuStylingProps["color"];
+    /** Size variant. */
+    size?: HamburgerMenuStylingProps["size"];
+    /** Shape the bars morph into while open. */
+    animation?: HamburgerMenuStylingProps["animation"];
+  }
+  let { color, size, animation, ariaLabel, ariaControls, disabled, open = $bindable(), ...__attrs }: HamburgerMenuProps & { open?: boolean } & Record<string, any> = $props()
+  let className = $derived(hamburgerMenuRecipe({ color: color, size: size, animation: animation, active: open ? "true" : "false" }))
+</script>
+<IHamburgerMenuBase bind:open={open} {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")} ariaLabel={ariaLabel} ariaControls={ariaControls} disabled={disabled} />
+",
+  "vue/IHamburgerMenu.vue": "<script setup lang="ts">
+  import { computed } from "vue";
+  import IHamburgerMenuBase, { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase.vue";
+  import {
+    hamburgerMenuRecipe,
+    type HamburgerMenuRecipeProps as HamburgerMenuStylingProps,
+  } from "virtual:styleframe";
+  export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
+    /** Color variant. */
+    color?: HamburgerMenuStylingProps["color"];
+    /** Size variant. */
+    size?: HamburgerMenuStylingProps["size"];
+    /** Shape the bars morph into while open. */
+    animation?: HamburgerMenuStylingProps["animation"];
+  }
+  const props = defineProps<HamburgerMenuProps>()
+  const open = defineModel<boolean>("open")
+  const className = computed(() => hamburgerMenuRecipe({ color: props.color, size: props.size, animation: props.animation, active: open.value ? "true" : "false" }))
+</script>
+<template>
+<IHamburgerMenuBase v-model:open="open" :class="className" :ariaLabel="ariaLabel" :ariaControls="ariaControls" :disabled="disabled" />
+</template>
+",
+}
+`;

--- a/ui/components/src/components/index.ts
+++ b/ui/components/src/components/index.ts
@@ -7,6 +7,9 @@ export { default as IButtonBase } from "./button/headless/IButtonBase.ink.tsx";
 export { default as IFieldGroup } from "./field-group/styled/IFieldGroup.ink.tsx";
 export { default as IFieldGroupBase } from "./field-group/headless/IFieldGroupBase.ink.tsx";
 
+export { default as IHamburgerMenu } from "./hamburger-menu/styled/IHamburgerMenu.ink.tsx";
+export { default as IHamburgerMenuBase } from "./hamburger-menu/headless/IHamburgerMenuBase.ink.tsx";
+
 // Input ships as a single styled component (IInput) that composes every headless part. The headless
 // parts remain individually exported for advanced/custom composition.
 export { default as IInput } from "./input/styled/IInput.ink.tsx";


### PR DESCRIPTION
## Summary

Adds `IHamburgerMenu` and `IHamburgerMenuBase` — a two-way-bindable disclosure toggle with full ARIA support and styleframe recipe integration. Also fixes a React codegen bug where `defineModel` getter names appeared bare in `useMemo`/`useEffect` dependency arrays (instead of as `props.<name>`), causing a temporal-dead-zone `ReferenceError` at runtime.

## Related issues

- Closes #

## Type of change

- [x] `feat` — new user-facing capability or public API
- [x] `fix` — bug fix

## Test plan

- [x] `vp run ready` passes locally
- [x] New `MemoModel` fixture + `reactivity.test.ts` case covers the React deps fix
- [x] `IHamburgerMenu` and `IHamburgerMenuBase` exported from `@inkline/components`

## Checklist

- [x] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".