### PR TITLE
fix(compiler): thread preserveWhitespace through nested whitespace-sensitive elements

### DIFF
--- a/core/compiler/src/ir/render/nodes.ts
+++ b/core/compiler/src/ir/render/nodes.ts
@@ -55,6 +55,12 @@ export interface IRElement {
   readonly isStatic: boolean;
   /** True when this is the component's root and inherits the parent's fallthrough attributes. */
   readonly acceptsAttrFallthrough?: boolean;
+  /**
+   * True for a whitespace-sensitive element (`pre`/`textarea`/`script`/`style`) and every descendant
+   * element parsed under one. Drives codegen's `inline` decision so no formatting whitespace is
+   * injected inside the element's rendered content.
+   */
+  readonly preserveWhitespace?: boolean;
   readonly loc: SourceLocation;
 }
 
@@ -81,6 +87,12 @@ export interface IRComponentInstance {
 export interface IRText {
   readonly kind: "Text";
   readonly value: string;
+  /**
+   * True for text parsed under a whitespace-sensitive element. Drives codegen to emit the raw value
+   * as a string-literal expression (`{"…"}` / `{{ "…" }}`) so each framework's own JSX/template
+   * whitespace cleaner can't re-collapse it.
+   */
+  readonly preserveWhitespace?: boolean;
   readonly loc: SourceLocation;
 }
 

--- a/core/compiler/src/pipeline/passes/02-parse/jsx/index.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/jsx/index.test.ts
@@ -123,6 +123,68 @@ describe("parseJsxElement", () => {
   });
 });
 
+describe("whitespace preservation", () => {
+  it("preserves raw whitespace in text directly under a sensitive tag", () => {
+    const node = parse("<pre>  x\n  y</pre>");
+    expect(node.kind).toBe("Element");
+    if (node.kind !== "Element") return;
+    expect(node.preserveWhitespace).toBe(true);
+    expect(node.children).toHaveLength(1);
+    expect(node.children[0]).toMatchObject({
+      kind: "Text",
+      value: "  x\n  y",
+      preserveWhitespace: true,
+    });
+  });
+
+  it("inherits the flag into a nested element (the <pre><code> case)", () => {
+    // `<code>` is not itself sensitive, but parsed under `<pre>` it preserves text verbatim.
+    const node = parse("<pre><code>  x\n  y</code></pre>");
+    expect(node.kind).toBe("Element");
+    if (node.kind !== "Element") return;
+    expect(node.preserveWhitespace).toBe(true);
+    expect(node.children).toHaveLength(1);
+    const code = node.children[0]!;
+    expect(code.kind).toBe("Element");
+    if (code.kind !== "Element") return;
+    expect(code.tag).toBe("code");
+    expect(code.preserveWhitespace).toBe(true);
+    expect(code.children[0]).toMatchObject({
+      kind: "Text",
+      value: "  x\n  y",
+      preserveWhitespace: true,
+    });
+  });
+
+  it("keeps whitespace-only text between elements when preserving", () => {
+    const node = parse("<pre>\n  <code>x</code></pre>");
+    expect(node.kind).toBe("Element");
+    if (node.kind !== "Element") return;
+    expect(node.children).toHaveLength(2);
+    expect(node.children[0]).toMatchObject({
+      kind: "Text",
+      value: "\n  ",
+      preserveWhitespace: true,
+    });
+    expect(node.children[1]!.kind).toBe("Element");
+  });
+
+  it("leaves ordinary elements without the flag and still collapses their text", () => {
+    const node = parse("<div><span>  x\n  y</span></div>");
+    expect(node.kind).toBe("Element");
+    if (node.kind !== "Element") return;
+    expect(node.preserveWhitespace).toBeUndefined();
+    const span = node.children[0]!;
+    if (span.kind !== "Element") return;
+    expect(span.preserveWhitespace).toBeUndefined();
+    const text = span.children[0]!;
+    expect(text.kind).toBe("Text");
+    if (text.kind !== "Text") return;
+    expect(text.value).toBe("  x y");
+    expect(text.preserveWhitespace).toBeUndefined();
+  });
+});
+
 describe("parseExpression", () => {
   it("parenthesized expression unwraps", () => {
     const node = parse("(<div />)");

--- a/core/compiler/src/pipeline/passes/02-parse/jsx/index.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/jsx/index.ts
@@ -58,7 +58,12 @@ function parseJsxChild(
     // Normalize JSX whitespace once, here in the IR, so every target emits identical rendered text.
     const value = preserveWhitespace ? node.text : cleanJsxText(node.text);
     if (value.length === 0) return undefined;
-    return { kind: "Text", value, loc: toLoc(node, sf) };
+    return {
+      kind: "Text",
+      value,
+      preserveWhitespace: preserveWhitespace || undefined,
+      loc: toLoc(node, sf),
+    };
   }
 
   if (ts.isJsxExpression(node)) {
@@ -67,7 +72,7 @@ function parseJsxChild(
   }
 
   if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
-    return parseJsxElement(node, sf);
+    return parseJsxElement(node, sf, preserveWhitespace);
   }
 
   if (ts.isJsxFragment(node)) {
@@ -84,13 +89,15 @@ function parseJsxChild(
 function parseJsxElement(
   node: ts.JsxElement | ts.JsxSelfClosingElement,
   sf: ts.SourceFile,
+  preserveWhitespace = false,
 ): IRNode {
   const isSelfClosing = ts.isJsxSelfClosingElement(node);
   const openingTag = isSelfClosing ? node : node.openingElement;
   const tag = getTagName(openingTag.tagName);
   const { attrs, events, refs } = parseAttributes(openingTag.attributes, sf);
-  const preserveWhitespace = WHITESPACE_SENSITIVE_TAGS.has(tag.text);
-  const children = isSelfClosing ? [] : parseChildren(node.children, sf, preserveWhitespace);
+  // Whitespace-sensitivity is inherited: once inside a `pre` (etc.) every descendant preserves too.
+  const preserve = preserveWhitespace || WHITESPACE_SENSITIVE_TAGS.has(tag.text);
+  const children = isSelfClosing ? [] : parseChildren(node.children, sf, preserve);
   const loc = toLoc(node, sf);
 
   if (tag.isComponent) {
@@ -122,6 +129,7 @@ function parseJsxElement(
     refs,
     children,
     isStatic: false,
+    preserveWhitespace: preserve || undefined,
     loc,
   };
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `preserveWhitespace` was not inherited by descendant elements inside whitespace-sensitive tags (e.g. `<pre><code>…</code></pre>`). The flag is now threaded through `parseJsxElement` and `parseJsxChild` so every element and text node under a sensitive ancestor carries `preserveWhitespace: true` in the IR.

## Related issues

- Closes #

## Type of change

- [ ] \`feat\` — new user-facing capability or public API
- [x] \`fix\` — bug fix
- [ ] \`refactor\` — internal change, no behavior change
- [ ] \`docs\` — documentation only
- [ ] \`test\` — tests only
- [ ] \`chore\` / \`ci\` — tooling, dependencies, or CI

## Test plan

- [x] Added unit tests for direct text, nested element (`<pre><code>`), whitespace-only text between elements, and non-sensitive elements (no flag)
- [ ] `vp run ready` passes locally

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".