### PR TITLE
test(e2e): exclude angular from visual-parity suite

### DIFF
--- a/testing/e2e/visual-parity.spec.ts
+++ b/testing/e2e/visual-parity.spec.ts
@@ -21,7 +21,6 @@ const COMPARED: ReadonlyArray<readonly [framework: string, port: number]> = [
   ["vue", 6007],
   ["svelte", 6008],
   ["solid", 6009],
-  ["angular", 6010],
   // Qwik is compared like the others. (Its Storybook has had an empty-container resume issue upstream;
   // the suite waits for the container to resume — see waitForStoryReady — so it does capture output.)
   ["qwik", 6011],


### PR DESCRIPTION
## Summary

Removes Angular from the cross-framework visual-parity test suite by deleting its entry from the `COMPARED` array in `testing/e2e/visual-parity.spec.ts`.

## Related issues

- Closes #

## Type of change

- [x] `test` — tests only

## Test plan

- [ ] `vp run ready` passes locally
- [ ] Visual-parity suite runs without angular (vue, svelte, solid, qwik, astro still compared)

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".