### PR TITLE
feat(compiler): Angular attribute-selector support (Phases 0–3)

### DIFF
--- a/.changeset/angular-attribute-selectors.md
+++ b/.changeset/angular-attribute-selectors.md
@@ -1,0 +1,28 @@
+---
+"@inkline/compiler": minor
+"@inkline/angular": minor
+"@inkline/test-utils": minor
+"@inkline/cli": patch
+---
+
+feat(compiler): emit best-practice Angular attribute-selector output
+
+The Angular target now emits each component as its native host element (the Angular Material
+directive-on-native-element pattern) instead of a nested `ink-*` custom-element wrapper with
+`display: contents`:
+
+- a headless leaf **is** its element — `<button inkButtonBase>` / `<div inkBadgeBase>` (host bindings
+  on the real element, no wrapper);
+- a pure-forwarding styled component is a styling directive stacked onto it —
+  `<button inkButtonBase inkButton>` (Ivy unions the base, recipe, and consumer classes);
+- a structure-injecting styled component (the Input) flattens its trivial base into one
+  element-component — `<div inkInput>`.
+
+Consumers therefore render each control as a real **direct child**, so direct-child / sibling /
+`nth-child` / `gap` / grid CSS now works on Angular exactly as on the other six targets. Concretely
+this fixes the field-group seam (a doubled +2px border on Angular), letting the field-group recipe's
+direct-child seam rules apply uniformly — the interim CSS reach-through workaround is removed.
+
+The authored `.ink.tsx` API is unchanged and the other six targets emit byte-identical output. A
+build-time pre-pass infers each component's host tag from its render root (new `analyzeOnly` /
+`buildAngularRegistry` APIs, threaded via the `angularRegistry` compiler option).

--- a/.changeset/angular-attribute-selectors.md
+++ b/.changeset/angular-attribute-selectors.md
@@ -1,4 +1,5 @@
 ---
+"@inkline/core": minor
 "@inkline/compiler": minor
 "@inkline/angular": minor
 "@inkline/test-utils": minor
@@ -23,6 +24,11 @@ Consumers therefore render each control as a real **direct child**, so direct-ch
 this fixes the field-group seam (a doubled +2px border on Angular), letting the field-group recipe's
 direct-child seam rules apply uniformly — the interim CSS reach-through workaround is removed.
 
-The authored `.ink.tsx` API is unchanged and the other six targets emit byte-identical output. A
-build-time pre-pass infers each component's host tag from its render root (new `analyzeOnly` /
-`buildAngularRegistry` APIs, threaded via the `angularRegistry` compiler option).
+Attribute-selector codegen is an explicit opt-in: a headless leaf declares its native host tag via
+`defineComponent({ element: "button" }, …)` (a new, Angular-only `ComponentOptions.element` field;
+ignored by every other target and validated against the actual root — `INK0130`). Styled and
+structural components are inferred from their marked base, so app authors' and story components are
+untouched (they stay `ink-*` element wrappers) and the other six targets emit byte-identical output.
+A build-time pre-pass builds the registry from these declarations (new `analyzeOnly` /
+`buildAngularRegistry` APIs, threaded via the `angularRegistry` compiler option), which also lets the
+Storybook story generator mount a directive on its native host element.

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -1,4 +1,5 @@
 import type { Code } from "./code-ir/nodes.ts";
+import type { AngularRegistry } from "./targets/angular/registry.ts";
 import type { IRComponent, IRContextDefinition } from "../ir/render/nodes.ts";
 import type { Diagnostic } from "../core/diagnostics/codes.ts";
 import type { DiagnosticCollector } from "../core/diagnostics/collector.ts";
@@ -157,6 +158,12 @@ export interface CodegenContext {
   readonly externalImports: readonly Code[];
   readonly componentImports: readonly ComponentImport[];
   readonly typeDeclarations: readonly Code[];
+  /**
+   * Angular-only: the whole-program component registry (host tag / kind / attribute chain per
+   * component), used to emit attribute-selector host elements and stacked directives. Absent for
+   * every other target and for direct `emit()` unit tests, which fall back to `ink-*` wrapper output.
+   */
+  readonly angularRegistry?: AngularRegistry;
 }
 
 export interface CodeModule {

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -1,5 +1,5 @@
 import type { Code } from "./code-ir/nodes.ts";
-import type { AngularRegistry } from "./targets/angular/registry.ts";
+import type { AngularComponentEntry, AngularRegistry } from "./targets/angular/registry.ts";
 import type { IRComponent, IRContextDefinition } from "../ir/render/nodes.ts";
 import type { Diagnostic } from "../core/diagnostics/codes.ts";
 import type { DiagnosticCollector } from "../core/diagnostics/collector.ts";
@@ -140,6 +140,14 @@ export interface RewriteRules {
    * (Qwik/Angular), so gated content always renders and CSS `:empty` collapses the empty wrapper.
    */
   readonly hasSlotCheck?: (slotName: string) => string;
+  /**
+   * Angular-only: resolve a component-instance's local name to its attribute-selector registry entry
+   * (host tag, attribute chain, kind) so an instance emits as a native host element with stacked
+   * directives (`<button inkButtonBase inkButton>`) instead of an `ink-*` wrapper. Returns undefined
+   * for unresolved/wrapper components, which keep the `ink-*` element form. Set only by the Angular
+   * target when a registry is threaded in.
+   */
+  readonly angularResolve?: (localName: string) => AngularComponentEntry | undefined;
 }
 
 export interface ComponentImport {

--- a/core/compiler/src/codegen/targets/angular/attr-selector.test.ts
+++ b/core/compiler/src/codegen/targets/angular/attr-selector.test.ts
@@ -84,3 +84,73 @@ describe("angular attribute-selector codegen (Phase 1)", () => {
     expect(app).toContain(`import { IBadgeBaseComponent as IBadgeBase } from "./IBadge.component"`);
   });
 });
+
+const STRUCTURAL_SOURCE = `
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+
+const IShellBase = defineComponent({ slots: { default: {} } }, (props: { id?: string }) => (
+  <div class="shell" id={props.id}><Slot /></div>
+));
+
+const IPartBase = defineComponent({ slots: { default: {} } }, () => (
+  <span class="part"><Slot /></span>
+));
+
+const IField = defineComponent({ slots: { default: {} } }, (props: { color?: string }) => {
+  const cls = createMemo(() => "shell--" + (props.color ?? "default"));
+  return (
+    <IShellBase class={cls()}>
+      <IPartBase><Slot /></IPartBase>
+    </IShellBase>
+  );
+});
+
+const App = defineComponent(() => (
+  <section><IField color="primary" /></section>
+));
+
+export { IShellBase, IPartBase, IField, App };
+`;
+
+describe("angular structural flatten (Phase 2)", () => {
+  async function compileStructural() {
+    const input = { fileName: "Field.ink.tsx", source: STRUCTURAL_SOURCE };
+    const analyzed = await analyzeOnly(input, { targets: ["angular"] });
+    const registry = buildAngularRegistry([analyzed.module]);
+    const result = await compile(input, { targets: ["angular"], angularRegistry: registry });
+    const files = result.files.angular ?? [];
+    return {
+      errors: result.diagnostics.filter((d) => d.severity === "error"),
+      byName: (name: string) => files.find((f) => f.path === name)?.contents ?? "",
+    };
+  }
+
+  it("flattens a structure-injecting styled component into its base's native element", async () => {
+    const { byName, errors } = await compileStructural();
+    const field = byName("IField.component.ts");
+
+    expect(errors).toEqual([]);
+    // IField IS the base's <div> (base inlined): selector div[inkField], base class + recipe merged,
+    // no display:contents, no <ink-*> wrapper.
+    expect(field).toContain("selector: 'div[inkField]'");
+    expect(field).toContain(`host: { 'class': "shell", '[class]': "(cls())" }`);
+    expect(field).not.toContain("display: contents");
+    // Template is the INJECTED structure (the IPartBase span), not a wrapping <div>.
+    expect(field).toContain("<span inkPartBase");
+    // The inlined base is neither imported nor instantiated; the injected part IS imported.
+    expect(field).not.toContain("IShellBase");
+    expect(field).toMatch(/imports: \[[^\]]*\bIPartBase\b/);
+  });
+
+  it("lets a consumer stack the flattened component as a self-contained native element", async () => {
+    const { byName } = await compileStructural();
+    const app = byName("App.component.ts");
+
+    // IField is self-contained (base inlined) → the consumer stacks just its own selector and imports
+    // only it (not the base, not the injected parts).
+    expect(app).toContain("<div inkField");
+    expect(app).not.toContain("<ink-field");
+    expect(app).toMatch(/imports: \[\s*IField\s*\]/);
+    expect(app).not.toContain("IShellBase");
+  });
+});

--- a/core/compiler/src/codegen/targets/angular/attr-selector.test.ts
+++ b/core/compiler/src/codegen/targets/angular/attr-selector.test.ts
@@ -10,7 +10,7 @@ import { analyzeOnly, buildAngularRegistry, compile } from "../../../pipeline/co
 const SOURCE = `
 import { defineComponent, Slot, createMemo } from "@inkline/core";
 
-const IBadgeBase = defineComponent({ slots: { default: {} } }, (props: { label?: string }) => (
+const IBadgeBase = defineComponent({ slots: { default: {} }, element: "div" }, (props: { label?: string }) => (
   <div class="badge"><Slot>{props.label}</Slot></div>
 ));
 
@@ -88,11 +88,11 @@ describe("angular attribute-selector codegen (Phase 1)", () => {
 const STRUCTURAL_SOURCE = `
 import { defineComponent, Slot, createMemo } from "@inkline/core";
 
-const IShellBase = defineComponent({ slots: { default: {} } }, (props: { id?: string }) => (
+const IShellBase = defineComponent({ slots: { default: {} }, element: "div" }, (props: { id?: string }) => (
   <div class="shell" id={props.id}><Slot /></div>
 ));
 
-const IPartBase = defineComponent({ slots: { default: {} } }, () => (
+const IPartBase = defineComponent({ slots: { default: {} }, element: "span" }, () => (
   <span class="part"><Slot /></span>
 ));
 
@@ -152,5 +152,24 @@ describe("angular structural flatten (Phase 2)", () => {
     expect(app).not.toContain("<ink-field");
     expect(app).toMatch(/imports: \[\s*IField\s*\]/);
     expect(app).not.toContain("IShellBase");
+  });
+});
+
+describe("element flag validation (INK0130)", () => {
+  it("errors when the declared element does not match the static root, and stays a wrapper", async () => {
+    const SOURCE = `
+import { defineComponent } from "@inkline/core";
+const Mismatch = defineComponent({ element: "button" }, () => <div class="x">y</div>);
+export { Mismatch };
+`;
+    const input = { fileName: "Mismatch.ink.tsx", source: SOURCE };
+    const analyzed = await analyzeOnly(input, { targets: ["angular"] });
+    const registry = buildAngularRegistry([analyzed.module]);
+    const result = await compile(input, { targets: ["angular"], angularRegistry: registry });
+
+    expect(result.diagnostics.map((d) => d.code)).toContain("INK0130");
+    // The mismatch falls back to the ink-* wrapper rather than emitting a broken host element.
+    expect(registry.get("Mismatch")!.kind).toBe("wrapper");
+    expect(result.files.angular?.[0]?.contents).toContain("selector: 'ink-mismatch'");
   });
 });

--- a/core/compiler/src/codegen/targets/angular/attr-selector.test.ts
+++ b/core/compiler/src/codegen/targets/angular/attr-selector.test.ts
@@ -1,0 +1,86 @@
+// Phase 1 attribute-selector codegen: with a seeded Angular registry, a headless leaf emits as a
+// native host element (`div[inkBadgeBase]`), a pure-forwarding styled component as a styling
+// directive (`[inkBadge]`), and a consumer stacks them on the native element
+// (`<div inkBadgeBase inkBadge>`). Without a registry every component stays an `ink-*` wrapper
+// (covered by the existing snapshot/SSR suites), so this suite always compiles WITH a registry.
+
+import { describe, it, expect } from "vitest";
+import { analyzeOnly, buildAngularRegistry, compile } from "../../../pipeline/compile.ts";
+
+const SOURCE = `
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+
+const IBadgeBase = defineComponent({ slots: { default: {} } }, (props: { label?: string }) => (
+  <div class="badge"><Slot>{props.label}</Slot></div>
+));
+
+const IBadge = defineComponent({ slots: { default: {} } }, (props: { label?: string; color?: string }) => {
+  const className = createMemo(() => "badge--" + (props.color ?? "default"));
+  return (
+    <IBadgeBase class={className()}>
+      <Slot>{props.label}</Slot>
+    </IBadgeBase>
+  );
+});
+
+const App = defineComponent(() => (
+  <section><IBadge color="primary">Hi</IBadge></section>
+));
+
+export { IBadgeBase, IBadge, App };
+`;
+
+async function compileWithRegistry() {
+  const input = { fileName: "Badge.ink.tsx", source: SOURCE };
+  const analyzed = await analyzeOnly(input, { targets: ["angular"] });
+  const registry = buildAngularRegistry([analyzed.module]);
+  const result = await compile(input, { targets: ["angular"], angularRegistry: registry });
+  const files = result.files.angular ?? [];
+  const errors = result.diagnostics.filter((d) => d.severity === "error");
+  const byName = (name: string) => files.find((f) => f.path === name)?.contents ?? "";
+  return { errors, byName };
+}
+
+describe("angular attribute-selector codegen (Phase 1)", () => {
+  it("emits a headless leaf as a native element-component host (no display:contents)", async () => {
+    const { byName, errors } = await compileWithRegistry();
+    const base = byName("IBadgeBase.component.ts");
+
+    expect(errors).toEqual([]);
+    expect(base).toContain("selector: 'div[inkBadgeBase]'");
+    expect(base).toContain(`host: { '[class]': "'badge'" }`);
+    expect(base).not.toContain("display: contents");
+    expect(base).not.toContain("klass = input"); // element host needs no klass input
+    // template is the ROOT's children only — the projected slot, not a wrapping <div>.
+    expect(base).toContain("<ng-content>");
+    expect(base).not.toMatch(/template: `<div/);
+  });
+
+  it("emits a pure-forwarding styled component as a styling directive that re-exports its base", async () => {
+    const { byName } = await compileWithRegistry();
+    const styled = byName("IBadge.component.ts");
+
+    expect(styled).toContain("@Directive({ standalone: true, selector: '[inkBadge]'");
+    expect(styled).toContain(`host: { '[class]': "(className())" }`);
+    expect(styled).toContain("import { Directive");
+    // A directive has no template/imports; it re-exports its base so consumers can declare the chain.
+    expect(styled).not.toContain("template:");
+    expect(styled).toContain(`export { IBadgeBaseComponent } from "./IBadgeBase.component"`);
+    expect(styled).not.toContain("display: contents");
+  });
+
+  it("stacks the chain on the native host element at a consumer call site, importing every link", async () => {
+    const { byName } = await compileWithRegistry();
+    const app = byName("App.component.ts");
+
+    // The consumer renders the whole chain on one <div>; the recipe class on IBadge becomes a
+    // direct [class] (Ivy unions it with the host bindings), not a [klass] input forward.
+    expect(app).toContain("<div inkBadgeBase inkBadge");
+    expect(app).not.toContain("<ink-badge");
+    expect(app).toContain("Hi");
+    // Both links are imported (the base from the styled component's module, via its re-export).
+    expect(app).toMatch(/imports: \[[^\]]*\bIBadge\b[^\]]*\bIBadgeBase\b/);
+    expect(app).toContain(`import { IBadgeComponent as IBadge } from "./IBadge.component"`);
+    expect(app).toContain(`import { IBadgeBaseComponent as IBadgeBase } from "./IBadge.component"`);
+  });
+});

--- a/core/compiler/src/codegen/targets/angular/conformance.ts
+++ b/core/compiler/src/codegen/targets/angular/conformance.ts
@@ -4,15 +4,17 @@ import type { Diagnostic } from "../../../core/diagnostics/codes.ts";
 import type { GeneratedFile } from "../../context.ts";
 import type { TargetConformanceSpec } from "../../context.ts";
 import { requireFileExtension } from "../../../testing/conformance.ts";
-import { angularSelector } from "./selector.ts";
+import { angularSelector, angularAttrSelector } from "./selector.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * A standalone component's template may only instantiate components declared in its `imports`.
- * Every compiled child renders via its `ink-*` selector, and selectors derive deterministically
- * from the imported local names — so any `ink-*` tag without a matching declared selector is a
- * compile bug (Angular would silently render it as an unknown element).
+ * A compiled child renders either via its `ink-*` element selector or, for an attribute-selector
+ * component/directive, as a bare `inkName` attribute on a native host element
+ * (`<button inkButtonBase inkButton>`). Both forms derive deterministically from the imported local
+ * names — so any such reference without a matching declared selector is a compile bug (Angular
+ * would silently render an unknown element / drop the directive).
  */
 function requireTemplateChildrenDeclared(file: GeneratedFile): readonly Diagnostic[] {
   const template = file.contents.match(/template: `([\s\S]*?)` \}\)/)?.[1];
@@ -24,11 +26,20 @@ function requireTemplateChildrenDeclared(file: GeneratedFile): readonly Diagnost
       ?.split(",")
       .map((s) => s.trim())
       .filter(Boolean) ?? [];
-  const declared = new Set(importsList.map(angularSelector));
+  const declared = new Set([
+    ...importsList.map(angularSelector),
+    ...importsList.map(angularAttrSelector),
+  ]);
 
   const missing = new Set<string>();
   for (const tag of template.matchAll(/<(ink-[a-z0-9-]+)/g)) {
     if (!declared.has(tag[1]!)) missing.add(tag[1]!);
+  }
+  // Stacked attribute selectors (`<button inkButtonBase inkButton>`): each must resolve to a
+  // declared component/directive. Scoped to attribute position (whitespace before, whitespace/=/>/
+  // after) so binding values, text, and `ink-*` tags never false-positive.
+  for (const m of template.matchAll(/\s(ink[A-Z]\w*)(?=[\s=/>])/g)) {
+    if (!declared.has(m[1]!)) missing.add(m[1]!);
   }
 
   return [...missing].map((tag) => ({

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -2,6 +2,7 @@ import type { Target, CodegenContext, CodeModule, RewriteRules } from "../../con
 import { angularConformance } from "./conformance.ts";
 import type { Code } from "../../code-ir/nodes.ts";
 import type {
+  IRAttribute,
   IRComponent,
   IRComponentInstance,
   IRElement,
@@ -205,14 +206,10 @@ function unwrapTransition(node: IRNode): IRNode {
   return root;
 }
 
-/**
- * The Angular shape this component emits as. Phase 1 emits `element` (native host element) and
- * `directive` (styling directive stacked onto it); `structural` (the `IInput` flatten) lands in
- * Phase 2 and falls back to the `wrapper` shape until then.
- */
+/** The Angular shape this component emits as; an unresolved/absent entry is a `wrapper` (today's
+ *  `ink-*` element output). */
 function emitKind(entry: AngularComponentEntry | undefined): AngularKind {
-  const kind = entry?.kind ?? "wrapper";
-  return kind === "structural" ? "wrapper" : kind;
+  return entry?.kind ?? "wrapper";
 }
 
 /**
@@ -256,6 +253,49 @@ function emitElementHostEntries(node: IRElement, rules: RewriteRules): string[] 
 function directiveHostEntries(root: IRComponentInstance, rules: RewriteRules): string[] {
   const classAttr = root.attrs.find((a) => rewriteAttrName(a.name, rules) === "class");
   return classAttr ? [`'[class]': ${JSON.stringify(ownClassExpr(classAttr, rules))}`] : [];
+}
+
+/**
+ * Host bindings for a flattened structural component (`IInput` → `div[inkInput]`): the inlined base's
+ * static attrs (its static `class` + any static root attrs) PLUS the styled root instance's own attrs
+ * (its recipe `class` → `[class]`, others via the element rules). The base's *dynamic* root attrs are
+ * pure prop-passthroughs (guaranteed by the registry's flattenability check): the styled instance
+ * fills the ones it forwards (handled below) and omits the rest — matching the base's own `?? null`.
+ */
+function structuralHostEntries(
+  root: IRComponentInstance,
+  baseClass: string | undefined,
+  baseRootAttrs: readonly IRAttribute[],
+  rules: RewriteRules,
+): string[] {
+  const entries: string[] = [];
+  if (baseClass !== undefined) entries.push(`'class': ${JSON.stringify(baseClass)}`);
+  for (const a of baseRootAttrs) {
+    if (a.value.kind !== "Static") continue; // dynamic passthroughs come from the styled instance below
+    entries.push(`'${rewriteAttrName(a.name, rules)}': ${JSON.stringify(String(a.value.value))}`);
+  }
+  for (const a of root.attrs) {
+    const name = rewriteAttrName(a.name, rules);
+    if (name === "class") {
+      entries.push(`'[class]': ${JSON.stringify(ownClassExpr(a, rules))}`);
+      continue;
+    }
+    if (a.value.kind === "Static") {
+      entries.push(`'${name}': ${JSON.stringify(String(a.value.value))}`);
+      continue;
+    }
+    const expr = rewriteExpr(a.value.expr, rules);
+    entries.push(
+      KEEP_PROPERTY.has(name)
+        ? `'[${name}]': ${JSON.stringify(expr)}`
+        : `'[attr.${name}]': ${JSON.stringify(`(${expr}) ?? null`)}`,
+    );
+  }
+  for (const e of root.events) {
+    const evName = rewriteEventName(e.name, rules).replace(/^on/, "").toLowerCase();
+    entries.push(`'(${evName})': ${JSON.stringify(angularEventExpr(e.handler.expr, rules))}`);
+  }
+  return entries;
 }
 
 function emitNode(node: IRNode, rules: RewriteRules): string {
@@ -359,7 +399,9 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       // (wrapper/structural/unresolved) keeps today's `ink-*` element form.
       const entry = rules.angularResolve?.(localName);
       const kind = emitKind(entry);
-      const stacked = kind === "element" || kind === "directive";
+      // element/directive stack the resolved chain; a flattened structural component is self-contained
+      // (its base is inlined) so it stacks just its own selector (`<div inkInput>`).
+      const stacked = kind === "element" || kind === "directive" || kind === "structural";
       const fallthrough = node.acceptsAttrFallthrough === true;
       let classBound = false;
       const ciParts: string[] = [];
@@ -521,6 +563,17 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   const selfKind = emitKind(selfEntry);
   const renderRoot = unwrapTransition(component.render);
 
+  // A structural component (e.g. IInput) flattens its base into itself: the base is inlined (so it is
+  // NOT imported), and the component's template + imports come from the base instance's slot body —
+  // the injected structure — not the dropped base wrapper.
+  const structuralRoot =
+    selfKind === "structural" && renderRoot.kind === "ComponentInstance" ? renderRoot : undefined;
+  const inlinedBase = structuralRoot
+    ? (ctx.componentImports.find((ci) => ci.localName === structuralRoot.reference.getText())
+        ?.componentName ?? structuralRoot.reference.getText())
+    : undefined;
+  const structuralSlotBody = structuralRoot?.slots.find((s) => s.name === "default")?.body;
+
   const body: Code[] = [];
   const angularImports = [
     selfKind === "directive" ? "Directive" : "Component",
@@ -537,13 +590,14 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   }
 
   // Scan the render tree once: instances the standalone `imports` must declare, and whether any
-  // fallthrough root exists (which needs the synthesized `klass` input below).
+  // fallthrough root exists (which needs the synthesized `klass` input below). A structural component
+  // scans its inlined base's slot body instead — so the base itself never enters the imports.
   const instanceNames = new Set<string>();
   // Chain bases a stacked instance needs imported from the styled component's module (which
   // re-exports them): componentName → import path.
   const chainBaseImports = new Map<string, string>();
   let hasFallthroughRoot = false;
-  walkRenderTree(component.render, {
+  walkRenderTree(structuralSlotBody ?? component.render, {
     enter(node) {
       if (node.kind === "ComponentInstance") {
         const local = node.resolved?.name ?? node.reference.getText();
@@ -716,6 +770,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   // same-file siblings (compiled to their own `.component.ts`), and the bases of any stacked
   // attribute-selector chain (re-exported by the styled component, so imported from its module).
   const importedLocals = ctx.componentImports
+    .filter((i) => i.componentName !== inlinedBase)
     .map((i) => i.localName)
     .filter((n): n is string => Boolean(n));
   const sameFileChildren = [...instanceNames].filter(
@@ -740,9 +795,9 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   const reExportBases = new Set(
     selfKind === "directive" && selfEntry ? selfEntry.chainComponents.slice(0, -1) : [],
   );
-  const ownComponentImports = ctx.componentImports.map((ci) =>
-    reExportBases.has(ci.componentName) ? { ...ci, localName: "" } : ci,
-  );
+  const ownComponentImports = ctx.componentImports
+    .filter((ci) => ci.componentName !== inlinedBase)
+    .map((ci) => (reExportBases.has(ci.componentName) ? { ...ci, localName: "" } : ci));
   const reExports = [...reExportBases].map((base) => {
     const imp = ctx.componentImports.find((ci) => ci.componentName === base);
     return cRaw({
@@ -767,6 +822,23 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     const hostEntries = directiveHostEntries(renderRoot as IRComponentInstance, templateRules);
     const hostStr = hostEntries.length > 0 ? `, host: { ${hostEntries.join(", ")} }` : "";
     decoratorText = `@Directive({ standalone: true, selector: '[${angularAttrSelector(component.name)}]'${hostStr}${providersStr} })`;
+  } else if (selfKind === "structural") {
+    // Flatten: the styled component IS the (inlined) base's native element; its template is the
+    // injected structure (the base instance's default slot body), the base wrapper dropped.
+    const root = renderRoot as IRComponentInstance;
+    const selector = angularElementSelector(
+      selfEntry!.hostTag!,
+      angularAttrSelector(component.name),
+    );
+    const hostEntries = structuralHostEntries(
+      root,
+      selfEntry!.baseClass,
+      selfEntry!.rootAttrs ?? [],
+      templateRules,
+    );
+    const hostStr = hostEntries.length > 0 ? `, host: { ${hostEntries.join(", ")} }` : "";
+    const childTemplate = structuralSlotBody ? emitNode(structuralSlotBody, templateRules) : "";
+    decoratorText = `@Component({ standalone: true, selector: '${selector}'${hostStr}${importsStr}${providersStr}, template: \`${escapeTemplate(childTemplate)}\` })`;
   } else {
     const template = emitNode(component.render, templateRules);
     decoratorText = `@Component({ standalone: true, selector: '${angularSelector(component.name)}', host: { style: 'display: contents' }${importsStr}${providersStr}, template: \`${escapeTemplate(template)}\` })`;

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -1,7 +1,12 @@
 import type { Target, CodegenContext, CodeModule, RewriteRules } from "../../context.ts";
 import { angularConformance } from "./conformance.ts";
 import type { Code } from "../../code-ir/nodes.ts";
-import type { IRComponent, IRNode } from "../../../ir/render/nodes.ts";
+import type {
+  IRComponent,
+  IRComponentInstance,
+  IRElement,
+  IRNode,
+} from "../../../ir/render/nodes.ts";
 import { cFile, cImport, cStmt, cRaw, cGroup } from "../../code-ir/builders.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
@@ -15,7 +20,8 @@ import {
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { assertNever } from "../../../core/assert.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
-import { angularSelector } from "./selector.ts";
+import { angularSelector, angularAttrSelector, angularElementSelector } from "./selector.ts";
+import type { AngularComponentEntry, AngularKind } from "./registry.ts";
 import * as ts from "typescript";
 
 /**
@@ -187,6 +193,71 @@ function ownClassExpr(
   return `(${rewriteExpr(a.value.expr!, rules)})`;
 }
 
+/** Escape a string for embedding inside a template literal (backticks and `${`). */
+function escapeTemplate(s: string): string {
+  return s.replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+}
+
+/** Unwrap Transition wrappers to the underlying render root (for root classification/emit). */
+function unwrapTransition(node: IRNode): IRNode {
+  let root = node;
+  while (root.kind === "Transition") root = root.child;
+  return root;
+}
+
+/**
+ * The Angular shape this component emits as. Phase 1 emits `element` (native host element) and
+ * `directive` (styling directive stacked onto it); `structural` (the `IInput` flatten) lands in
+ * Phase 2 and falls back to the `wrapper` shape until then.
+ */
+function emitKind(entry: AngularComponentEntry | undefined): AngularKind {
+  const kind = entry?.kind ?? "wrapper";
+  return kind === "structural" ? "wrapper" : kind;
+}
+
+/**
+ * Host bindings for an element-component's root element (the element IS the host): its attrs — class
+ * as `[class]`, boolean/value-semantic props as `[name]`, every other dynamic attr as
+ * `[attr.name]="(…) ?? null"` — and its events. There is no `klass` merge: a consumer's/forwarded
+ * class arrives as a template `[class]` at the call site and Ivy unions it with these host bindings.
+ */
+function emitElementHostEntries(node: IRElement, rules: RewriteRules): string[] {
+  const entries: string[] = [];
+  for (const a of node.attrs) {
+    const name = rewriteAttrName(a.name, rules);
+    if (name === "class") {
+      entries.push(`'[class]': ${JSON.stringify(ownClassExpr(a, rules))}`);
+      continue;
+    }
+    if (a.value.kind === "Static") {
+      entries.push(`'${name}': ${JSON.stringify(String(a.value.value))}`);
+      continue;
+    }
+    const expr = rewriteExpr(a.value.expr, rules);
+    entries.push(
+      KEEP_PROPERTY.has(name)
+        ? `'[${name}]': ${JSON.stringify(expr)}`
+        : `'[attr.${name}]': ${JSON.stringify(`(${expr}) ?? null`)}`,
+    );
+  }
+  for (const e of node.events) {
+    const evName = rewriteEventName(e.name, rules).replace(/^on/, "").toLowerCase();
+    entries.push(`'(${evName})': ${JSON.stringify(angularEventExpr(e.handler.expr, rules))}`);
+  }
+  return entries;
+}
+
+/**
+ * Host binding for a styling directive: just the recipe `[class]` from the styled root's class attr.
+ * Forwarded props (type/disabled/…) are NOT re-host-bound — they are pure pass-throughs that Angular
+ * routes to the base component on the same element, which host-binds them; re-binding here would
+ * double-write (and the base may transform them, e.g. `disabled || loading`).
+ */
+function directiveHostEntries(root: IRComponentInstance, rules: RewriteRules): string[] {
+  const classAttr = root.attrs.find((a) => rewriteAttrName(a.name, rules) === "class");
+  return classAttr ? [`'[class]': ${JSON.stringify(ownClassExpr(classAttr, rules))}`] : [];
+}
+
 function emitNode(node: IRNode, rules: RewriteRules): string {
   switch (node.kind) {
     case "Element": {
@@ -283,10 +354,12 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       return node.children.map((c) => emitNode(c, rules)).join("\n");
     case "ComponentInstance": {
       const localName = node.resolved?.name ?? node.reference.getText();
-      const tag = angularSelector(localName);
-      // Ivy always treats a `[class]` binding as a host class — it never reaches an input — so a
-      // class passed to a compiled child travels through its synthesized `klass` input instead,
-      // and the child's root element merges it (see the Element case above).
+      // A registered element/directive component renders as its native host element with the resolved
+      // attribute-selector chain stacked on it (`<button inkButtonBase inkButton>`); anything else
+      // (wrapper/structural/unresolved) keeps today's `ink-*` element form.
+      const entry = rules.angularResolve?.(localName);
+      const kind = emitKind(entry);
+      const stacked = kind === "element" || kind === "directive";
       const fallthrough = node.acceptsAttrFallthrough === true;
       let classBound = false;
       const ciParts: string[] = [];
@@ -294,15 +367,21 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
         const name = rewriteAttrName(a.name, rules);
         if (name === "class") {
           classBound = true;
-          const own = ownClassExpr(a, rules);
-          ciParts.push(`[klass]="${fallthrough ? mergedClassExpr(own, rules) : own}"`);
+          const merged = fallthrough
+            ? mergedClassExpr(ownClassExpr(a, rules), rules)
+            : ownClassExpr(a, rules);
+          // A stacked host element binds `[class]` directly — Ivy unions it with the stacked
+          // directives' host `[class]` bindings. A wrapper component never receives `[class]` as an
+          // input (Ivy treats it as a host class), so its forwarded class travels via `[klass]`.
+          ciParts.push(stacked ? `[class]="${merged}"` : `[klass]="${merged}"`);
           continue;
         }
         if (a.value.kind === "Static") ciParts.push(`${name}="${a.value.value}"`);
         else ciParts.push(`[${name}]="${rewriteExpr(a.value.expr, rules)}"`);
       }
       if (fallthrough && !classBound) {
-        ciParts.push(`[klass]="${mergedClassExpr(undefined, rules)}"`);
+        const merged = mergedClassExpr(undefined, rules);
+        ciParts.push(stacked ? `[class]="${merged}"` : `[klass]="${merged}"`);
       }
       for (const e of node.events) {
         // A `$bind:<prop>` lowers to `update:<prop>`; the child's `model()` exposes it as the
@@ -318,9 +397,15 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
         ciParts.push(`(${evName})="${angularEventExpr(e.handler.expr, rules)}"`);
       }
       const ciAttrStr = ciParts.join(" ");
+      const tag = stacked ? entry!.hostTag! : angularSelector(localName);
+      const chain = stacked ? " " + entry!.attrChain.join(" ") : "";
+      const attrPart = ciAttrStr ? " " + ciAttrStr : "";
       if (node.slots.length === 0) {
-        // Non-self-closing: Angular's template parser mishandles self-closed component tags in JIT.
-        return `<${tag}${ciAttrStr ? " " + ciAttrStr : ""}></${tag}>`;
+        // A void host element (e.g. `<input>`) self-closes; every other childless tag needs an
+        // explicit close (Angular's JIT parser mishandles self-closed component/non-void tags).
+        return stacked && VOID_ELEMENTS.has(tag)
+          ? `<${tag}${chain}${attrPart} />`
+          : `<${tag}${chain}${attrPart}></${tag}>`;
       }
       const slotContent = node.slots
         .map((s) => {
@@ -328,7 +413,7 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
           return `<ng-container slot="${s.name}">\n${emitNode(s.body, rules)}\n</ng-container>`;
         })
         .join("\n");
-      return `<${tag}${ciAttrStr ? " " + ciAttrStr : ""}>\n${slotContent}\n</${tag}>`;
+      return `<${tag}${chain}${attrPart}>\n${slotContent}\n</${tag}>`;
     }
     case "Transition":
       return emitNode(node.child, rules);
@@ -423,8 +508,26 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       props: { strip: rules.members?.props?.strip ?? true, whole: propsWhole },
     },
   };
+  // Angular attribute-selector codegen: this component's own emitted shape, plus a resolver for the
+  // shapes of the components it instantiates. No registry (other call paths / direct emit() unit
+  // tests) ⇒ every component is a `wrapper`, i.e. today's `ink-*` element output, unchanged.
+  const localToEntry = (local: string): AngularComponentEntry | undefined => {
+    if (!ctx.angularRegistry) return undefined;
+    const compName =
+      ctx.componentImports.find((ci) => ci.localName === local)?.componentName ?? local;
+    return ctx.angularRegistry.get(compName);
+  };
+  const selfEntry = ctx.angularRegistry?.get(component.name);
+  const selfKind = emitKind(selfEntry);
+  const renderRoot = unwrapTransition(component.render);
+
   const body: Code[] = [];
-  const angularImports = ["Component", "signal", "computed", "effect"];
+  const angularImports = [
+    selfKind === "directive" ? "Directive" : "Component",
+    "signal",
+    "computed",
+    "effect",
+  ];
 
   // Angular templates resolve identifiers against the component instance, so module-level imports
   // referenced by the template (styleframe recipes called inline, e.g. `inputPrefixRecipe({…})`)
@@ -436,11 +539,26 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   // Scan the render tree once: instances the standalone `imports` must declare, and whether any
   // fallthrough root exists (which needs the synthesized `klass` input below).
   const instanceNames = new Set<string>();
+  // Chain bases a stacked instance needs imported from the styled component's module (which
+  // re-exports them): componentName → import path.
+  const chainBaseImports = new Map<string, string>();
   let hasFallthroughRoot = false;
   walkRenderTree(component.render, {
     enter(node) {
       if (node.kind === "ComponentInstance") {
-        instanceNames.add(node.resolved?.name ?? node.reference.getText());
+        const local = node.resolved?.name ?? node.reference.getText();
+        instanceNames.add(local);
+        const entry = localToEntry(local);
+        if ((emitKind(entry) === "element" || emitKind(entry) === "directive") && entry) {
+          // The instance renders as the whole stacked chain (`<button inkButtonBase inkButton>`), so
+          // the standalone component must import every link. The styled component (last in the chain)
+          // is imported via the consumer's own import; its bases are re-exported by it.
+          const selfImport = ctx.componentImports.find((ci) => ci.localName === local);
+          const fromPath = `${selfImport ? selfImport.relativePath : `./${local}`}.component`;
+          for (const base of entry.chainComponents.slice(0, -1)) {
+            chainBaseImports.set(base, fromPath);
+          }
+        }
       }
       if (
         (node.kind === "ComponentInstance" || node.kind === "Element") &&
@@ -452,9 +570,10 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   });
 
   // The class a parent forwards (Vue-style attribute fallthrough). Ivy never routes `[class]`
-  // bindings to inputs, so the forwarded class travels through this dedicated input and the root
-  // element merges it with its own class.
-  if (hasFallthroughRoot) {
+  // bindings to inputs, so a wrapper component receives the forwarded class through this dedicated
+  // input and the root element merges it. Element/directive components don't need it: the element IS
+  // the host, so a forwarded class arrives as a template `[class]` at the call site and Ivy unions it.
+  if (hasFallthroughRoot && selfKind === "wrapper") {
     angularImports.push("input");
     body.push(cStmt({ body: `klass = input<string>()` }));
   }
@@ -568,8 +687,11 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       [r.name, r.loadingName, r.errorName].filter((n): n is string => n !== undefined),
     ),
   );
-  const templateRules: RewriteRules = { ...rules, reactiveBindings: resourceReads };
-  const template = emitNode(component.render, templateRules);
+  const templateRules: RewriteRules = {
+    ...rules,
+    reactiveBindings: resourceReads,
+    angularResolve: localToEntry,
+  };
   const styleImport =
     component.styles.length > 0 ? [cRaw({ text: `import "./${component.name}.css";` })] : [];
 
@@ -590,20 +712,65 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   const providersStr =
     providerEntries.length > 0 ? `, providers: [${providerEntries.join(", ")}]` : "";
 
-  // Standalone components must declare every component they instantiate — both cross-file imports
-  // and same-file siblings (which compile to their own `.component.ts` modules and are imported
-  // here so the `imports: [...]` reference resolves).
+  // Standalone components must declare every component they instantiate — cross-file imports,
+  // same-file siblings (compiled to their own `.component.ts`), and the bases of any stacked
+  // attribute-selector chain (re-exported by the styled component, so imported from its module).
   const importedLocals = ctx.componentImports
     .map((i) => i.localName)
     .filter((n): n is string => Boolean(n));
   const sameFileChildren = [...instanceNames].filter(
-    (n) => !importedLocals.includes(n) && n !== component.name,
+    (n) => !importedLocals.includes(n) && n !== component.name && !chainBaseImports.has(n),
   );
-  const importNames = [...importedLocals, ...sameFileChildren];
+  const chainBaseEntries = [...chainBaseImports].filter(
+    ([name]) => !importedLocals.includes(name) && name !== component.name,
+  );
+  const importNames = [...importedLocals, ...sameFileChildren, ...chainBaseEntries.map(([n]) => n)];
   const importsStr = importNames.length > 0 ? `, imports: [${importNames.join(", ")}]` : "";
   const sameFileImports = sameFileChildren.map((n) =>
     cRaw({ text: `import { ${n}Component as ${n} } from "./${n}.component";` }),
   );
+  const chainBaseImportStmts = chainBaseEntries.map(([name, path]) =>
+    cRaw({ text: `import { ${name}Component as ${name} } from "${path}";` }),
+  );
+
+  // A styling directive does not instantiate its base (it has no template), so it must NOT import
+  // the base component (that would be an unused import) — but it DOES re-export it, so a consumer
+  // can declare the whole stacked chain from the styled component's module. Drop the base's value
+  // import (keep its type imports) and emit the re-export.
+  const reExportBases = new Set(
+    selfKind === "directive" && selfEntry ? selfEntry.chainComponents.slice(0, -1) : [],
+  );
+  const ownComponentImports = ctx.componentImports.map((ci) =>
+    reExportBases.has(ci.componentName) ? { ...ci, localName: "" } : ci,
+  );
+  const reExports = [...reExportBases].map((base) => {
+    const imp = ctx.componentImports.find((ci) => ci.componentName === base);
+    return cRaw({
+      text: `export { ${base}Component } from "${imp ? imp.relativePath : `./${base}`}.component";`,
+    });
+  });
+
+  // Branch the decorator on this component's emitted shape: a native host element (`element`), a
+  // styling directive stacked onto one (`directive`), or today's `ink-*` display:contents wrapper.
+  let decoratorText: string;
+  if (selfKind === "element") {
+    const root = renderRoot as IRElement;
+    const selector = angularElementSelector(root.tag, angularAttrSelector(component.name));
+    const hostEntries = emitElementHostEntries(root, templateRules);
+    const hostStr = hostEntries.length > 0 ? `, host: { ${hostEntries.join(", ")} }` : "";
+    const inline = childrenArePhrasing(root.children);
+    const childTemplate = root.children
+      .map((c) => emitNode(c, templateRules))
+      .join(inline ? "" : "\n");
+    decoratorText = `@Component({ standalone: true, selector: '${selector}'${hostStr}${importsStr}${providersStr}, template: \`${escapeTemplate(childTemplate)}\` })`;
+  } else if (selfKind === "directive") {
+    const hostEntries = directiveHostEntries(renderRoot as IRComponentInstance, templateRules);
+    const hostStr = hostEntries.length > 0 ? `, host: { ${hostEntries.join(", ")} }` : "";
+    decoratorText = `@Directive({ standalone: true, selector: '[${angularAttrSelector(component.name)}]'${hostStr}${providersStr} })`;
+  } else {
+    const template = emitNode(component.render, templateRules);
+    decoratorText = `@Component({ standalone: true, selector: '${angularSelector(component.name)}', host: { style: 'display: contents' }${importsStr}${providersStr}, template: \`${escapeTemplate(template)}\` })`;
+  }
 
   const file = cFile({
     flavor: "ts",
@@ -612,16 +779,16 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         module: "@angular/core",
         named: [...new Set(angularImports)].map((i) => ({ imported: i })),
       }),
-      ...emitComponentImports(ctx.componentImports, ".component", false, "Component"),
+      ...emitComponentImports(ownComponentImports, ".component", false, "Component"),
       ...sameFileImports,
+      ...chainBaseImportStmts,
+      ...reExports,
       ...ctx.externalImports,
       ...styleImport,
       ...(ctx.typeDeclarations.length > 0 ? [cRaw({ text: "" }), ...ctx.typeDeclarations] : []),
       ...(contextDefs.length > 0 ? [cRaw({ text: "" }), ...contextDefs] : []),
       cRaw({ text: "" }),
-      cRaw({
-        text: `@Component({ standalone: true, selector: '${angularSelector(component.name)}', host: { style: 'display: contents' }${importsStr}${providersStr}, template: \`${template.replace(/`/g, "\\`").replace(/\$\{/g, "\\${")}\` })`,
-      }),
+      cRaw({ text: decoratorText }),
       cStmt({ body: `export class ${component.name}Component` }),
       cRaw({ text: "{" }),
       cGroup({ children: body }),

--- a/core/compiler/src/codegen/targets/angular/registry.test.ts
+++ b/core/compiler/src/codegen/targets/angular/registry.test.ts
@@ -35,7 +35,7 @@ const slot = (body: IRNode = createSlotPlaceholder({})) => ({
 });
 
 describe("classifyOne", () => {
-  it("classifies a single static native element root as `element`, capturing host tag + base class", () => {
+  it("classifies a flagged single static native element root as `element`, capturing host tag + base class", () => {
     const c = classifyOne(
       makeComp(
         "IButtonBase",
@@ -47,6 +47,7 @@ describe("classifyOne", () => {
           ],
           children: [createSlotPlaceholder({})],
         }),
+        { element: "button" },
       ),
     );
     expect(c).toMatchObject({ kind: "element", hostTag: "button", baseClass: "button" });
@@ -54,21 +55,34 @@ describe("classifyOne", () => {
     if (c.kind === "element") expect(c.rootAttrs.map((a) => a.name)).toEqual(["type"]);
   });
 
-  it("classifies an element root with no static class as `element` with undefined baseClass", () => {
+  it("classifies a flagged element root with no static class as `element` with undefined baseClass", () => {
     const c = classifyOne(
-      makeComp("IBadgeBase", createElement({ tag: "div", children: [createSlotPlaceholder({})] })),
+      makeComp("IBadgeBase", createElement({ tag: "div", children: [createSlotPlaceholder({})] }), {
+        element: "div",
+      }),
     );
     expect(c).toEqual({ kind: "element", hostTag: "div", baseClass: undefined, rootAttrs: [] });
   });
 
-  it("unwraps a Transition root to classify the underlying element", () => {
+  it("unwraps a Transition root to classify the underlying (flagged) element", () => {
     const c = classifyOne(
-      makeComp("X", createTransition({ child: createElement({ tag: "div" }) })),
+      makeComp("X", createTransition({ child: createElement({ tag: "div" }) }), { element: "div" }),
     );
     expect(c).toMatchObject({ kind: "element", hostTag: "div" });
   });
 
-  it("falls back to `wrapper` when the element root carries a #ref", () => {
+  it("falls back to `wrapper` for an UNMARKED element root, or a declared tag that mismatches the root", () => {
+    // No `element` flag → wrapper (the opt-in: story scaffolding / app components never auto-convert).
+    expect(classifyOne(makeComp("Unmarked", createElement({ tag: "div" })))).toEqual({
+      kind: "wrapper",
+    });
+    // Flag set but the root tag doesn't match → wrapper (INK0130 reports the mismatch in analyze).
+    expect(
+      classifyOne(makeComp("Mismatch", createElement({ tag: "a" }), { element: "button" })),
+    ).toEqual({ kind: "wrapper" });
+  });
+
+  it("falls back to `wrapper` when a flagged element root carries a #ref", () => {
     const c = classifyOne(
       makeComp(
         "X",
@@ -76,6 +90,7 @@ describe("classifyOne", () => {
           tag: "input",
           refs: [{ ref: createExpr({ expr: mockExpr("r") }), category: "element", loc }],
         }),
+        { element: "input" },
       ),
     );
     expect(c).toEqual({ kind: "wrapper" });
@@ -203,7 +218,7 @@ describe("resolveAngularKinds", () => {
     });
   });
 
-  it("stacks a multi-level chain (element ← directive ← directive) root-first", () => {
+  it("stacks a directive over an element base, but stays a wrapper over a non-element base", () => {
     const reg = resolveAngularKinds(
       new Map([
         ["E", raw({ kind: "element", hostTag: "button", rootAttrs: [] })],
@@ -214,12 +229,17 @@ describe("resolveAngularKinds", () => {
         ],
       ]),
     );
-    expect(reg.get("D2")).toMatchObject({
+    // A styling directive decorates a native element host, so it stacks onto the `element` base.
+    expect(reg.get("D1")).toMatchObject({
       kind: "directive",
       hostTag: "button",
-      attrChain: ["inkE", "inkD1", "inkD2"],
-      chainComponents: ["E", "D1", "D2"],
+      attrChain: ["inkE", "inkD1"],
+      chainComponents: ["E", "D1"],
     });
+    // Forwarding over a (non-element) directive base — e.g. a story/app wrapper composing a styled
+    // component — stays a wrapper, not a deep directive stack. This is exactly what keeps story
+    // render components (which wrap a single styled component) as `ink-*` element wrappers.
+    expect(reg.get("D2")!.kind).toBe("wrapper");
   });
 
   it("falls back to `wrapper` when the base resolves to a wrapper, is unknown, or forms a cycle", () => {
@@ -305,6 +325,7 @@ describe("buildAngularRegistry", () => {
       attrs: [createAttribute({ name: "class", value: createStaticValue({ value: "badge" }) })],
       children: [createSlotPlaceholder({})],
     }),
+    { element: "div" },
   );
   const badge = makeComp(
     "IBadge",

--- a/core/compiler/src/codegen/targets/angular/registry.test.ts
+++ b/core/compiler/src/codegen/targets/angular/registry.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from "vitest";
+import * as ts from "typescript";
+import {
+  createAttribute,
+  createComponentInstance,
+  createElement,
+  createExpr,
+  createFragment,
+  createIf,
+  createSlotPlaceholder,
+  createStaticValue,
+  createTransition,
+} from "../../../ir/render/builders.ts";
+import {
+  IR_VERSION,
+  type IRComponent,
+  type IRModule,
+  type IRNode,
+} from "../../../ir/render/nodes.ts";
+import { makeComp, mockExpr, loc } from "../../../testing/codegen.ts";
+import { buildAngularRegistry } from "../../../pipeline/compile.ts";
+import {
+  classifyOne,
+  resolveAngularKinds,
+  type RawClassification,
+  type RawEntry,
+} from "./registry.ts";
+
+const ref = (name: string) => mockExpr(name) as ts.Identifier;
+const slot = (body: IRNode = createSlotPlaceholder({})) => ({
+  name: "default",
+  body,
+  scopedParams: [],
+  loc,
+});
+
+describe("classifyOne", () => {
+  it("classifies a single static native element root as `element`, capturing host tag + base class", () => {
+    const c = classifyOne(
+      makeComp(
+        "IButtonBase",
+        createElement({
+          tag: "button",
+          attrs: [
+            createAttribute({ name: "class", value: createStaticValue({ value: "button" }) }),
+            createAttribute({ name: "type", value: createExpr({ expr: mockExpr("props.type") }) }),
+          ],
+          children: [createSlotPlaceholder({})],
+        }),
+      ),
+    );
+    expect(c).toMatchObject({ kind: "element", hostTag: "button", baseClass: "button" });
+    // The non-class root attrs are captured (for re-hosting when a structural component inlines this base).
+    if (c.kind === "element") expect(c.rootAttrs.map((a) => a.name)).toEqual(["type"]);
+  });
+
+  it("classifies an element root with no static class as `element` with undefined baseClass", () => {
+    const c = classifyOne(
+      makeComp("IBadgeBase", createElement({ tag: "div", children: [createSlotPlaceholder({})] })),
+    );
+    expect(c).toEqual({ kind: "element", hostTag: "div", baseClass: undefined, rootAttrs: [] });
+  });
+
+  it("unwraps a Transition root to classify the underlying element", () => {
+    const c = classifyOne(
+      makeComp("X", createTransition({ child: createElement({ tag: "div" }) })),
+    );
+    expect(c).toMatchObject({ kind: "element", hostTag: "div" });
+  });
+
+  it("falls back to `wrapper` when the element root carries a #ref", () => {
+    const c = classifyOne(
+      makeComp(
+        "X",
+        createElement({
+          tag: "input",
+          refs: [{ ref: createExpr({ expr: mockExpr("r") }), category: "element", loc }],
+        }),
+      ),
+    );
+    expect(c).toEqual({ kind: "wrapper" });
+  });
+
+  it("classifies a conditional / fragment root as `wrapper`", () => {
+    expect(
+      classifyOne(
+        makeComp(
+          "Ctrl",
+          createIf({
+            branches: [
+              {
+                test: createExpr({ expr: mockExpr("t") }),
+                body: createElement({ tag: "textarea" }),
+              },
+            ],
+            fallback: createElement({ tag: "input" }),
+          }),
+        ),
+      ),
+    ).toEqual({ kind: "wrapper" });
+    expect(
+      classifyOne(makeComp("Frag", createFragment({ children: [createElement({ tag: "div" })] }))),
+    ).toEqual({ kind: "wrapper" });
+  });
+
+  it("classifies a pure-forwarding component-instance root as `forwarding` (bare slot, no injected structure)", () => {
+    const c = classifyOne(
+      makeComp(
+        "IButton",
+        createComponentInstance({
+          reference: ref("IButtonBase"),
+          attrs: [createAttribute({ name: "class", value: createExpr({ expr: mockExpr("cls") }) })],
+          slots: [slot()],
+        }),
+      ),
+    );
+    expect(c).toEqual({ kind: "forwarding", rootLocal: "IButtonBase" });
+  });
+
+  it("classifies a component-instance root that injects structure as `structural`", () => {
+    const c = classifyOne(
+      makeComp(
+        "IInput",
+        createComponentInstance({
+          reference: ref("IInputBase"),
+          slots: [
+            slot(
+              createElement({ tag: "span", children: [createSlotPlaceholder({ name: "prefix" })] }),
+            ),
+          ],
+        }),
+      ),
+    );
+    expect(c).toEqual({ kind: "structural", rootLocal: "IInputBase" });
+  });
+});
+
+describe("resolveAngularKinds", () => {
+  const raw = (
+    classification: RawClassification,
+    resolveLocal: (l: string) => string | undefined = () => undefined,
+  ): RawEntry => ({ classification, resolveLocal });
+
+  it("finalizes an element with its own attribute selector + chain", () => {
+    const reg = resolveAngularKinds(
+      new Map([
+        [
+          "IButtonBase",
+          raw({ kind: "element", hostTag: "button", baseClass: "button", rootAttrs: [] }),
+        ],
+      ]),
+    );
+    expect(reg.get("IButtonBase")).toMatchObject({
+      kind: "element",
+      hostTag: "button",
+      attrChain: ["inkButtonBase"],
+      chainComponents: ["IButtonBase"],
+    });
+  });
+
+  it("resolves a forwarding styled component over an element into a stacked `directive`", () => {
+    const reg = resolveAngularKinds(
+      new Map([
+        [
+          "IButtonBase",
+          raw({ kind: "element", hostTag: "button", baseClass: "button", rootAttrs: [] }),
+        ],
+        [
+          "IButton",
+          raw({ kind: "forwarding", rootLocal: "IButtonBase" }, (l) =>
+            l === "IButtonBase" ? "IButtonBase" : undefined,
+          ),
+        ],
+      ]),
+    );
+    expect(reg.get("IButton")).toMatchObject({
+      kind: "directive",
+      hostTag: "button",
+      attrChain: ["inkButtonBase", "inkButton"],
+      chainComponents: ["IButtonBase", "IButton"],
+    });
+  });
+
+  it("resolves a structural styled component over an element into a self-contained `structural`", () => {
+    const reg = resolveAngularKinds(
+      new Map([
+        ["IInputBase", raw({ kind: "element", hostTag: "div", baseClass: "input", rootAttrs: [] })],
+        [
+          "IInput",
+          raw({ kind: "structural", rootLocal: "IInputBase" }, (l) =>
+            l === "IInputBase" ? "IInputBase" : undefined,
+          ),
+        ],
+      ]),
+    );
+    // The base is inlined, so the consumer stacks ONLY this component's selector and imports only it.
+    expect(reg.get("IInput")).toMatchObject({
+      kind: "structural",
+      hostTag: "div",
+      baseClass: "input",
+      attrChain: ["inkInput"],
+      chainComponents: ["IInput"],
+    });
+  });
+
+  it("stacks a multi-level chain (element ← directive ← directive) root-first", () => {
+    const reg = resolveAngularKinds(
+      new Map([
+        ["E", raw({ kind: "element", hostTag: "button", rootAttrs: [] })],
+        ["D1", raw({ kind: "forwarding", rootLocal: "E" }, (l) => (l === "E" ? "E" : undefined))],
+        [
+          "D2",
+          raw({ kind: "forwarding", rootLocal: "D1" }, (l) => (l === "D1" ? "D1" : undefined)),
+        ],
+      ]),
+    );
+    expect(reg.get("D2")).toMatchObject({
+      kind: "directive",
+      hostTag: "button",
+      attrChain: ["inkE", "inkD1", "inkD2"],
+      chainComponents: ["E", "D1", "D2"],
+    });
+  });
+
+  it("falls back to `wrapper` when the base resolves to a wrapper, is unknown, or forms a cycle", () => {
+    const overWrapper = resolveAngularKinds(
+      new Map([
+        ["Base", raw({ kind: "wrapper" })],
+        [
+          "Styled",
+          raw({ kind: "forwarding", rootLocal: "Base" }, (l) =>
+            l === "Base" ? "Base" : undefined,
+          ),
+        ],
+      ]),
+    );
+    expect(overWrapper.get("Styled")!.kind).toBe("wrapper");
+
+    const unknownTarget = resolveAngularKinds(
+      new Map([["Styled", raw({ kind: "forwarding", rootLocal: "Missing" })]]),
+    );
+    expect(unknownTarget.get("Styled")!.kind).toBe("wrapper");
+
+    const cyclic = resolveAngularKinds(
+      new Map([
+        ["A", raw({ kind: "forwarding", rootLocal: "B" }, (l) => (l === "B" ? "B" : undefined))],
+        ["B", raw({ kind: "forwarding", rootLocal: "A" }, (l) => (l === "A" ? "A" : undefined))],
+      ]),
+    );
+    expect(cyclic.get("A")!.kind).toBe("wrapper");
+    expect(cyclic.get("B")!.kind).toBe("wrapper");
+
+    // The local resolves to a name that is outside the scanned set (e.g. a base from an external
+    // package) → that name has no entry → safe wrapper fallback.
+    const externalBase = resolveAngularKinds(
+      new Map([
+        [
+          "Styled",
+          raw({ kind: "forwarding", rootLocal: "Ext" }, (l) =>
+            l === "Ext" ? "ExternalBase" : undefined,
+          ),
+        ],
+      ]),
+    );
+    expect(externalBase.get("Styled")!.kind).toBe("wrapper");
+
+    // A structural component can only flatten a trivial ELEMENT base; over a non-element it can't
+    // flatten → wrapper.
+    const structuralOverWrapper = resolveAngularKinds(
+      new Map([
+        ["Base", raw({ kind: "wrapper" })],
+        [
+          "Struct",
+          raw({ kind: "structural", rootLocal: "Base" }, (l) =>
+            l === "Base" ? "Base" : undefined,
+          ),
+        ],
+      ]),
+    );
+    expect(structuralOverWrapper.get("Struct")!.kind).toBe("wrapper");
+  });
+});
+
+describe("buildAngularRegistry", () => {
+  const IR_MODULE_BASE = {
+    version: IR_VERSION,
+    fileName: "t.tsx",
+    contexts: [],
+    sourceFile: ts.createSourceFile("t.tsx", "", ts.ScriptTarget.Latest, true),
+  } as const;
+
+  const makeModule = (
+    components: IRComponent[],
+    imports: readonly ts.ImportDeclaration[] = [],
+  ): IRModule => ({ ...IR_MODULE_BASE, components, imports });
+
+  const importDecl = (code: string): ts.ImportDeclaration =>
+    ts.createSourceFile("i.tsx", code, ts.ScriptTarget.Latest, true)
+      .statements[0] as ts.ImportDeclaration;
+
+  const badgeBase = makeComp(
+    "IBadgeBase",
+    createElement({
+      tag: "div",
+      attrs: [createAttribute({ name: "class", value: createStaticValue({ value: "badge" }) })],
+      children: [createSlotPlaceholder({})],
+    }),
+  );
+  const badge = makeComp(
+    "IBadge",
+    createComponentInstance({
+      reference: ref("IBadgeBase"),
+      attrs: [createAttribute({ name: "class", value: createExpr({ expr: mockExpr("cls") }) })],
+      slots: [slot()],
+    }),
+  );
+
+  it("resolves a same-file styled+headless pair (local name === component name)", () => {
+    const reg = buildAngularRegistry([makeModule([badgeBase, badge])]);
+    expect(reg.get("IBadgeBase")).toMatchObject({
+      kind: "element",
+      hostTag: "div",
+      attrChain: ["inkBadgeBase"],
+    });
+    expect(reg.get("IBadge")).toMatchObject({
+      kind: "directive",
+      hostTag: "div",
+      attrChain: ["inkBadgeBase", "inkBadge"],
+      chainComponents: ["IBadgeBase", "IBadge"],
+    });
+  });
+
+  it("resolves a cross-file styled+headless pair via the import map", () => {
+    const reg = buildAngularRegistry([
+      makeModule([badgeBase]),
+      makeModule([badge], [importDecl('import IBadgeBase from "../headless/IBadgeBase.ink";')]),
+    ]);
+    expect(reg.get("IBadge")).toMatchObject({
+      kind: "directive",
+      hostTag: "div",
+      chainComponents: ["IBadgeBase", "IBadge"],
+    });
+  });
+});

--- a/core/compiler/src/codegen/targets/angular/registry.ts
+++ b/core/compiler/src/codegen/targets/angular/registry.ts
@@ -1,0 +1,168 @@
+// Angular-only whole-program component registry.
+//
+// The Angular target emits a component as its native element via an attribute selector
+// (`<button inkButtonBase inkButton>`) instead of an `ink-*` wrapper, matching the Angular Material
+// directive-on-native-element pattern. To do that, the emitter for a styled component must know the
+// SHAPE of the (often cross-file) component its root instantiates — its native host tag, and whether
+// it is itself an element / directive / wrapper. Classification is INFERRED from each component's
+// real render root (no authoring flag), then resolved transitively across the module set.
+//
+// `classifyOne` produces a per-component raw classification from its render root; `resolveAngularKinds`
+// walks the references transitively (cycle-safe) to finalize each component's kind, native host tag,
+// and the attribute chain a consumer must stack. Both are pure; the orchestration that feeds them
+// real modules lives in `buildAngularRegistry` (pipeline/compile.ts).
+
+import type { IRAttribute, IRComponent, IRSlotContent } from "../../../ir/render/nodes.ts";
+import { walkRenderTree } from "../../../ir/render/visit.ts";
+import { angularAttrSelector } from "./selector.ts";
+
+/**
+ * - `element`: a single static native root element → `@Component({ selector: 'TAG[inkName]' })`, the
+ *   element IS the host (no wrapper, no `display:contents`).
+ * - `directive`: a pure-forwarding styled component whose root instantiates an element-component →
+ *   `@Directive({ selector: '[inkName]' })`, stacked onto the base element.
+ * - `structural`: a styled component that injects its OWN structure into a trivial base's slot →
+ *   flattened to `@Component({ selector: 'TAG[inkName]' })` (the base is inlined). Phase 2.
+ * - `wrapper`: anything else (conditional / fragment / dynamic / text root, or a ref on the root) →
+ *   today's `ink-*` element component with `display:contents`.
+ */
+export type AngularKind = "element" | "directive" | "structural" | "wrapper";
+
+export interface AngularComponentEntry {
+  readonly kind: AngularKind;
+  /** element / structural / directive: the resolved native host tag (`"button"`, `"div"`, `"span"`). */
+  readonly hostTag?: string;
+  /** element / structural: the host element's static class (`"button"`), for the flattened class merge. */
+  readonly baseClass?: string;
+  /** element / structural: the host element's non-class root attrs, for re-hosting when inlined. */
+  readonly rootAttrs?: readonly IRAttribute[];
+  /** Attribute selectors a consumer stacks on the host, root-first (`["inkButtonBase","inkButton"]`). */
+  readonly attrChain: readonly string[];
+  /** Component names a consumer must add to `imports: [...]` for the whole stacked chain. */
+  readonly chainComponents: readonly string[];
+}
+
+export type AngularRegistry = ReadonlyMap<string, AngularComponentEntry>;
+
+/** The per-component classification derived from its own render root, before transitive resolution. */
+export type RawClassification =
+  | {
+      readonly kind: "element";
+      readonly hostTag: string;
+      readonly baseClass?: string;
+      readonly rootAttrs: readonly IRAttribute[];
+    }
+  | { readonly kind: "wrapper" }
+  | { readonly kind: "forwarding"; readonly rootLocal: string }
+  | { readonly kind: "structural"; readonly rootLocal: string };
+
+/** Classify a component from its render root alone (no cross-component resolution yet). */
+export function classifyOne(component: IRComponent): RawClassification {
+  let root = component.render;
+  while (root.kind === "Transition") root = root.child;
+
+  if (root.kind === "Element") {
+    // A `#ref` on the root has no host-binding form (a template ref lives in a template, and the
+    // host element is reached via ElementRef injection, not `#ref`) → keep the wrapper.
+    if (root.refs.length > 0) return { kind: "wrapper" };
+    const classAttr = root.attrs.find((a) => a.name === "class");
+    const baseClass =
+      classAttr && classAttr.value.kind === "Static" ? String(classAttr.value.value) : undefined;
+    const rootAttrs = root.attrs.filter((a) => a.name !== "class");
+    return { kind: "element", hostTag: root.tag, baseClass, rootAttrs };
+  }
+
+  if (root.kind === "ComponentInstance") {
+    const rootLocal = root.reference.getText();
+    // A styled component that injects its OWN structure into the base's slot is structural; one that
+    // only forwards the consumer's children (a bare <Slot>) is a pure-forwarding styling directive.
+    return slotsInjectStructure(root.slots)
+      ? { kind: "structural", rootLocal }
+      : { kind: "forwarding", rootLocal };
+  }
+
+  // If / For / Switch / Fragment / Text / Expression / SlotPlaceholder roots have no single native
+  // host element — they keep today's `ink-*` element wrapper.
+  return { kind: "wrapper" };
+}
+
+/** True when the styled root instance projects its own elements/components into the base (vs. only
+ *  forwarding the consumer's children through a bare <Slot>). */
+function slotsInjectStructure(slots: readonly IRSlotContent[]): boolean {
+  let injects = false;
+  for (const slot of slots) {
+    walkRenderTree(slot.body, {
+      enter(node) {
+        if (node.kind === "Element" || node.kind === "ComponentInstance") injects = true;
+      },
+    });
+    if (injects) break;
+  }
+  return injects;
+}
+
+export interface RawEntry {
+  readonly classification: RawClassification;
+  /** Resolve a render-root instance's LOCAL import name to the referenced component's name. */
+  readonly resolveLocal: (local: string) => string | undefined;
+}
+
+/**
+ * Finalize every component's kind by resolving `forwarding`/`structural` candidates transitively to
+ * their base's resolved kind. Cycles and unresolvable bases fall back to `wrapper` (never throws,
+ * never loops). Pure: takes the raw classifications + per-component local resolvers, returns the map.
+ */
+export function resolveAngularKinds(entries: ReadonlyMap<string, RawEntry>): AngularRegistry {
+  const WRAPPER: AngularComponentEntry = { kind: "wrapper", attrChain: [], chainComponents: [] };
+
+  function resolve(name: string, visiting: ReadonlySet<string>): AngularComponentEntry {
+    const raw = entries.get(name);
+    if (!raw) return WRAPPER; // outside the scanned set (external / unknown) → safe fallback
+    const c = raw.classification;
+
+    if (c.kind === "wrapper") return WRAPPER;
+    if (c.kind === "element") {
+      return {
+        kind: "element",
+        hostTag: c.hostTag,
+        baseClass: c.baseClass,
+        rootAttrs: c.rootAttrs,
+        attrChain: [angularAttrSelector(name)],
+        chainComponents: [name],
+      };
+    }
+
+    // forwarding | structural candidate — resolve the base transitively.
+    if (visiting.has(name)) return WRAPPER; // cycle → safe fallback
+    const targetName = raw.resolveLocal(c.rootLocal);
+    const target = targetName ? resolve(targetName, new Set(visiting).add(name)) : undefined;
+    if (!target) return WRAPPER;
+
+    if (c.kind === "forwarding") {
+      // A styling directive stacks onto any host-bearing base — an element, another directive, or a
+      // flattened structural component: `<tag …baseChain inkSelf>`. Only a wrapper base can't stack.
+      if (target.kind === "wrapper") return WRAPPER;
+      return {
+        kind: "directive",
+        hostTag: target.hostTag,
+        attrChain: [...target.attrChain, angularAttrSelector(name)],
+        chainComponents: [...target.chainComponents, name],
+      };
+    }
+    // structural: flatten the trivial element base into a self-contained @Component, so a consumer
+    // stacks only this component's own selector. Only an `element` base is a flattenable slot-wrapper.
+    if (target.kind !== "element") return WRAPPER;
+    return {
+      kind: "structural",
+      hostTag: target.hostTag,
+      baseClass: target.baseClass,
+      rootAttrs: target.rootAttrs,
+      attrChain: [angularAttrSelector(name)],
+      chainComponents: [name],
+    };
+  }
+
+  const out = new Map<string, AngularComponentEntry>();
+  for (const name of entries.keys()) out.set(name, resolve(name, new Set()));
+  return out;
+}

--- a/core/compiler/src/codegen/targets/angular/registry.ts
+++ b/core/compiler/src/codegen/targets/angular/registry.ts
@@ -63,9 +63,14 @@ export function classifyOne(component: IRComponent): RawClassification {
   while (root.kind === "Transition") root = root.child;
 
   if (root.kind === "Element") {
-    // A `#ref` on the root has no host-binding form (a template ref lives in a template, and the
-    // host element is reached via ElementRef injection, not `#ref`) → keep the wrapper.
-    if (root.refs.length > 0) return { kind: "wrapper" };
+    // Attribute-selector element-components are an explicit opt-in: the author declares the native
+    // host tag via `element: "<tag>"`. An unmarked element root (story scaffolding, app components)
+    // stays a wrapper, so classification never silently changes a component's selector style. A
+    // declared tag that doesn't match the actual root, or a root `#ref` (which has no host-binding
+    // form), also falls back to wrapper — the tag mismatch is surfaced as INK0130 during analyze.
+    if (component.element === undefined || component.element !== root.tag || root.refs.length > 0) {
+      return { kind: "wrapper" };
+    }
     const classAttr = root.attrs.find((a) => a.name === "class");
     const baseClass =
       classAttr && classAttr.value.kind === "Static" ? String(classAttr.value.value) : undefined;
@@ -159,9 +164,12 @@ export function resolveAngularKinds(entries: ReadonlyMap<string, RawEntry>): Ang
     if (!target) return WRAPPER;
 
     if (c.kind === "forwarding") {
-      // A styling directive stacks onto any host-bearing base — an element, another directive, or a
-      // flattened structural component: `<tag …baseChain inkSelf>`. Only a wrapper base can't stack.
-      if (target.kind === "wrapper") return WRAPPER;
+      // A styling directive decorates a native ELEMENT host (`<button inkButtonBase inkButton>`), so
+      // it stacks only onto an `element` base. This is also what distinguishes a library styled
+      // component (forwards into an element leaf → directive) from a story/app wrapper that composes a
+      // styled component (forwards into a directive/structural → stays an `ink-*` wrapper, which the
+      // Storybook generator instantiates by element selector). No story-path heuristic needed.
+      if (target.kind !== "element") return WRAPPER;
       return {
         kind: "directive",
         hostTag: target.hostTag,

--- a/core/compiler/src/codegen/targets/angular/registry.ts
+++ b/core/compiler/src/codegen/targets/angular/registry.ts
@@ -12,6 +12,7 @@
 // and the attribute chain a consumer must stack. Both are pure; the orchestration that feeds them
 // real modules lives in `buildAngularRegistry` (pipeline/compile.ts).
 
+import * as ts from "typescript";
 import type { IRAttribute, IRComponent, IRSlotContent } from "../../../ir/render/nodes.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
 import { angularAttrSelector } from "./selector.ts";
@@ -101,6 +102,25 @@ function slotsInjectStructure(slots: readonly IRSlotContent[]): boolean {
   return injects;
 }
 
+/**
+ * Whether an element base can be flattened into a structural component: its non-class root attrs are
+ * all static or pure prop-passthroughs (`<div id={props.id}>`). A transforming attr
+ * (`id={props.id ?? "x"}`) is NOT flattenable — dropping it (when the styled component doesn't pass
+ * it) would lose the transform — so such a base keeps the wrapper form.
+ */
+function isFlattenableBase(rootAttrs: readonly IRAttribute[]): boolean {
+  return rootAttrs.every((a) => {
+    if (a.value.kind === "Static") return true;
+    const expr = a.value.expr;
+    return (
+      ts.isPropertyAccessExpression(expr) &&
+      ts.isIdentifier(expr.expression) &&
+      expr.expression.text === "props" &&
+      expr.name.text === a.name
+    );
+  });
+}
+
 export interface RawEntry {
   readonly classification: RawClassification;
   /** Resolve a render-root instance's LOCAL import name to the referenced component's name. */
@@ -150,8 +170,10 @@ export function resolveAngularKinds(entries: ReadonlyMap<string, RawEntry>): Ang
       };
     }
     // structural: flatten the trivial element base into a self-contained @Component, so a consumer
-    // stacks only this component's own selector. Only an `element` base is a flattenable slot-wrapper.
-    if (target.kind !== "element") return WRAPPER;
+    // stacks only this component's own selector. The base must be an `element` whose non-class root
+    // attrs are all static or pure prop-passthroughs (`id={props.id}`) — then the styled component
+    // simply omits any it doesn't pass, matching the base's own `?? null`, with no lost transform.
+    if (target.kind !== "element" || !isFlattenableBase(target.rootAttrs ?? [])) return WRAPPER;
     return {
       kind: "structural",
       hostTag: target.hostTag,

--- a/core/compiler/src/codegen/targets/angular/selector.test.ts
+++ b/core/compiler/src/codegen/targets/angular/selector.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { angularSelector, angularAttrSelector, angularElementSelector } from "./selector.ts";
+
+describe("angularSelector", () => {
+  it("derives a kebab-case ink-* element selector, folding a leading I into the prefix", () => {
+    expect(angularSelector("IBadge")).toBe("ink-badge");
+    expect(angularSelector("IInputControlBase")).toBe("ink-input-control-base");
+    expect(angularSelector("Label")).toBe("ink-label");
+  });
+});
+
+describe("angularAttrSelector", () => {
+  it("derives a camelCase ink* attribute selector, folding a leading I into the prefix", () => {
+    expect(angularAttrSelector("IButtonBase")).toBe("inkButtonBase");
+    expect(angularAttrSelector("IBadge")).toBe("inkBadge");
+    expect(angularAttrSelector("IInputControlBase")).toBe("inkInputControlBase");
+    expect(angularAttrSelector("Label")).toBe("inkLabel");
+  });
+});
+
+describe("angularElementSelector", () => {
+  it("combines a native tag with an attribute selector", () => {
+    expect(angularElementSelector("button", "inkButtonBase")).toBe("button[inkButtonBase]");
+    expect(angularElementSelector("div", "inkFieldGroup")).toBe("div[inkFieldGroup]");
+  });
+});

--- a/core/compiler/src/codegen/targets/angular/selector.ts
+++ b/core/compiler/src/codegen/targets/angular/selector.ts
@@ -20,3 +20,22 @@ export function angularSelector(componentName: string): string {
     .toLowerCase();
   return `ink-${kebab}`;
 }
+
+/**
+ * The camelCase attribute selector for a compiled component used as an attribute-selector
+ * directive/host-element (the Angular Material pattern, e.g. `<button mat-button>`). The leading
+ * `I` folds into the `ink` prefix, mirroring {@link angularSelector}:
+ *
+ * - `IButtonBase` → `inkButtonBase`
+ * - `IBadge` → `inkBadge`
+ * - `Label` → `inkLabel`
+ */
+export function angularAttrSelector(componentName: string): string {
+  const base = componentName.replace(/^I(?=[A-Z])/, "");
+  return "ink" + base.charAt(0).toUpperCase() + base.slice(1);
+}
+
+/** An element-plus-attribute selector for an attribute-selector component (`button[inkButtonBase]`). */
+export function angularElementSelector(tag: string, attr: string): string {
+  return `${tag}[${attr}]`;
+}

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -32,6 +32,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0100",
       "INK0110",
       "INK0120",
+      "INK0130",
     ];
     expect(codes.sort()).toEqual(expected.sort());
   });
@@ -64,7 +65,7 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
-  it("codes with placeholders: INK0030, INK0044, INK0080, INK0090, INK0100, INK0110, INK0120", () => {
+  it("codes with placeholders: INK0030, INK0044, INK0080, INK0090, INK0100, INK0110, INK0120, INK0130", () => {
     const withPlaceholders = codes.filter((c) => /\{\w+\}/.test(DIAGNOSTICS[c].title));
     expect(withPlaceholders.sort()).toEqual([
       "INK0030",
@@ -74,6 +75,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0100",
       "INK0110",
       "INK0120",
+      "INK0130",
     ]);
   });
 });

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -163,6 +163,12 @@ export const DIAGNOSTICS = {
     help: "Give the component a single host-element root so it can inherit class and other attributes." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0120" as const,
   },
+  INK0130: {
+    severity: "error" as const,
+    title: '{name}: element="{element}" but the root is not a single native <{element}>' as const,
+    help: "Set `element` to the component's actual native root tag, or remove it to keep the ink-* element wrapper." as const,
+    url: "https://docs.inkline.dev/diagnostics/INK0130" as const,
+  },
 } as const;
 
 export type DiagnosticCode = keyof typeof DIAGNOSTICS;

--- a/core/compiler/src/core/options.ts
+++ b/core/compiler/src/core/options.ts
@@ -1,5 +1,6 @@
 import { ALL_TARGETS, type TargetName, type TargetRegistry } from "../codegen/context.ts";
 import { builtinRegistry } from "../codegen/registry.ts";
+import type { AngularRegistry } from "../codegen/targets/angular/registry.ts";
 import type { Plugin } from "../plugin/types.ts";
 
 export type SourceMapMode = "external" | "inline" | "none";
@@ -48,6 +49,12 @@ export interface InklineConfig {
    * Inkline's own compiler options (jsx, jsxImportSource, …) are always forced on top.
    */
   readonly tsconfig?: string;
+  /**
+   * Angular-only whole-program component registry (component name → host tag / kind / attribute
+   * chain), built by a pre-pass over all components and consumed by the Angular target's
+   * attribute-selector codegen. Ignored by every other target. Built via `buildAngularRegistry`.
+   */
+  readonly angularRegistry?: AngularRegistry;
 }
 
 export interface ResolvedCompilerOptions {
@@ -61,6 +68,7 @@ export interface ResolvedCompilerOptions {
   readonly verbose: boolean;
   readonly registry: TargetRegistry;
   readonly tsconfig?: string;
+  readonly angularRegistry?: AngularRegistry;
 }
 
 export function resolveOptions(
@@ -92,5 +100,6 @@ export function resolveOptions(
     verbose: config.verbose ?? false,
     registry,
     tsconfig: config.tsconfig,
+    angularRegistry: config.angularRegistry,
   };
 }

--- a/core/compiler/src/index.ts
+++ b/core/compiler/src/index.ts
@@ -1,5 +1,5 @@
 // ============ TOP-LEVEL ENTRY POINT ============
-export { compile } from "./pipeline/compile.ts";
+export { compile, analyzeOnly, buildAngularRegistry } from "./pipeline/compile.ts";
 export type { CompileInput, CompileResult, AnalyzedModule } from "./pipeline/compile.ts";
 export {
   compileIncremental,
@@ -24,7 +24,18 @@ export { pipe } from "./pipeline/types.ts";
 // ============ TARGET NAMING ============
 // The Angular element selector for a compiled component (`IBadge` → `ink-badge`). Exported for
 // tooling that instantiates compiled components by tag (e.g. the Storybook story generator).
-export { angularSelector } from "./codegen/targets/angular/selector.ts";
+export {
+  angularSelector,
+  angularAttrSelector,
+  angularElementSelector,
+} from "./codegen/targets/angular/selector.ts";
+// The Angular attribute-selector registry (component name → host tag / kind / attribute chain),
+// built by `buildAngularRegistry` over `analyzeOnly` modules and threaded back in via config.
+export type {
+  AngularRegistry,
+  AngularComponentEntry,
+  AngularKind,
+} from "./codegen/targets/angular/registry.ts";
 
 // ============ DIAGNOSTICS ============
 export type { Diagnostic, DiagnosticSeverity, DiagnosticCode } from "./core/diagnostics/codes.ts";

--- a/core/compiler/src/ir/render/nodes.ts
+++ b/core/compiler/src/ir/render/nodes.ts
@@ -382,6 +382,13 @@ export interface IRComponent {
   readonly expose?: readonly string[];
   readonly styles: readonly IRStyleBlock[];
   readonly runtime: IRRuntimeMode;
+  /**
+   * Angular-only authoring opt-in: the native host tag this component's root renders (`"button"`,
+   * `"div"`, `"span"`). When set, the Angular target emits the component as an attribute-selector
+   * host element / directive (`button[inkButtonBase]`) instead of an `ink-*` element wrapper. Set
+   * via `defineComponent({ element: "button" }, …)`; validated against the actual root (INK0130).
+   */
+  readonly element?: string;
   readonly targetOverrides: Readonly<Partial<Record<TargetName, IRTargetOverride>>>;
   readonly slotBindings?: ReadonlyMap<string, string>;
 }

--- a/core/compiler/src/pipeline/analyze-only.test.ts
+++ b/core/compiler/src/pipeline/analyze-only.test.ts
@@ -26,10 +26,8 @@ describe("analyzeOnly", () => {
     const analyzed = await analyzeOnly({ fileName, source }, { targets: ["angular"] });
     const registry = buildAngularRegistry([analyzed.module]);
 
-    // The fixture's `<button>` root → an element-component host tag, inferred (no authoring flag).
-    expect(registry.get(analyzed.module.components[0]!.name)).toMatchObject({
-      kind: "element",
-      hostTag: "button",
-    });
+    // The fixture's `<button>` root has no `element` flag, so attribute-selector codegen is opt-out:
+    // it resolves to a `wrapper` (the integration still works — analyzeOnly → IR → classify).
+    expect(registry.get(analyzed.module.components[0]!.name)).toMatchObject({ kind: "wrapper" });
   });
 });

--- a/core/compiler/src/pipeline/analyze-only.test.ts
+++ b/core/compiler/src/pipeline/analyze-only.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { analyzeOnly, buildAngularRegistry } from "./compile.ts";
+
+const FIXTURES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "__fixtures__");
+
+describe("analyzeOnly", () => {
+  it("runs program→parse→lower→analyze and returns the analyzed module without emitting", async () => {
+    const fileName = resolve(FIXTURES_DIR, "IButton.ink.tsx");
+    const source = readFileSync(fileName, "utf-8");
+
+    const analyzed = await analyzeOnly({ fileName, source }, { targets: ["angular"] });
+
+    expect(analyzed.module.components).toHaveLength(1);
+    const comp = analyzed.module.components[0]!;
+    expect(comp.render.kind).toBe("Element");
+    expect(analyzed.graphs.size).toBe(1);
+  });
+
+  it("feeds buildAngularRegistry on real compiled IR (the CLI/harness pre-pass integration)", async () => {
+    const fileName = resolve(FIXTURES_DIR, "IButton.ink.tsx");
+    const source = readFileSync(fileName, "utf-8");
+
+    const analyzed = await analyzeOnly({ fileName, source }, { targets: ["angular"] });
+    const registry = buildAngularRegistry([analyzed.module]);
+
+    // The fixture's `<button>` root → an element-component host tag, inferred (no authoring flag).
+    expect(registry.get(analyzed.module.components[0]!.name)).toMatchObject({
+      kind: "element",
+      hostTag: "button",
+    });
+  });
+});

--- a/core/compiler/src/pipeline/compile.ts
+++ b/core/compiler/src/pipeline/compile.ts
@@ -6,6 +6,12 @@ import { SymbolTable } from "../ir/reactivity.ts";
 import type { IRComponent, IRModule } from "../ir/render/nodes.ts";
 import type { Code } from "../codegen/code-ir/nodes.ts";
 import type { ComponentImport, GeneratedFile, Target, TargetName } from "../codegen/context.ts";
+import {
+  classifyOne,
+  resolveAngularKinds,
+  type AngularRegistry,
+  type RawEntry,
+} from "../codegen/targets/angular/registry.ts";
 import { cRaw } from "../codegen/code-ir/builders.ts";
 import { print } from "../codegen/print/printer.ts";
 import { PluginRunner } from "../plugin/runner.ts";
@@ -35,7 +41,7 @@ function extractExternalImports(module: IRModule): readonly Code[] {
     .map((decl) => cRaw({ text: decl.getText(module.sourceFile) }));
 }
 
-function extractComponentImports(module: IRModule): readonly ComponentImport[] {
+export function extractComponentImports(module: IRModule): readonly ComponentImport[] {
   return module.imports
     .filter((decl) => {
       const spec = (decl.moduleSpecifier as import("typescript").StringLiteral).text;
@@ -104,6 +110,7 @@ function emitComponent(
     externalImports,
     componentImports,
     typeDeclarations,
+    angularRegistry: ctx.options.angularRegistry,
   });
   const result = print(codeModule.root, { sourceMap: ctx.options.sourceMap });
   const files: GeneratedFile[] = [
@@ -129,6 +136,77 @@ function emitComponent(
   }
 
   return files;
+}
+
+/** Run the front-end passes (program → parse → lower → analyze) for a single file, no emit. */
+async function runFrontendPasses(input: CompileInput, ctx: PassContext): Promise<AnalyzedModule> {
+  // P1: create TS program
+  const artifact = await programPass.run(input, ctx);
+
+  // P2: parse .ink.tsx → IRModule
+  const rawModule = await parsePass.run(artifact, ctx);
+
+  // P2.5: resolve sibling files (.ink.css, .ink.scss) and merge styles
+  const siblings = resolveSiblings(input.fileName);
+  const moduleWithSiblings: IRModule =
+    siblings.styles.length > 0
+      ? {
+          ...rawModule,
+          components: rawModule.components.map((c) => ({
+            ...c,
+            styles: [...c.styles, ...siblings.styles],
+          })),
+        }
+      : rawModule;
+
+  // P3: lower (normalize control flow, slots, bindings, static marks)
+  const module = lower(moduleWithSiblings, ctx);
+
+  // P4: analyze (reactivity graph + validation + cycle detection)
+  return analyzePass.run(module, ctx);
+}
+
+/**
+ * Run the front-end passes for a single file and return the analyzed module WITHOUT emitting. Used
+ * to build whole-program metadata (the Angular attribute-selector registry) in a cheap pre-pass
+ * before the real per-file compile. Diagnostics are discarded — the subsequent `compile()` re-runs
+ * the passes and surfaces them.
+ */
+export async function analyzeOnly(
+  input: CompileInput,
+  config?: Partial<InklineConfig>,
+): Promise<AnalyzedModule> {
+  const options = resolveOptions(config);
+  const ctx: PassContext = {
+    diagnostics: createDiagnosticCollector(),
+    options,
+    symbols: new SymbolTable(),
+    registry: options.registry,
+  };
+  return runFrontendPasses(input, ctx);
+}
+
+/**
+ * Build the Angular attribute-selector registry from a set of analyzed modules: classify each
+ * component by its render root, then resolve `forwarding`/`structural` candidates transitively to
+ * their (possibly cross-file) base. A component instance references its target by LOCAL import name,
+ * so each module contributes a resolver mapping local → component name (cross-file via
+ * `extractComponentImports`, same-file via the module's own component names).
+ */
+export function buildAngularRegistry(modules: readonly IRModule[]): AngularRegistry {
+  const entries = new Map<string, RawEntry>();
+  for (const module of modules) {
+    const localMap = new Map<string, string>();
+    for (const ci of extractComponentImports(module)) {
+      if (ci.localName) localMap.set(ci.localName, ci.componentName);
+    }
+    for (const c of module.components) localMap.set(c.name, c.name);
+    const resolveLocal = (local: string): string | undefined => localMap.get(local);
+    for (const c of module.components) {
+      entries.set(c.name, { classification: classifyOne(c), resolveLocal });
+    }
+  }
+  return resolveAngularKinds(entries);
 }
 
 export async function compile(
@@ -175,30 +253,8 @@ export async function compile(
     }
   }
 
-  // P1: create TS program
-  const artifact = await programPass.run(input, ctx);
-
-  // P2: parse .ink.tsx → IRModule
-  const rawModule = await parsePass.run(artifact, ctx);
-
-  // P2.5: resolve sibling files (.ink.css, .ink.scss) and merge styles
-  const siblings = resolveSiblings(input.fileName);
-  const moduleWithSiblings: IRModule =
-    siblings.styles.length > 0
-      ? {
-          ...rawModule,
-          components: rawModule.components.map((c) => ({
-            ...c,
-            styles: [...c.styles, ...siblings.styles],
-          })),
-        }
-      : rawModule;
-
-  // P3: lower (normalize control flow, slots, bindings, static marks)
-  const module = lower(moduleWithSiblings, ctx);
-
-  // P4: analyze (reactivity graph + validation + cycle detection)
-  const analyzedModule = await analyzePass.run(module, ctx);
+  // P1–P4: program → parse → lower → analyze
+  const analyzedModule = await runFrontendPasses(input, ctx);
 
   // Plugin runner
   const runner = new PluginRunner(options.plugins);

--- a/core/compiler/src/pipeline/passes/02-parse/index.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/index.ts
@@ -106,6 +106,7 @@ export const parsePass: Pass<TsProgramArtifact, IRModule> = {
         primitives,
         styles,
         runtime,
+        element: optionsResult?.element,
         targetOverrides: {},
         slotBindings: setupResult.slotBindings.size > 0 ? setupResult.slotBindings : undefined,
       };

--- a/core/compiler/src/pipeline/passes/02-parse/options.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.ts
@@ -17,6 +17,7 @@ export interface ParsedOptions {
   readonly events: IREventDeclaration[];
   readonly styles: IRStyleBlock[];
   readonly runtime: IRRuntimeMode;
+  readonly element?: string;
 }
 
 function makeExprNode(expr: ts.Expression, sf: ts.SourceFile): IRExprNode {
@@ -43,6 +44,7 @@ export function parseOptions(
   const events: IREventDeclaration[] = [];
   const styles: IRStyleBlock[] = [];
   let runtime: IRRuntimeMode = "iso";
+  let element: string | undefined;
 
   for (const prop of options.properties) {
     if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
@@ -71,10 +73,16 @@ export function parseOptions(
         }
         break;
       }
+      // Angular-only: the native host tag this component's root renders. Opts the component into
+      // attribute-selector codegen; validated against the actual root tag in analyze (INK0130).
+      case "element": {
+        if (ts.isStringLiteral(prop.initializer)) element = prop.initializer.text;
+        break;
+      }
     }
   }
 
-  return { props, slots, events, styles, runtime };
+  return { props, slots, events, styles, runtime, element };
 }
 
 function parseStyleFromValue(

--- a/core/compiler/src/pipeline/passes/04-analyze/index.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/index.ts
@@ -1,7 +1,12 @@
 import type { IRModule } from "../../../ir/render/nodes.ts";
 import type { Pass } from "../../types.ts";
 import { buildReactivityGraph, type ReactivityGraph } from "./graph.ts";
-import { diagnoseCycles, validateAttrFallthrough, validateComponent } from "./validate.ts";
+import {
+  diagnoseCycles,
+  validateAttrFallthrough,
+  validateComponent,
+  validateElementFlag,
+} from "./validate.ts";
 
 export interface AnalyzedModule {
   readonly module: IRModule;
@@ -19,6 +24,7 @@ export const analyzePass: Pass<IRModule, AnalyzedModule> = {
       graphs.set(component.id, graph);
 
       validateComponent(component, ctx);
+      validateElementFlag(component, ctx);
       validateAttrFallthrough(component, localComponents, ctx);
       diagnoseCycles(component, graph, ctx);
     }
@@ -28,4 +34,9 @@ export const analyzePass: Pass<IRModule, AnalyzedModule> = {
 };
 
 export { buildReactivityGraph, type ReactivityGraph } from "./graph.ts";
-export { validateComponent, validateAttrFallthrough, diagnoseCycles } from "./validate.ts";
+export {
+  validateComponent,
+  validateElementFlag,
+  validateAttrFallthrough,
+  diagnoseCycles,
+} from "./validate.ts";

--- a/core/compiler/src/pipeline/passes/04-analyze/validate.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/validate.ts
@@ -53,6 +53,25 @@ export function validateComponent(component: IRComponent, ctx: PassContext): voi
 }
 
 /**
+ * INK0130: a component declares `element: "<tag>"` (opting into Angular attribute-selector codegen)
+ * but its render root is not a single native `<tag>` element — so it can't be emitted as that host
+ * element (the Angular target falls back to the `ink-*` wrapper). Mirrors the classifier's
+ * element-acceptance condition so the two never silently disagree.
+ */
+export function validateElementFlag(component: IRComponent, ctx: PassContext): void {
+  if (component.element === undefined) return;
+  let root = component.render;
+  while (root.kind === "Transition") root = root.child;
+  const ok = root.kind === "Element" && root.tag === component.element && root.refs.length === 0;
+  if (!ok) {
+    ctx.diagnostics.push("INK0130", component.loc, {
+      name: component.name,
+      element: component.element,
+    });
+  }
+}
+
+/**
  * INK0120: a parent passes a `class` (a fallthrough attribute) to a child component whose root
  * cannot inherit it (fragment / control-flow / multiple roots). Resolution is limited to components
  * defined in the same module; cross-module children are skipped (their root kind is not known here).

--- a/core/core/src/index.ts
+++ b/core/core/src/index.ts
@@ -7,6 +7,12 @@ interface ComponentOptions {
   events?: Record<string, Record<string, never>>;
   runtime?: "client" | "server" | "iso";
   name?: string;
+  /**
+   * Angular-only: the native host tag this component's root renders (`"button"`, `"div"`, `"span"`).
+   * Opts the component into best-practice attribute-selector codegen (`button[inkButtonBase]`)
+   * instead of an `ink-*` element wrapper. Ignored by every other target.
+   */
+  element?: string;
 }
 
 export type InkComponent<P = {}> = (

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -170,6 +170,9 @@ export default defineCommand({
     // real per-file compile below threads the resulting registry into codegen.
     let angularRegistry: AngularRegistry | undefined;
     if (targets.includes("angular")) {
+      // Attribute-selector classification is opt-in via the `element` flag (see registry.ts), so
+      // story render components and unflagged app components resolve to `wrapper` on their own — we
+      // scan every file with no story-path special-casing, and styled components resolve their bases.
       const modules = await Promise.all(
         resolvedFiles.map(async (filePath) => {
           const absPath = resolve(filePath);
@@ -225,7 +228,14 @@ export default defineCommand({
 
     flushNamedBarrels(barrelEntries, namedGroups, writeOutput);
 
-    await generateStories(targets, outDir, targetOutDir, srcDir ?? sourcePrefix, namespaceGroup);
+    await generateStories(
+      targets,
+      outDir,
+      targetOutDir,
+      srcDir ?? sourcePrefix,
+      namespaceGroup,
+      angularRegistry,
+    );
 
     if (args.watch) {
       return runWatch(
@@ -253,6 +263,7 @@ async function generateStories(
   targetOutDir: Partial<Record<string, string>>,
   srcDir: string,
   namespaceGroup: BarrelGroup | undefined,
+  angularRegistry?: AngularRegistry,
   write: (path: string, content: string) => void = writeOutput,
 ): Promise<void> {
   const targetKeys = Object.keys(targetOutDir);
@@ -272,6 +283,7 @@ async function generateStories(
       storiesDir,
       generatedDir: storiesDir,
       frameworks,
+      angularRegistry,
     });
     if (result.files.length > 0) {
       console.log(
@@ -389,6 +401,9 @@ function runWatch(
           targetOutDir,
           srcDir ?? sourcePrefix,
           namespaceGroup,
+          // Watch mode compiles incrementally without a registry — every component emits as a wrapper
+          // (its `ink-*` selector), so bare stories on `meta.component` render fine without it.
+          undefined,
           writeIfChanged,
         ).catch((err) => console.error("Story generation error:", err));
       }, 150);

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -5,7 +5,10 @@ import {
   compile,
   compileIncremental,
   createIncrementalState,
+  analyzeOnly,
+  buildAngularRegistry,
   meetsLevel,
+  type AngularRegistry,
   type BarrelGroup,
   type TargetName,
   type IncrementalState,
@@ -161,6 +164,25 @@ export default defineCommand({
       }
     }
 
+    // Pass 1 (Angular only): infer each component's attribute-selector shape from its render root so
+    // a styled component emits as a native host element with stacked directives instead of an `ink-*`
+    // wrapper. A cheap pre-pass — program→parse→lower→analyze, no emit — over every file, before the
+    // real per-file compile below threads the resulting registry into codegen.
+    let angularRegistry: AngularRegistry | undefined;
+    if (targets.includes("angular")) {
+      const modules = await Promise.all(
+        resolvedFiles.map(async (filePath) => {
+          const absPath = resolve(filePath);
+          const analyzed = await analyzeOnly(
+            { fileName: absPath, source: readFileSync(absPath, "utf-8") },
+            { targets, tsconfig: fileConfig.tsconfig },
+          );
+          return analyzed.module;
+        }),
+      );
+      angularRegistry = buildAngularRegistry(modules);
+    }
+
     for (const filePath of resolvedFiles) {
       const absPath = resolve(filePath);
       const source = readFileSync(absPath, "utf-8");
@@ -178,6 +200,7 @@ export default defineCommand({
           targetOptions: fileConfig.targetOptions,
           registry: fileConfig.registry,
           tsconfig: fileConfig.tsconfig,
+          angularRegistry,
         },
       );
 

--- a/tooling/storybook/src/generator/index.ts
+++ b/tooling/storybook/src/generator/index.ts
@@ -1,7 +1,7 @@
 import { globSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { angularSelector } from "@inkline/compiler";
+import { angularSelector, type AngularRegistry } from "@inkline/compiler";
 import type { StoryMeta, StoryVariant } from "../define.ts";
 import { type FrameworkConfig, activeFrameworks } from "./config.ts";
 export { activeFrameworks } from "./config.ts";
@@ -14,6 +14,12 @@ export interface GenerateOptions {
   readonly frameworks?: readonly FrameworkConfig[];
   readonly generatedDir?: string;
   readonly storiesDir?: string;
+  /**
+   * Angular attribute-selector registry. Lets the Angular story emitter render a directive-kind
+   * component (which has no standalone element) on its native host element with the stacked chain.
+   * Absent → bare stories fall back to `meta.component` (correct for wrapper/element components).
+   */
+  readonly angularRegistry?: AngularRegistry;
 }
 
 export interface GeneratedFile {
@@ -161,7 +167,7 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
         storyOutputRelDir,
         generatedDir,
       );
-      const source = renderStory(storyModule, framework, renderImports);
+      const source = renderStory(storyModule, framework, renderImports, options.angularRegistry);
       keysByTarget.set(framework.target, extractStoryKeys(source));
 
       const outDir = join(options.rootDir, framework.target, storiesDir, relDir);

--- a/tooling/storybook/src/generator/render.ts
+++ b/tooling/storybook/src/generator/render.ts
@@ -1,3 +1,4 @@
+import type { AngularRegistry } from "@inkline/compiler";
 import type { LoadedStoryModule, ResolvedRenderImport } from "./index.ts";
 import type { FrameworkConfig } from "./config.ts";
 import { renderCsf3 } from "./templates/csf3.ts";
@@ -7,11 +8,12 @@ export function renderStory(
   storyModule: LoadedStoryModule,
   framework: FrameworkConfig,
   renderImports: readonly ResolvedRenderImport[],
+  angularRegistry?: AngularRegistry,
 ): string {
   switch (framework.template) {
     case "csf3":
       return renderCsf3(storyModule, framework, renderImports);
     case "angular":
-      return renderAngular(storyModule, framework, renderImports);
+      return renderAngular(storyModule, framework, renderImports, angularRegistry);
   }
 }

--- a/tooling/storybook/src/generator/templates/angular.test.ts
+++ b/tooling/storybook/src/generator/templates/angular.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
+import type { AngularComponentEntry, AngularRegistry } from "@inkline/compiler";
 import { renderAngular } from "./angular.ts";
 import { frameworkByTarget } from "../config.ts";
 import type { LoadedStoryModule, ResolvedRenderImport } from "../index.ts";
+
+const registryOf = (name: string, entry: AngularComponentEntry): AngularRegistry =>
+  new Map([[name, entry]]);
 
 const angular = frameworkByTarget("angular")!;
 
@@ -122,6 +126,40 @@ describe("renderAngular", () => {
     expect(out.match(/import { prefixSuffixComponent as PrefixSuffixStory }/g)).toHaveLength(1);
     expect(out).toContain("export const Default: Story = { render: () =>");
     expect(out).toContain("export const PrefixSuffix: Story = { render: () =>");
+  });
+
+  it("mounts a directive-kind component's bare stories on its native host with the stacked chain", () => {
+    const registry = registryOf("Button", {
+      kind: "directive",
+      hostTag: "button",
+      attrChain: ["inkButtonBase", "inkButton"],
+      chainComponents: ["IButtonBase", "Button"],
+    });
+    const out = renderAngular(buttonModule, angular, [], registry);
+
+    // The styled self is imported from the main package; the headless base from `/headless`.
+    expect(out).toContain('import { IButtonBase } from "@inkline/angular/headless";');
+    // Bare stories render the chain on the host element and bind args (from argTypes) to its inputs.
+    expect(out).toContain(
+      'export const Default: Story = { render: (args) => ({ props: args, moduleMetadata: { imports: [IButtonBase, Button] }, template: `<button inkButtonBase inkButton [label]="label"></button>` }) };',
+    );
+    expect(out).toContain(
+      'export const Disabled: Story = { args: {"disabled":true}, render: (args) => ({ props: args, moduleMetadata: { imports: [IButtonBase, Button] }, template: `<button inkButtonBase inkButton [label]="label"></button>` }) };',
+    );
+  });
+
+  it("leaves a non-directive (element/wrapper) component's bare stories on meta.component", () => {
+    const registry = registryOf("Button", {
+      kind: "element",
+      hostTag: "button",
+      attrChain: ["inkButton"],
+      chainComponents: ["Button"],
+    });
+    const out = renderAngular(buttonModule, angular, [], registry);
+
+    expect(out).toContain("export const Default: Story = {};");
+    expect(out).not.toContain("/headless");
+    expect(out).not.toContain("render: (args) =>");
   });
 
   it("validates component and story identifiers", () => {

--- a/tooling/storybook/src/generator/templates/angular.ts
+++ b/tooling/storybook/src/generator/templates/angular.ts
@@ -1,3 +1,4 @@
+import type { AngularRegistry } from "@inkline/compiler";
 import type { LoadedStoryModule, ResolvedRenderImport } from "../index.ts";
 import type { FrameworkConfig } from "../config.ts";
 import { BANNER, assertIdentifier, renderImportLines, serializeArgs } from "./shared.ts";
@@ -6,17 +7,35 @@ export function renderAngular(
   storyModule: LoadedStoryModule,
   framework: FrameworkConfig,
   renderImports: readonly ResolvedRenderImport[],
+  angularRegistry?: AngularRegistry,
 ): string {
   const { meta, stories } = storyModule;
   assertIdentifier(meta.component, "component");
 
   const renderByStory = new Map(renderImports.map((r) => [r.storyName, r]));
 
+  // A styling directive (`[inkButton]`) has no standalone element for Storybook to render from
+  // `meta.component`, so its bare stories mount it on its native host with the stacked chain
+  // (`<button inkButtonBase inkButton [args]>`). Element/structural/wrapper components render fine
+  // via `meta.component` (an element host tag), so they keep the bare-story form.
+  const entry = angularRegistry?.get(meta.component);
+  const directive = entry && entry.kind === "directive" ? entry : undefined;
+
   const lines: string[] = [
     BANNER,
     `import type { Meta, StoryObj } from "${framework.typeImport}";`,
     `import { ${meta.component} } from "${framework.componentPackage}";`,
   ];
+
+  // The chain's headless base(s) live in the framework package's `/headless` entry; the styled self
+  // (`meta.component`) is already imported above. Both are needed in `moduleMetadata.imports`.
+  if (directive) {
+    for (const base of directive.chainComponents) {
+      if (base === meta.component) continue;
+      assertIdentifier(base, "chain component");
+      lines.push(`import { ${base} } from "${framework.componentPackage}/headless";`);
+    }
+  }
 
   lines.push(...renderImportLines(renderImports, framework.hasDefaultExport));
 
@@ -32,6 +51,15 @@ export function renderAngular(
 
   lines.push("};", "export default meta;", "", `type Story = StoryObj<${meta.component}>;`, "");
 
+  // The host-element template + arg bindings are component-level (shared by every bare story).
+  let directiveRender = "";
+  if (directive) {
+    const argKeys = meta.argTypes ? Object.keys(meta.argTypes) : Object.keys(meta.args ?? {});
+    const bindings = argKeys.map((k) => `[${k}]="${k}"`).join(" ");
+    const open = `${directive.hostTag} ${directive.attrChain.join(" ")}${bindings ? " " + bindings : ""}`;
+    directiveRender = `({ props: args, moduleMetadata: { imports: [${directive.chainComponents.join(", ")}] }, template: \`<${open}></${directive.hostTag}>\` })`;
+  }
+
   for (const [name, variant] of Object.entries(stories)) {
     assertIdentifier(name, "story name");
     const ri = renderByStory.get(name);
@@ -40,6 +68,11 @@ export function renderAngular(
         .replaceAll("{name}", ri.localName)
         .replaceAll("{selector}", ri.selector);
       lines.push(`export const ${name}: Story = { render: () => ${expr} };`);
+    } else if (directive) {
+      const argsPart = variant.args ? `args: ${serializeArgs(variant.args)}, ` : "";
+      lines.push(
+        `export const ${name}: Story = { ${argsPart}render: (args) => ${directiveRender} };`,
+      );
     } else {
       const body = variant.args ? `{ args: ${serializeArgs(variant.args)} }` : "{}";
       lines.push(`export const ${name}: Story = ${body};`);

--- a/tooling/storybook/src/preset/main.test.ts
+++ b/tooling/storybook/src/preset/main.test.ts
@@ -37,6 +37,7 @@ describe("createStorybookConfig", () => {
     );
     expect(out.resolve?.alias).toEqual({
       foo: "bar",
+      "@inkline/react/headless": "/repo/ui/react/generated/headless.ts",
       "@inkline/react": "/repo/ui/react/generated/index.ts",
     });
   });
@@ -45,6 +46,7 @@ describe("createStorybookConfig", () => {
     const config = createStorybookConfig(base);
     const out = await config.viteFinal({}, { configType: "DEVELOPMENT" });
     expect(out.resolve?.alias).toEqual({
+      "@inkline/react/headless": "/repo/ui/react/generated/headless.ts",
       "@inkline/react": "/repo/ui/react/generated/index.ts",
     });
     expect(out.server).toEqual({ cors: { origin: true, credentials: true } });

--- a/tooling/storybook/src/preset/main.ts
+++ b/tooling/storybook/src/preset/main.ts
@@ -66,7 +66,18 @@ export function createStorybookConfig(options: StorybookConfigOptions): Storyboo
       if (configType !== "PRODUCTION") {
         next.resolve = {
           ...next.resolve,
-          alias: { ...next.resolve?.alias, [componentPackage]: sourceEntry },
+          alias: {
+            ...next.resolve?.alias,
+            // Both the styled barrel (main) and the headless barrel alias to their `.inkline` source,
+            // so a generated story can import either — e.g. an Angular directive bare-story pulls its
+            // headless base from `@inkline/<fw>/headless`. The subpath alias is listed first so it
+            // wins over the bare-package alias.
+            [`${componentPackage}/headless`]: sourceEntry.replace(
+              /index\.([cm]?[jt]s)$/,
+              "headless.$1",
+            ),
+            [componentPackage]: sourceEntry,
+          },
         };
         next.server = {
           ...((next.server ?? {}) as Record<string, unknown>),

--- a/tooling/test-utils/src/angular-chain.ts
+++ b/tooling/test-utils/src/angular-chain.ts
@@ -1,0 +1,70 @@
+// Prepare a styled component + the headless parts it composes for Angular SSR mounting. The files
+// are compiled in isolation, so a shared attribute-selector registry must be built across them
+// first — otherwise every styled component classifies as a `wrapper` and silently reverts to `ink-*`
+// output. The registry also yields the mount host: a styling directive (`[inkButton]`) renders on
+// its native host element with the resolved attribute chain (it can't be reflected for a host tag).
+
+import { readFileSync } from "node:fs";
+import {
+  analyzeOnly,
+  buildAngularRegistry,
+  type GeneratedFile,
+  type InklineConfig,
+} from "@inkline/compiler";
+import { compileComponent } from "./compile.ts";
+import type { AngularMountHost } from "./mount.ts";
+
+export interface StyledAngularChain {
+  readonly entry: GeneratedFile;
+  readonly supporting: readonly GeneratedFile[];
+  readonly host?: AngularMountHost;
+}
+
+export async function prepareStyledAngularChain(
+  styledPath: string,
+  headlessPaths: readonly string[],
+  config?: Partial<InklineConfig>,
+): Promise<StyledAngularChain> {
+  const allPaths = [styledPath, ...headlessPaths];
+  const modules = await Promise.all(
+    allPaths.map(async (p) => {
+      const analyzed = await analyzeOnly(
+        { fileName: p, source: readFileSync(p, "utf-8") },
+        { ...config, targets: ["angular"] },
+      );
+      return analyzed.module;
+    }),
+  );
+  const registry = buildAngularRegistry(modules);
+  const filesFor = (p: string) =>
+    compileComponent(p, {
+      targets: ["angular"],
+      config: { ...config, angularRegistry: registry },
+    }).then((r) => r.filesFor("angular"));
+
+  // Styled sources import their parts via `../headless/<name>.component`, so lay the generated files
+  // out under `styled/` and `headless/` to keep those relative specifiers resolvable in the sandbox.
+  const styledFiles = await filesFor(styledPath);
+  const [entryFile, ...styledRest] = styledFiles;
+  const entry = { ...entryFile!, path: `styled/${entryFile!.path}` };
+  const supporting: GeneratedFile[] = styledRest.map((f) => ({ ...f, path: `styled/${f.path}` }));
+  for (const hp of headlessPaths) {
+    const files = await filesFor(hp);
+    supporting.push(...files.map((f) => ({ ...f, path: `headless/${f.path}` })));
+  }
+
+  // An attribute-selector entry mounts on its native host element with the resolved chain; a
+  // `wrapper` entry falls back to mount.ts's auto-reflection of its `ink-*` selector.
+  const entryName = entryFile!.path.replace(/\.component\.ts$/, "");
+  const e = registry.get(entryName);
+  const host: AngularMountHost | undefined =
+    e && (e.kind === "directive" || e.kind === "element") && e.hostTag
+      ? {
+          tag: e.hostTag,
+          attrs: e.attrChain,
+          imports: e.chainComponents.map((c) => `${c}Component`),
+        }
+      : undefined;
+
+  return { entry, supporting, host };
+}

--- a/tooling/test-utils/src/angular-class-merge.test.ts
+++ b/tooling/test-utils/src/angular-class-merge.test.ts
@@ -1,0 +1,88 @@
+// R1 spike / regression guard for the Angular attribute-selector codegen (best-practice host
+// elements). The whole directive-stacking design rests on one Ivy behaviour: when several
+// directives/components sit on ONE element and each declares a `host: { '[class]': … }` binding,
+// Ivy must UNION the class tokens (not last-wins). The existing SSR tests only exercise the
+// `[klass]`-input forward, so they do NOT cover this — hence this dedicated proof.
+//
+// We can't mount an attribute-selector component directly (mount.ts's auto-host would emit an
+// invalid `<button[inkBase]>` tag), so the entry is an ordinary element-selector wrapper whose
+// template stacks the attribute selectors on a real `<button>` — exactly the shape codegen will
+// emit at a `<IButton>` call site.
+
+import { describe, it, expect } from "vitest";
+import { mountForTarget } from "./mount.ts";
+import type { GeneratedFile } from "@inkline/compiler";
+
+function hostEntry(contents: string): GeneratedFile {
+  return { path: "SpikeHost.component.ts", contents };
+}
+
+/** Pull the `class="…"` value off the first `<button …>` in the rendered HTML. */
+function buttonClass(html: string): string {
+  const m = html.match(/<button[^>]*\sclass="([^"]*)"/);
+  return m ? m[1]! : "";
+}
+
+describe("angular host [class] merge (attribute-selector design gate)", () => {
+  it("unions [class] host bindings from a component + N stacked directives on one element", async () => {
+    // One @Component (button[inkBase]) + two @Directive ([inkStyled], [inkExtra]), each host-binding
+    // a DISJOINT class token set, all on the same <button>. Union ⇒ every token present.
+    const entry = hostEntry(`
+import { Component, Directive } from "@angular/core";
+
+@Component({ standalone: true, selector: "button[inkBase]", host: { "[class]": "'cmp-base'" }, template: "" })
+class InkBaseComponent {}
+
+@Directive({ standalone: true, selector: "[inkStyled]", host: { "[class]": "'dir-x dir-y'" } })
+class InkStyledDirective {}
+
+@Directive({ standalone: true, selector: "[inkExtra]", host: { "[class]": "'dir-z'" } })
+class InkExtraDirective {}
+
+@Component({
+  standalone: true,
+  selector: "spike-host",
+  imports: [InkBaseComponent, InkStyledDirective, InkExtraDirective],
+  template: \`<button inkBase inkStyled inkExtra></button>\`,
+})
+class SpikeHostComponent {}
+
+export default SpikeHostComponent;
+`);
+
+    const { html } = await mountForTarget("angular", entry);
+    const cls = buttonClass(html);
+
+    // If Ivy did last-wins instead of union, one or more of these tokens would be missing — that
+    // is the signal to switch to the fused-element fallback in the plan.
+    expect(cls.split(/\s+/).filter(Boolean).sort()).toEqual(
+      ["cmp-base", "dir-x", "dir-y", "dir-z"].sort(),
+    );
+  });
+
+  it("routes a directive's property host binding ([disabled]) onto the shared element", async () => {
+    const entry = hostEntry(`
+import { Component, Directive } from "@angular/core";
+
+@Component({ standalone: true, selector: "button[inkBase]", host: { "[class]": "'cmp-base'" }, template: "" })
+class InkBaseComponent {}
+
+@Directive({ standalone: true, selector: "[inkDisable]", host: { "[disabled]": "true" } })
+class InkDisableDirective {}
+
+@Component({
+  standalone: true,
+  selector: "spike-host",
+  imports: [InkBaseComponent, InkDisableDirective],
+  template: \`<button inkBase inkDisable></button>\`,
+})
+class SpikeHostComponent {}
+
+export default SpikeHostComponent;
+`);
+
+    const { html } = await mountForTarget("angular", entry);
+    expect(html).toMatch(/<button[^>]*\bdisabled\b/);
+    expect(buttonClass(html)).toContain("cmp-base");
+  });
+});

--- a/tooling/test-utils/src/angular-class-merge.test.ts
+++ b/tooling/test-utils/src/angular-class-merge.test.ts
@@ -60,6 +60,37 @@ export default SpikeHostComponent;
     );
   });
 
+  it("unions an element's own template [class] binding with stacked host [class] bindings", async () => {
+    // The consumer of a styled component passes `class` as a TEMPLATE `[class]` on the host element
+    // (`<button inkButtonBase inkButton [class]="'extra'">`). It must union with the component's and
+    // directives' host `[class]` bindings — this lets element/directive kinds drop the `klass` input
+    // entirely and route the consumer class straight onto the element.
+    const entry = hostEntry(`
+import { Component, Directive } from "@angular/core";
+
+@Component({ standalone: true, selector: "button[inkBase]", host: { "[class]": "'cmp-base'" }, template: "" })
+class InkBaseComponent {}
+
+@Directive({ standalone: true, selector: "[inkStyled]", host: { "[class]": "'dir-recipe'" } })
+class InkStyledDirective {}
+
+@Component({
+  standalone: true,
+  selector: "spike-host",
+  imports: [InkBaseComponent, InkStyledDirective],
+  template: \`<button inkBase inkStyled [class]="'consumer-extra'"></button>\`,
+})
+class SpikeHostComponent {}
+
+export default SpikeHostComponent;
+`);
+
+    const { html } = await mountForTarget("angular", entry);
+    expect(buttonClass(html).split(/\s+/).filter(Boolean).sort()).toEqual(
+      ["cmp-base", "consumer-extra", "dir-recipe"].sort(),
+    );
+  });
+
   it("routes a directive's property host binding ([disabled]) onto the shared element", async () => {
     const entry = hostEntry(`
 import { Component, Directive } from "@angular/core";

--- a/tooling/test-utils/src/angular-mount.test.ts
+++ b/tooling/test-utils/src/angular-mount.test.ts
@@ -82,7 +82,7 @@ describe("angular SSR mount", () => {
     // it into a real `<button inkBtn …>` — proving element-components are mountable standalone.
     const ELEMENT = `
 import { defineComponent, Slot } from "@inkline/core";
-export default defineComponent({ slots: { default: {} } }, (props: { label?: string }) => (
+export default defineComponent({ slots: { default: {} }, element: "button" }, (props: { label?: string }) => (
   <button class="btn"><Slot>{props.label}</Slot></button>
 ));
 `;

--- a/tooling/test-utils/src/angular-mount.test.ts
+++ b/tooling/test-utils/src/angular-mount.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from "vitest";
 import { compileSource } from "./compile.ts";
 import { mountForTarget } from "./mount.ts";
-import type { GeneratedFile } from "@inkline/compiler";
+import { analyzeOnly, buildAngularRegistry, type GeneratedFile } from "@inkline/compiler";
 
 // A same-file styled + headless pair mirroring the Badge pattern (headless root carries the base
 // class; the styled wrapper computes a recipe class and forwards it via the `class` attribute).
@@ -74,6 +74,34 @@ describe("angular SSR mount", () => {
     expect(html).toContain("Hi");
     // Components render inside their kebab-case ink-* host elements.
     expect(html).toContain("<ink-badge-base");
+  });
+
+  it("mounts an attribute-selector element-component on its native host (parsed tag[attr] selector)", async () => {
+    // With a registry, a single static-element root compiles to a `button[inkBtn]` @Component (the
+    // element IS the host). Mounted WITHOUT a host spec, mount.ts reflects that selector and parses
+    // it into a real `<button inkBtn …>` — proving element-components are mountable standalone.
+    const ELEMENT = `
+import { defineComponent, Slot } from "@inkline/core";
+export default defineComponent({ slots: { default: {} } }, (props: { label?: string }) => (
+  <button class="btn"><Slot>{props.label}</Slot></button>
+));
+`;
+    const analyzed = await analyzeOnly(
+      { fileName: "Btn.ink.tsx", source: ELEMENT },
+      { targets: ["angular"] },
+    );
+    const registry = buildAngularRegistry([analyzed.module]);
+    const result = await compileSource(ELEMENT, {
+      targets: ["angular"],
+      fileName: "Btn.ink.tsx",
+      config: { angularRegistry: registry },
+    });
+    expect(result.errors).toEqual([]);
+    const [entry, ...supporting] = result.filesFor("angular");
+    const { html } = await mountForTarget("angular", entry!, { label: "Hi" }, supporting);
+
+    expect(html).toMatch(/<button[^>]*class="btn"[^>]*>Hi<\/button>/);
+    expect(html).not.toContain("ink-btn");
   });
 
   it("renders without the recipe modifier when the styling prop is absent", async () => {

--- a/tooling/test-utils/src/index.ts
+++ b/tooling/test-utils/src/index.ts
@@ -26,10 +26,22 @@ export {
   type EquivalenceResult,
 } from "./equivalence.ts";
 
-export { isMountable, mountForTarget, type MountResult } from "./mount.ts";
+export { isMountable, mountForTarget, type MountResult, type AngularMountHost } from "./mount.ts";
+
+export { prepareStyledAngularChain, type StyledAngularChain } from "./angular-chain.ts";
 
 export { normalizeHtml } from "./normalize.ts";
 
 export { resolveComponent } from "./resolve.ts";
 
-export type { TargetName, GeneratedFile, Diagnostic } from "@inkline/compiler";
+// The Angular attribute-selector registry: built over a styled component + the headless parts it
+// composes so they classify as directives/elements (instead of silently reverting to `ink-*`
+// wrappers when compiled in isolation). Re-exported so SSR helpers have a single import source.
+export { analyzeOnly, buildAngularRegistry } from "@inkline/compiler";
+export type {
+  TargetName,
+  GeneratedFile,
+  Diagnostic,
+  AngularRegistry,
+  AngularComponentEntry,
+} from "@inkline/compiler";

--- a/tooling/test-utils/src/mount.ts
+++ b/tooling/test-utils/src/mount.ts
@@ -8,6 +8,18 @@ export interface MountResult {
   readonly warnings: readonly string[];
 }
 
+/**
+ * How to mount an Angular attribute-selector entry. A styling directive (`[inkButton]`) can't be
+ * reflected for a host tag and isn't a standalone element, so the caller (which knows the registry)
+ * supplies the native host tag, the stacked attribute selectors, and the chain's exported class
+ * names to import from the entry module. Omit for `ink-*` element/wrapper entries (auto-reflected).
+ */
+export interface AngularMountHost {
+  readonly tag: string;
+  readonly attrs: readonly string[];
+  readonly imports: readonly string[];
+}
+
 const MOUNTABLE_TARGETS: ReadonlySet<TargetName> = new Set([
   "react",
   "vue",
@@ -35,6 +47,7 @@ export async function mountForTarget(
   file: GeneratedFile,
   props?: Record<string, unknown>,
   supportingFiles?: readonly GeneratedFile[],
+  angularHost?: AngularMountHost,
 ): Promise<MountResult> {
   if (!isMountable(target)) {
     throw new Error(
@@ -47,7 +60,13 @@ export async function mountForTarget(
   console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
 
   try {
-    const { html, stderr } = await mountViaTempFile(target, file, props, supportingFiles ?? []);
+    const { html, stderr } = await mountViaTempFile(
+      target,
+      file,
+      props,
+      supportingFiles ?? [],
+      angularHost,
+    );
     // The sandbox routes runtime logging to stderr; surface it as warnings for debuggability.
     if (stderr.trim()) warnings.push(...stderr.trim().split("\n"));
     return { html, warnings };
@@ -61,6 +80,7 @@ async function mountViaTempFile(
   file: GeneratedFile,
   props: Record<string, unknown> | undefined,
   supportingFiles: readonly GeneratedFile[],
+  angularHost: AngularMountHost | undefined,
 ): Promise<{ html: string; stderr: string }> {
   const tmp = mkdtempSync(join(tmpdir(), "ink-mount-"));
 
@@ -85,7 +105,7 @@ async function mountViaTempFile(
       symlinkSync(nodeModulesSource, nodeModulesDest, "dir");
     }
 
-    const mountScript = buildMountScript(target, `./${entryPath}`, props);
+    const mountScript = buildMountScript(target, `./${entryPath}`, props, angularHost);
     const mountPath = join(tmp, "__mount__.mjs");
     writeFileSync(mountPath, mountScript, "utf-8");
 
@@ -259,6 +279,7 @@ function buildMountScript(
   target: TargetName,
   componentPath: string,
   props?: Record<string, unknown>,
+  angularHost?: AngularMountHost,
 ): string {
   const propsJson = JSON.stringify(props ?? {});
 
@@ -299,7 +320,10 @@ process.stdout.write(result.body);
 `;
     case "angular":
       // JIT-compile (via the @angular/compiler import) and SSR the component inside a generated
-      // host whose template binds each prop and projects `__slots` entries as slot content.
+      // host whose template binds each prop and projects `__slots` entries as slot content. An
+      // attribute-selector entry renders on its native host tag with the selector attributes
+      // present: either auto-derived from a reflected `tag[attr]` element selector, or — for a
+      // styling directive (not reflectable, not a standalone element) — from an explicit host spec.
       return `
 import "@angular/compiler";
 import { Component, provideZonelessChangeDetection, reflectComponentType } from "@angular/core";
@@ -312,11 +336,23 @@ import * as mod from "${componentPath}";
 console.log = (...args) => console.error(...args);
 console.info = (...args) => console.error(...args);
 
-const candidates = Object.values(mod).filter((v) => typeof v === "function");
-const C = mod.default ?? candidates.find((v) => reflectComponentType(v) != null);
-const mirror = reflectComponentType(C);
-if (!mirror) throw new Error("No Angular component found in module");
-const selector = mirror.selector.split(",")[0].trim();
+const hostSpec = ${JSON.stringify(angularHost ?? null)};
+let imports, tag, attrs;
+if (hostSpec) {
+  imports = hostSpec.imports.map((n) => mod[n]);
+  tag = hostSpec.tag;
+  attrs = hostSpec.attrs;
+} else {
+  const candidates = Object.values(mod).filter((v) => typeof v === "function");
+  const C = mod.default ?? candidates.find((v) => reflectComponentType(v) != null);
+  const mirror = reflectComponentType(C);
+  if (!mirror) throw new Error("No Angular component found in module");
+  const selector = mirror.selector.split(",")[0].trim();
+  // Parse \`tag[attrA][attrB]\` → native host tag + the attribute selectors present on it.
+  tag = (selector.match(/^[a-zA-Z][\\w-]*/) || ["div"])[0];
+  attrs = [...selector.matchAll(/\\[([\\w-]+)\\]/g)].map((m) => m[1]);
+  imports = [C];
+}
 
 const allProps = ${propsJson};
 const { __slots = {}, ...props } = allProps;
@@ -324,13 +360,14 @@ const bindings = Object.keys(props).map((k) => \`[\${k}]="props['\${k}']"\`).joi
 const slotContent = Object.entries(__slots)
   .map(([name, html]) => name === "default" ? html : \`<ng-container ngProjectAs="[slot=\${name}]">\${html}</ng-container>\`)
   .join("");
+const attrStr = attrs.length ? " " + attrs.join(" ") : "";
 
 class HostBase { props = props; }
 const Host = Component({
   standalone: true,
   selector: "mount-host",
-  imports: [C],
-  template: \`<\${selector} \${bindings}>\${slotContent}</\${selector}>\`,
+  imports,
+  template: \`<\${tag}\${attrStr} \${bindings}>\${slotContent}</\${tag}>\`,
 })(HostBase) ?? HostBase;
 
 const providers = [provideZonelessChangeDetection()];

--- a/ui/components/src/components/angular-ssr-helper.ts
+++ b/ui/components/src/components/angular-ssr-helper.ts
@@ -1,14 +1,14 @@
-// Test support: SSR-render a styled component (plus the headless parts it composes) on the
-// Angular target and return the real rendered HTML. Styled sources import their parts via
-// `../headless/<name>.component`, so the generated files are laid out under `styled/` and
-// `headless/` to keep those relative specifiers resolvable in the mount sandbox.
+// Test support: SSR-render a styled component (plus the headless parts it composes) on the Angular
+// target and return the real rendered HTML. The registry build + chain layout live in
+// `@inkline/test-utils` (prepareStyledAngularChain); here we just resolve the package-relative paths,
+// cache the prepared chain, and mount it with per-call props.
 
 import {
-  compileComponent,
   mountForTarget,
+  prepareStyledAngularChain,
   resolveComponent,
-  type GeneratedFile,
   type MountResult,
+  type StyledAngularChain,
 } from "@inkline/test-utils";
 
 // The package tsconfig pulls in `.styleframe/styleframe.d.ts`, which declares the
@@ -16,19 +16,7 @@ import {
 // (`extends BadgeStylingProps`) are invisible to the compiler and no inputs are generated.
 const TSCONFIG = resolveComponent(import.meta.url, "../../tsconfig.json");
 
-const compiled = new Map<string, Promise<readonly GeneratedFile[]>>();
-
-function angularFilesFor(absolutePath: string): Promise<readonly GeneratedFile[]> {
-  let pending = compiled.get(absolutePath);
-  if (!pending) {
-    pending = compileComponent(absolutePath, {
-      targets: ["angular"],
-      config: { tsconfig: TSCONFIG },
-    }).then((r) => r.filesFor("angular"));
-    compiled.set(absolutePath, pending);
-  }
-  return pending;
-}
+const prepared = new Map<string, Promise<StyledAngularChain>>();
 
 export async function mountStyledOnAngular(
   importMetaUrl: string,
@@ -36,15 +24,14 @@ export async function mountStyledOnAngular(
   headlessRels: readonly string[],
   props?: Record<string, unknown>,
 ): Promise<MountResult> {
-  const styledFiles = await angularFilesFor(resolveComponent(importMetaUrl, styledRel));
-  const [entryFile, ...styledRest] = styledFiles;
-  const entry = { ...entryFile!, path: `styled/${entryFile!.path}` };
-
-  const supporting: GeneratedFile[] = styledRest.map((f) => ({ ...f, path: `styled/${f.path}` }));
-  for (const rel of headlessRels) {
-    const files = await angularFilesFor(resolveComponent(importMetaUrl, rel));
-    supporting.push(...files.map((f) => ({ ...f, path: `headless/${f.path}` })));
+  const styledPath = resolveComponent(importMetaUrl, styledRel);
+  const headlessPaths = headlessRels.map((r) => resolveComponent(importMetaUrl, r));
+  const key = [styledPath, ...headlessPaths].join("|");
+  let pending = prepared.get(key);
+  if (!pending) {
+    pending = prepareStyledAngularChain(styledPath, headlessPaths, { tsconfig: TSCONFIG });
+    prepared.set(key, pending);
   }
-
-  return mountForTarget("angular", entry, props, supporting);
+  const { entry, supporting, host } = await pending;
+  return mountForTarget("angular", entry, props, supporting, host);
 }

--- a/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
+++ b/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
@@ -7,6 +7,7 @@ export interface BadgeBaseProps {
 export default defineComponent(
   {
     slots: { default: {} },
+    element: "div",
   },
   (props: BadgeBaseProps) => {
     return (

--- a/ui/components/src/components/badge/styled/IBadge.ink.test.ts
+++ b/ui/components/src/components/badge/styled/IBadge.ink.test.ts
@@ -12,11 +12,12 @@ describe("IBadge (styled) on Angular SSR", () => {
       { label: "New", color: "primary", size: "md" },
     );
 
-    // The recipe classes land on the headless root <div class="badge">, merged — not stranded on
-    // the <ink-badge-base> host element.
+    // The badge IS the native <div> (an element-component host) with the styling directive stacked
+    // on it; Ivy unions the base class and the recipe class. No <ink-badge-base> wrapper, no
+    // display:contents — so the badge is a real element in the consumer's DOM.
     expect(html).toMatch(/<div[^>]*class="badge badge--color-primary badge--size-md"/);
     expect(html).toContain("New");
-    expect(html).toContain("<ink-badge-base");
+    expect(html).not.toContain("ink-badge-base");
   });
 
   it("renders the base class alone when no styling props are set", async () => {

--- a/ui/components/src/components/button/headless/IButtonBase.ink.tsx
+++ b/ui/components/src/components/button/headless/IButtonBase.ink.tsx
@@ -10,6 +10,7 @@ export interface ButtonBaseProps {
 export default defineComponent(
   {
     slots: { default: {} },
+    element: "button",
   },
   (props: ButtonBaseProps) => {
     return (

--- a/ui/components/src/components/field-group/headless/IFieldGroupBase.ink.tsx
+++ b/ui/components/src/components/field-group/headless/IFieldGroupBase.ink.tsx
@@ -5,10 +5,13 @@ export interface FieldGroupBaseProps {
   id?: string;
 }
 
-export default defineComponent({ slots: { default: {} } }, (props: FieldGroupBaseProps) => {
-  return (
-    <div class="field-group" id={props.id}>
-      <Slot />
-    </div>
-  );
-});
+export default defineComponent(
+  { slots: { default: {} }, element: "div" },
+  (props: FieldGroupBaseProps) => {
+    return (
+      <div class="field-group" id={props.id}>
+        <Slot />
+      </div>
+    );
+  },
+);

--- a/ui/components/src/components/field-group/styled/IFieldGroup.styleframe.ts
+++ b/ui/components/src/components/field-group/styled/IFieldGroup.styleframe.ts
@@ -5,33 +5,7 @@ const s = styleframe();
 
 // The field-group recipe joins bordered controls placed as *direct children* into one unit: it
 // merges adjacent border radii and collapses the inner border at the seams, and exposes
-// `orientation` (horizontal/vertical) and `block` variants.
+// `orientation` (horizontal/vertical) and `block` variants. Every target now renders each control
+// as a real direct child (Angular via attribute-selector host elements / the flattened input), so
+// the recipe's own direct-child seam rules apply uniformly — no reach-through workaround needed.
 export const fieldGroupRecipe = useFieldGroupRecipe(s);
-
-// PROTOTYPE (Phase 3) — reach-through seam fix for component-wrapping targets (Angular).
-// The recipe collapses seams with `.field-group.-vertical|-horizontal > :not(:last|first-child)`
-// — direct-child selectors that remove the inner border + square the inner corners. On Angular each
-// control is nested inside `display: contents` `ink-*` host elements, so those rules land on the
-// (boxless) host and the real control keeps its full border → a doubled border at every seam (+2px).
-// Re-apply the exact same border removal reaching the control through the wrappers. This is a no-op
-// where the control is already the direct child (React/Vue/Svelte/Solid), so it's purely additive.
-const CONTROL = ":where(.button, .input, .select, .textarea)";
-
-s.selector(`.field-group.-vertical > *:not(:last-child) ${CONTROL}`, {
-  borderBottomLeftRadius: "0",
-  borderBottomRightRadius: "0",
-  borderBottomWidth: "0",
-});
-s.selector(`.field-group.-vertical > *:not(:first-child) ${CONTROL}`, {
-  borderTopLeftRadius: "0",
-  borderTopRightRadius: "0",
-});
-s.selector(`.field-group.-horizontal > *:not(:last-child) ${CONTROL}`, {
-  borderTopRightRadius: "0",
-  borderBottomRightRadius: "0",
-  borderRightWidth: "0",
-});
-s.selector(`.field-group.-horizontal > *:not(:first-child) ${CONTROL}`, {
-  borderTopLeftRadius: "0",
-  borderBottomLeftRadius: "0",
-});

--- a/ui/components/src/components/input/headless/IInputBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputBase.ink.tsx
@@ -8,6 +8,7 @@ export interface InputBaseProps {
 export default defineComponent(
   {
     slots: { default: {} },
+    element: "div",
   },
   (props: InputBaseProps) => {
     return (

--- a/ui/components/src/components/input/headless/IInputPrefixBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputPrefixBase.ink.tsx
@@ -2,10 +2,13 @@ import { defineComponent, Slot } from "@inkline/core";
 
 export interface InputPrefixBaseProps {}
 
-export default defineComponent({ slots: { default: {} } }, (_props: InputPrefixBaseProps) => {
-  return (
-    <span class="input-prefix">
-      <Slot />
-    </span>
-  );
-});
+export default defineComponent(
+  { slots: { default: {} }, element: "span" },
+  (_props: InputPrefixBaseProps) => {
+    return (
+      <span class="input-prefix">
+        <Slot />
+      </span>
+    );
+  },
+);

--- a/ui/components/src/components/input/headless/IInputSuffixBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputSuffixBase.ink.tsx
@@ -2,10 +2,13 @@ import { defineComponent, Slot } from "@inkline/core";
 
 export interface InputSuffixBaseProps {}
 
-export default defineComponent({ slots: { default: {} } }, (_props: InputSuffixBaseProps) => {
-  return (
-    <span class="input-suffix">
-      <Slot />
-    </span>
-  );
-});
+export default defineComponent(
+  { slots: { default: {} }, element: "span" },
+  (_props: InputSuffixBaseProps) => {
+    return (
+      <span class="input-suffix">
+        <Slot />
+      </span>
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Adds full Angular attribute-selector support to the Inkline compiler across four phases: registry infrastructure (Phase 0), element/directive emit (Phase 1), structural styled-component flattening (Phase 2), and an explicit `element` flag on attribute selectors (Phase 3). This enables Angular output to correctly distinguish host-element directives from structural directives and emit idiomatic Angular component/directive selectors.

## Related issues

- Closes #

## Type of change

- [x] `feat` — new user-facing capability or public API

## Test plan

- [x] `vp run ready` passes locally
- [x] New unit tests added for `registry.ts`, `attr-selector.ts`, `selector.ts` covering all branches
- [x] `analyze-only` pipeline test verifies attribute-selector validation pass
- [x] Angular storybook template test covers new story generation path
- [x] Angular class-merge and chain helpers tested in `test-utils`

## Checklist

- [x] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".