### PR TITLE
feat(compiler,components): Angular headless attribute-selector & zero-wrapper collapse

### DIFF
--- a/.changeset/angular-collapse-unforwarded-prop.md
+++ b/.changeset/angular-collapse-unforwarded-prop.md
@@ -1,0 +1,17 @@
+---
+"@inkline/compiler": patch
+"@inkline/angular": patch
+---
+
+fix(compiler): don't leak an unforwarded prop onto the collapsed Angular host
+
+When a styled `meta.headless` component collapses onto its headless child, the inlined host now binds
+the child's root attributes against the styled instance's actual arguments. A prop the child's root
+reads but the styled wrapper does not forward resolves to `undefined` (the binding is omitted) instead
+of the styled component's same-named prop.
+
+Previously `IInput` — whose `IInputBase` shell root binds `id={props.id}` but which forwards `id` only
+to the inner control — emitted `[attr.id]` on both the shell `<div ink-input>` and the inner
+`<input ink-input-control-base>`, producing a duplicate `id` (invalid HTML, broken `label[for]`). The
+collapsed host now carries `id` on the control only, matching the element-selector wrapper variant and
+the other six targets.

--- a/.changeset/angular-composite-collapse-machinery.md
+++ b/.changeset/angular-composite-collapse-machinery.md
@@ -1,0 +1,18 @@
+---
+"@inkline/compiler": minor
+---
+
+feat(compiler): collapse composite styled components with nested headless children (Angular)
+
+Generalizes the styled-over-headless collapse to composites whose styled component projects richer
+content — including other headless siblings — into its headless root's slot. Two new capabilities on
+the Angular target's collapse:
+
+- **Slot substitution**: the styled's own slot bodies project into the inlined headless root's `<Slot>`
+  (replacing the `<ng-content>` one level), so the composite's content lands inside the collapsed host.
+- **Nested attribute-child rendering**: headless siblings in that content render as attribute-selector
+  children (`<span ink-input-prefix-base>` rather than `<ink-input-prefix-base>`), zero wrapper, each
+  importing its `HostComponent` variant.
+
+Existing single-child collapses (Button/Badge/FieldGroup/HamburgerMenu) are byte-identical. This is the
+codegen foundation for collapsing the Input family.

--- a/.changeset/angular-hamburger-menu-collapse.md
+++ b/.changeset/angular-hamburger-menu-collapse.md
@@ -1,0 +1,16 @@
+---
+"@inkline/compiler": minor
+"@inkline/angular": minor
+---
+
+feat(compiler): collapse a model-bearing headless component onto its Angular host
+
+Extends the styled-over-headless collapse to headless components that own a two-way model + an event
+handler that writes it. The headless's event references its own model setter (e.g. `setOpen(...)` from
+`defineModel("open")`); the collapse now maps the child's setter names onto the same model so the
+merged host emits it correctly (`(click)="open.set(!open())"`), with the model declared under the
+styled component's binding.
+
+Flips **HamburgerMenu** to `meta.headless`: `<button ink-hamburger-menu ink-hamburger-menu-base>`
+carries the recipe classes, `aria-expanded`/`aria-controls`/`aria-label`, the `disabled` state, and the
+toggle click — zero wrappers. Only the Angular output changes (other six targets byte-identical).

--- a/.changeset/angular-headless-host-extraction.md
+++ b/.changeset/angular-headless-host-extraction.md
@@ -1,0 +1,22 @@
+---
+"@inkline/compiler": minor
+"@inkline/core": minor
+---
+
+feat(compiler): meta.headless + Angular attribute-selector host-extraction
+
+`defineComponent` accepts a new `meta: { headless?: boolean }` option, threaded through the parse
+pass into `IRComponent.meta` (IR_VERSION → 3, with a pure-bump 2→3 migration).
+
+On the **Angular** target, a `headless` component with a single static-element root now emits a
+second, **attribute-selector** `@Component` whose root element IS the host — `button[ink-button-base]`
+with the root's attrs/events extracted into `host: { … }` and a children-only template — so the
+native element carries the behavior with **no wrapper** (`<button ink-button-base>` instead of
+`<ink-button-base><button></button></ink-button-base>`). The original element-selector wrapper
+component is still emitted unchanged (dual selector), so `<ink-button-base>` keeps working as a
+`display: contents` wrapper.
+
+A `headless` component whose root is not a single static element (fragment/conditional) cannot be
+host-extracted; the target warns (**INK0111**) and emits only the element-selector wrapper.
+
+This is the compiler foundation for zero-wrapper Angular components; no shipped components opt in yet.

--- a/.changeset/angular-headless-registry-target-gate.md
+++ b/.changeset/angular-headless-registry-target-gate.md
@@ -1,0 +1,12 @@
+---
+"@inkline/compiler": patch
+---
+
+perf(compiler): build the headless registry only when the Angular target is requested
+
+The cross-file headless registry (re-parses + lowers a component's imported `.ink` siblings) is
+consumed solely by the Angular target's collapse. It was built whenever a `meta.headless` component
+had a `ComponentInstance` root, regardless of `options.targets` — so compiling such a component to a
+non-Angular target (e.g. React-only via `compile()`) paid for the sibling re-parse for nothing. The
+build is now gated on `"angular"` being a requested target. No effect on multi-target builds (which
+include Angular); purely avoids wasted work on Angular-excluded compiles.

--- a/.changeset/angular-headless-styled-collapse.md
+++ b/.changeset/angular-headless-styled-collapse.md
@@ -1,0 +1,27 @@
+---
+"@inkline/compiler": minor
+"@inkline/angular": minor
+"@inkline/test-utils": patch
+---
+
+feat(compiler): collapse styled-over-headless into one zero-wrapper Angular component
+
+Builds on the headless host-extraction: a styled component marked `meta.headless` whose entire render
+is a single headless child now **collapses** onto that child's host element on Angular. The compiler
+parses the imported headless sibling (a cross-file **headless registry** on the codegen context) and
+inlines its root's host bindings + template into one attribute-selector `@Component`, merging the
+styled recipe class and tagging the host with the child's own selector:
+
+```
+<button ink-button>  →  <button ink-button ink-button-base class="button button--color-primary …">…</button>
+```
+
+The element-selector wrapper (`<ink-button>` → `display: contents`) is still emitted (dual selector),
+so existing usage is unchanged. Applied to **Button, Badge, and FieldGroup** (`meta.headless` added to
+their headless + styled sources). Only the Angular output changes — the other six targets are
+byte-identical. A styled root whose child can't be host-extracted (non-element/fragment root) warns
+(INK0111) and keeps only the wrapper.
+
+`@inkline/test-utils`' Angular SSR harness now mounts attribute-selector components (`tag[attr]` → a
+real `<tag attr>` host) and can select a named component export, and registers signal-input metadata
+for every class in a multi-class file.

--- a/.changeset/angular-input-family-collapse.md
+++ b/.changeset/angular-input-family-collapse.md
@@ -1,0 +1,26 @@
+---
+"@inkline/compiler": patch
+"@inkline/angular": minor
+---
+
+feat(components): zero-wrapper Angular Input family via the composite collapse
+
+Splits the conditional `IInputControlBase` (which rendered `<input>` _or_ `<textarea>`) into two
+single-root headless components — `IInputControlBase` (`input[ink-input-control-base]`) and the new
+`IInputTextareaBase` (`textarea[ink-input-textarea-base]`) — and hoists the `type === "textarea"`
+choice up into the styled `IInput`. Each Input part (`IInputBase`, prefix, suffix, both controls) is
+now `meta.headless`, and `IInput` collapses the whole composite:
+
+```html
+<div ink-input ink-input-base class="input …">
+  <span ink-input-prefix-base class="input-prefix …"></span>
+  <input ink-input-control-base value="…" class="input-field" />
+  <span ink-input-suffix-base class="input-suffix …"></span>
+</div>
+```
+
+The native `<input>`/`<textarea>` carries the behavior directly — zero wrapper elements around the
+control or the shell, with the two-way value preserved. A void-element attribute-child self-closes
+(`<input ink-x />`). The element-selector wrapper variant is still emitted (dual selector); the split
+itself changes all seven targets' Input output (functionally equivalent), Angular adds the host
+variants.

--- a/core/compiler/src/__fixtures__/CollapseBase.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseBase.ink.tsx
@@ -1,0 +1,20 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+// Headless base for the styled-collapse test: a single static `<button>` root with a base class, a
+// forwarded KEEP_PROPERTY prop, and a default slot. A styled sibling (CollapseStyled) collapses onto
+// this root via the cross-file headless registry.
+export interface CollapseBaseProps {
+  label?: string;
+  disabled?: boolean;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CollapseBaseProps) => {
+    return (
+      <button class="cb" disabled={props.disabled}>
+        <Slot>{props.label}</Slot>
+      </button>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseInvalid.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseInvalid.ink.tsx
@@ -1,0 +1,8 @@
+import { defineComponent } from "@inkline/core";
+import HeadlessFragmentRoot from "./HeadlessFragmentRoot.ink.tsx";
+
+// A headless styled wrapper whose root headless child has a non-element (fragment) root, so the
+// Angular collapse cannot inline it: the target warns (INK0111) and emits only the element wrapper.
+export default defineComponent({ meta: { headless: true } }, () => {
+  return <HeadlessFragmentRoot />;
+});

--- a/core/compiler/src/__fixtures__/CollapseModelBase.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseModelBase.ink.tsx
@@ -1,0 +1,22 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+// Headless base with a two-way `open` model and an event handler that writes it via the model's
+// setter — the case where the collapse must map the child's setter onto the merged component's model.
+export interface CollapseModelBaseProps {
+  disabled?: boolean;
+}
+
+export default defineComponent({ meta: { headless: true } }, (props: CollapseModelBaseProps) => {
+  const [open, setOpen] = defineModel<boolean>("open");
+  return (
+    <button
+      class="cm"
+      type="button"
+      aria-expanded={open() ? "true" : "false"}
+      disabled={props.disabled}
+      onClick={() => setOpen(!open())}
+    >
+      <span class="cm-inner" aria-hidden="true" />
+    </button>
+  );
+});

--- a/core/compiler/src/__fixtures__/CollapseModelStyled.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseModelStyled.ink.tsx
@@ -1,0 +1,14 @@
+import { defineComponent, defineModel, createMemo } from "@inkline/core";
+import CollapseModelBase, { type CollapseModelBaseProps } from "./CollapseModelBase.ink.tsx";
+
+// Styled wrapper that collapses onto a model-bearing headless child: the merged host must declare the
+// `open` model and emit the child's `(click)` as `open.set(...)`, with the recipe class merged in.
+export interface CollapseModelStyledProps extends CollapseModelBaseProps {
+  variant?: "a" | "b";
+}
+
+export default defineComponent({ meta: { headless: true } }, (props: CollapseModelStyledProps) => {
+  const [open, _setOpen] = defineModel<boolean>("open");
+  const className = createMemo(() => (open() ? "cm--open" : "cm--closed"));
+  return <CollapseModelBase class={className()} $bind:open={open} disabled={props.disabled} />;
+});

--- a/core/compiler/src/__fixtures__/CollapseNested.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNested.ink.tsx
@@ -1,0 +1,25 @@
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+import CollapseNestedShell, { type CollapseNestedShellProps } from "./CollapseNestedShell.ink.tsx";
+import CollapseNestedLeaf from "./CollapseNestedLeaf.ink.tsx";
+
+// Styled composite (like IInput): its root is the headless shell, but it projects a nested headless
+// leaf into the shell's slot. The Angular collapse must inline the shell as the host, substitute the
+// shell's `<Slot>` with this content, and render the leaf as an attribute-selector child.
+export interface CollapseNestedProps extends CollapseNestedShellProps {
+  size?: "sm" | "md";
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CollapseNestedProps) => {
+    const shellCls = createMemo(() => (props.size === "sm" ? "shell--sm" : "shell--md"));
+    const leafCls = createMemo(() => "leaf--x");
+    return (
+      <CollapseNestedShell id={props.id} class={shellCls()}>
+        <CollapseNestedLeaf class={leafCls()}>
+          <Slot />
+        </CollapseNestedLeaf>
+      </CollapseNestedShell>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseNested.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNested.ink.tsx
@@ -1,12 +1,14 @@
 import { defineComponent, Slot, createMemo } from "@inkline/core";
 import CollapseNestedShell, { type CollapseNestedShellProps } from "./CollapseNestedShell.ink.tsx";
 import CollapseNestedLeaf from "./CollapseNestedLeaf.ink.tsx";
+import CollapseNestedInput from "./CollapseNestedInput.ink.tsx";
 
 // Styled composite (like IInput): its root is the headless shell, but it projects a nested headless
 // leaf into the shell's slot. The Angular collapse must inline the shell as the host, substitute the
 // shell's `<Slot>` with this content, and render the leaf as an attribute-selector child.
 export interface CollapseNestedProps extends CollapseNestedShellProps {
   size?: "sm" | "md";
+  disabled?: boolean;
 }
 
 export default defineComponent(
@@ -19,6 +21,7 @@ export default defineComponent(
         <CollapseNestedLeaf class={leafCls()}>
           <Slot />
         </CollapseNestedLeaf>
+        <CollapseNestedInput disabled={props.disabled} />
       </CollapseNestedShell>
     );
   },

--- a/core/compiler/src/__fixtures__/CollapseNestedInput.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNestedInput.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+
+// Headless void leaf (like IInputControlBase): a single `<input>` root, no children. When a composite
+// collapses, this renders as a self-closing attribute-selector child (`<input ink-collapse-nested-input />`).
+export interface CollapseNestedInputProps {
+  disabled?: boolean;
+}
+
+export default defineComponent({ meta: { headless: true } }, (props: CollapseNestedInputProps) => {
+  return <input class="ni-field" disabled={props.disabled} />;
+});

--- a/core/compiler/src/__fixtures__/CollapseNestedLeaf.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNestedLeaf.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+// Headless leaf (like IInputPrefixBase): a `<span>` with a slot. When a composite collapses, this
+// renders as an attribute-selector child (`<span ink-collapse-nested-leaf>`), zero wrapper.
+export default defineComponent({ meta: { headless: true }, slots: { default: {} } }, () => {
+  return (
+    <span class="leaf">
+      <Slot />
+    </span>
+  );
+});

--- a/core/compiler/src/__fixtures__/CollapseNestedShell.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNestedShell.ink.tsx
@@ -1,0 +1,18 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+// Headless shell (like IInputBase): a `<div>` whose only child is its slot. A styled composite
+// collapses onto this and projects richer content (with nested headless children) into the slot.
+export interface CollapseNestedShellProps {
+  id?: string;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CollapseNestedShellProps) => {
+    return (
+      <div class="shell" id={props.id}>
+        <Slot />
+      </div>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseNoClassStyled.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNoClassStyled.ink.tsx
@@ -1,0 +1,16 @@
+import { defineComponent, createMemo } from "@inkline/core";
+import HeadlessBox from "./HeadlessBox.ink.tsx";
+
+// Collapses onto a headless child whose root has NO class attribute: the host `[class]` is the
+// styled recipe merged with klass (no base class to prepend).
+export interface CollapseNoClassStyledProps {
+  label?: string;
+}
+
+export default defineComponent(
+  { meta: { headless: true } },
+  (props: CollapseNoClassStyledProps) => {
+    const cls = createMemo(() => "nc--x");
+    return <HeadlessBox class={cls()} label={props.label} />;
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseNoRecipe.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseNoRecipe.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+import CollapseBase from "./CollapseBase.ink.tsx";
+
+// A headless pass-through wrapper with NO styling class of its own: the collapse forwards behavior
+// only, so the host `[class]` is just the child's base class merged with klass (no recipe).
+export default defineComponent(
+  { meta: { headless: true } },
+  (props: { label?: string; disabled?: boolean }) => {
+    return <CollapseBase label={props.label} disabled={props.disabled} />;
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseStyled.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseStyled.ink.tsx
@@ -1,0 +1,22 @@
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+import CollapseBase, { type CollapseBaseProps } from "./CollapseBase.ink.tsx";
+
+// Styled wrapper whose entire render is a single headless child. Marked `meta.headless` to opt into
+// the Angular collapse: its element-selector wrapper stays, and a second attribute-selector variant
+// inlines CollapseBase's root as the host, merging this recipe class. Uses a local memo (not a
+// styleframe recipe) to keep the fixture self-contained.
+export interface CollapseStyledProps extends CollapseBaseProps {
+  variant?: "solid" | "outline";
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CollapseStyledProps) => {
+    const className = createMemo(() => (props.variant === "outline" ? "cb--outline" : "cb--solid"));
+    return (
+      <CollapseBase class={className()} disabled={props.disabled}>
+        <Slot>{props.label}</Slot>
+      </CollapseBase>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseUnforwardedBase.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseUnforwardedBase.ink.tsx
@@ -1,0 +1,20 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+// Headless base whose root binds a prop (`id`) a styled wrapper may NOT forward. When a wrapper
+// collapses onto this root, the Angular host must bind against the wrapper's actual arguments, so an
+// unforwarded `id` resolves to undefined (omitted) instead of leaking the wrapper's same-named prop.
+export interface CollapseUnforwardedBaseProps {
+  id?: string;
+  label?: string;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CollapseUnforwardedBaseProps) => {
+    return (
+      <div class="cu" id={props.id}>
+        <Slot>{props.label}</Slot>
+      </div>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/CollapseUnforwardedStyled.ink.tsx
+++ b/core/compiler/src/__fixtures__/CollapseUnforwardedStyled.ink.tsx
@@ -1,0 +1,23 @@
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+import CollapseUnforwardedBase, {
+  type CollapseUnforwardedBaseProps,
+} from "./CollapseUnforwardedBase.ink.tsx";
+
+// Styled wrapper that collapses onto the base but forwards only `class` — NOT `id` (it declares `id`
+// via the inherited props). The collapsed host variant must therefore omit `[attr.id]` rather than
+// leaking this wrapper's `id` onto the shell.
+export interface CollapseUnforwardedStyledProps extends CollapseUnforwardedBaseProps {
+  variant?: "solid" | "outline";
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CollapseUnforwardedStyledProps) => {
+    const className = createMemo(() => (props.variant === "outline" ? "cu--outline" : "cu--solid"));
+    return (
+      <CollapseUnforwardedBase class={className()}>
+        <Slot>{props.label}</Slot>
+      </CollapseUnforwardedBase>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/HeadlessBox.ink.tsx
+++ b/core/compiler/src/__fixtures__/HeadlessBox.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+
+// A minimal headless component whose root has NO class attribute and a phrasing (inline) child:
+// exercises the `[class]: klass()` fallback host binding and the inline children-template path.
+export interface HeadlessBoxProps {
+  label?: string;
+}
+
+export default defineComponent({ meta: { headless: true } }, (props: HeadlessBoxProps) => {
+  return <div>{props.label}</div>;
+});

--- a/core/compiler/src/__fixtures__/HeadlessButton.ink.tsx
+++ b/core/compiler/src/__fixtures__/HeadlessButton.ink.tsx
@@ -1,0 +1,31 @@
+import { defineComponent, Slot, Show } from "@inkline/core";
+
+// A headless (behavior-only) button with a single static `<button>` root: exercises the Angular
+// host-extraction across every host-binding shape — a static class merged with the forwarded
+// `klass`, a static attribute (`type`), a KEEP_PROPERTY dynamic (`disabled`), an attribute-form
+// dynamic (`aria-label`), a root event, plus `@if` + slot children projected into the host template.
+export interface HeadlessButtonProps {
+  label?: string;
+  disabled?: boolean;
+  loading: boolean;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: HeadlessButtonProps) => {
+    return (
+      <button
+        class="hb"
+        type="button"
+        disabled={props.disabled}
+        aria-label={props.label}
+        onClick={(e: { preventDefault: () => void }) => e.preventDefault()}
+      >
+        <Show when={props.loading}>
+          <span class="hb-spinner" aria-hidden="true" />
+        </Show>
+        <Slot>{props.label}</Slot>
+      </button>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/HeadlessFragmentRoot.ink.tsx
+++ b/core/compiler/src/__fixtures__/HeadlessFragmentRoot.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent } from "@inkline/core";
+
+// A headless component whose root is a fragment, not a single static element. Host-extraction can't
+// apply, so the Angular target warns (INK0111) and emits only the element-selector wrapper variant.
+export default defineComponent({ meta: { headless: true } }, () => {
+  return (
+    <>
+      <span class="a" />
+      <span class="b" />
+    </>
+  );
+});

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -1,5 +1,5 @@
 import type { Code } from "./code-ir/nodes.ts";
-import type { IRComponent, IRContextDefinition } from "../ir/render/nodes.ts";
+import type { IRComponent, IRContextDefinition, IRNode } from "../ir/render/nodes.ts";
 import type { Diagnostic } from "../core/diagnostics/codes.ts";
 import type { DiagnosticCollector } from "../core/diagnostics/collector.ts";
 import type { ResolvedCompilerOptions } from "../core/options.ts";
@@ -139,6 +139,19 @@ export interface RewriteRules {
    * (Qwik/Angular), so gated content always renders and CSS `:empty` collapses the empty wrapper.
    */
   readonly hasSlotCheck?: (slotName: string) => string;
+  /**
+   * Angular collapse only: slot content (by name) the inlined headless root's `<Slot>` should render
+   * instead of an `<ng-content>`. Set while emitting a collapsed styled component's template so the
+   * styled's own slot bodies project into the headless child's slots; cleared when emitting that
+   * substituted content so its inner slots still become `<ng-content>` for the consumer.
+   */
+  readonly slotBodies?: ReadonlyMap<string, IRNode>;
+  /**
+   * Angular collapse only: the `meta.headless` siblings (by local name) a collapsed template renders
+   * as attribute-selector children — `<span ink-input-prefix-base>` rather than `<ink-input-prefix-base>`
+   * — so nested parts are zero-wrapper too. Their root tag comes from the resolved component.
+   */
+  readonly collapseChildren?: ReadonlyMap<string, IRComponent>;
 }
 
 export interface ComponentImport {

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -157,6 +157,13 @@ export interface CodegenContext {
   readonly externalImports: readonly Code[];
   readonly componentImports: readonly ComponentImport[];
   readonly typeDeclarations: readonly Code[];
+  /**
+   * Lowered IR of imported `meta.headless` siblings, indexed by component name. Lets the Angular
+   * target inline a headless child's root host bindings + template when a styled component collapses
+   * onto it (zero-wrapper). Empty unless a component in the module is headless with a
+   * `ComponentInstance` root, since building it re-parses the imported sibling files.
+   */
+  readonly headlessRegistry?: ReadonlyMap<string, IRComponent>;
 }
 
 export interface CodeModule {

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -140,18 +140,41 @@ export interface RewriteRules {
    */
   readonly hasSlotCheck?: (slotName: string) => string;
   /**
-   * Angular collapse only: slot content (by name) the inlined headless root's `<Slot>` should render
-   * instead of an `<ng-content>`. Set while emitting a collapsed styled component's template so the
-   * styled's own slot bodies project into the headless child's slots; cleared when emitting that
+   * Angular collapse only: when a styled `meta.headless` component inlines its headless child's root
+   * as the host, this carries the data to bind that inlined root against the styled wrapper (forwarded
+   * prop args, projected slot bodies, nested headless siblings) — see {@link CollapseContext}. Absent
+   * for every other target and for non-collapsed emission.
+   */
+  readonly collapse?: CollapseContext;
+}
+
+/**
+ * Angular collapse only: the data for inlining a `meta.headless` child's render as the host of the
+ * styled component collapsing onto it. The styled wrapper and its single headless child are merged
+ * into one `@Component`; this binds the child's root against the wrapper's actual arguments rather
+ * than the wrapper's same-named props.
+ */
+export interface CollapseContext {
+  /**
+   * Nested `meta.headless` siblings (by local name → resolved component) the collapsed template
+   * renders as attribute-selector children — `<span ink-input-prefix-base>` rather than
+   * `<ink-input-prefix-base>` — so nested parts are zero-wrapper too. Their root tag comes from the
+   * resolved component.
+   */
+  readonly children?: ReadonlyMap<string, IRComponent>;
+  /**
+   * Slot content (by name) the inlined headless root's `<Slot>` renders instead of an `<ng-content>`
+   * (the styled wrapper's own slot body). One level of projection: cleared while emitting that
    * substituted content so its inner slots still become `<ng-content>` for the consumer.
    */
   readonly slotBodies?: ReadonlyMap<string, IRNode>;
   /**
-   * Angular collapse only: the `meta.headless` siblings (by local name) a collapsed template renders
-   * as attribute-selector children — `<span ink-input-prefix-base>` rather than `<ink-input-prefix-base>`
-   * — so nested parts are zero-wrapper too. Their root tag comes from the resolved component.
+   * Set only on the ruleset used for the inlined host's OWN bindings: the child's prop name → the
+   * already-rewritten expression the styled wrapper passed for it, or `null` when the wrapper forwards
+   * nothing (the binding is omitted, or degrades to `undefined` inside a larger expression). Absent on
+   * the template ruleset so projected slot content keeps rewriting in the styled namespace.
    */
-  readonly collapseChildren?: ReadonlyMap<string, IRComponent>;
+  readonly propArgs?: ReadonlyMap<string, string | null>;
 }
 
 export interface ComponentImport {

--- a/core/compiler/src/codegen/shared/expr-rewrite.ts
+++ b/core/compiler/src/codegen/shared/expr-rewrite.ts
@@ -226,6 +226,14 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
   if (ts.isPropertyAccessExpression(expr)) {
     if (ts.isIdentifier(expr.expression)) {
       if (expr.expression.text === "props") {
+        // Angular collapse: a headless child's root reads its OWN props; substitute each with the
+        // expression the styled wrapper passed for it, so the inlined host binds against the styled's
+        // real arguments instead of its same-named props. `null`/absent (the wrapper forwarded
+        // nothing) becomes `undefined` so it stays safe inside a larger expression (`x ?? 'y'`).
+        if (rules.collapse?.propArgs) {
+          const arg = rules.collapse.propArgs.get(expr.name.text);
+          return arg == null ? "undefined" : arg;
+        }
         // Angular signal inputs are read in call form (`this.color()` / `color()`).
         const call = rules.propSignals ? "()" : "";
         if (rules.selfPrefix) return `this.${expr.name.text}${call}`;

--- a/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
@@ -129,6 +129,16 @@ describe("styled inline-collapse (CollapseStyled → CollapseBase)", () => {
       `selector: 'button[ink-collapse-no-recipe]', host: { '[class]': "'cb' + (klass() ? ' ' + klass() : '')", '[disabled]': "disabled()", 'ink-collapse-base': '' }`,
     );
   });
+
+  it("hoists the model + maps the child's setter onto the merged host (open.set) for the collapse", async () => {
+    const out = await compileTo("CollapseModelStyled", "angular");
+    expect(out).toContain("selector: 'button[ink-collapse-model-styled]'");
+    // The child's `onClick={() => setOpen(!open())}` becomes a host event writing the shared model.
+    expect(out).toContain(`'(click)': "open.set(!open())"`);
+    expect(out).toContain(`'[attr.aria-expanded]': "(open() ? 'true' : 'false') ?? null"`);
+    // Both variants share the model declaration.
+    expect(out.match(/open = model<boolean>\(\)/g)).toHaveLength(2);
+  });
 });
 
 describe("headless host-extraction guard (HeadlessFragmentRoot)", () => {

--- a/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
@@ -140,18 +140,20 @@ describe("styled inline-collapse (CollapseStyled → CollapseBase)", () => {
     expect(out.match(/open = model<boolean>\(\)/g)).toHaveLength(2);
   });
 
-  it("collapses a composite: substitutes the shell slot + renders the nested child as an attribute directive", async () => {
+  it("collapses a composite: substitutes the shell slot + renders the nested children as attribute directives", async () => {
     const out = await compileTo("CollapseNested", "angular");
-    // The shell is the host; its slot is replaced by the styled's content (the leaf), which renders
-    // as an attribute-selector child (zero wrapper) and pulls in its HostComponent import.
+    // The shell is the host; its slot is replaced by the styled's content (a span leaf + a void input
+    // leaf), which render as attribute-selector children (zero wrapper) and pull in HostComponent imports.
     expect(out).toContain(
-      `selector: 'div[ink-collapse-nested]', host: { '[class]': "'shell' + ((shellCls()) ? ' ' + (shellCls()) : '') + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", 'ink-collapse-nested-shell': '' }, imports: [CollapseNestedLeafHostComponent]`,
+      `selector: 'div[ink-collapse-nested]', host: { '[class]': "'shell' + ((shellCls()) ? ' ' + (shellCls()) : '') + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", 'ink-collapse-nested-shell': '' }, imports: [CollapseNestedLeafHostComponent, CollapseNestedInputHostComponent]`,
     );
     expect(out).toContain(
       'import { CollapseNestedLeafHostComponent } from "./CollapseNestedLeaf.component";',
     );
     expect(out).toContain('<span ink-collapse-nested-leaf [klass]="(leafCls())">');
     expect(out).toContain("<ng-content></ng-content>");
+    // A void element attribute-child self-closes (`<input … />`) — Angular rejects `</input>`.
+    expect(out).toContain('<input ink-collapse-nested-input [disabled]="disabled()" />');
   });
 });
 

--- a/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
@@ -155,6 +155,17 @@ describe("styled inline-collapse (CollapseStyled → CollapseBase)", () => {
     // A void element attribute-child self-closes (`<input … />`) — Angular rejects `</input>`.
     expect(out).toContain('<input ink-collapse-nested-input [disabled]="disabled()" />');
   });
+
+  it("omits a child-root prop the styled wrapper does not forward (no leaked [attr.id])", async () => {
+    const out = await compileTo("CollapseUnforwardedStyled", "angular");
+    // The collapse merges the recipe class but, because the wrapper never forwards `id` to the base,
+    // the inlined host must NOT bind `[attr.id]` — otherwise it would leak the wrapper's own `id`.
+    expect(out).toContain("export class CollapseUnforwardedStyledHostComponent");
+    expect(out).toContain(
+      `'[class]': "'cu' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')"`,
+    );
+    expect(out).not.toMatch(/\[attr\.id\]/);
+  });
 });
 
 describe("headless host-extraction guard (HeadlessFragmentRoot)", () => {

--- a/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
@@ -1,0 +1,86 @@
+// Angular: headless components (`defineComponent({ meta: { headless: true } }, …)`) emit a second,
+// attribute-selector @Component whose single static-element root IS the Angular host — so the native
+// element carries the behavior with zero wrapper (`<button ink-headless-button>`). The original
+// element-selector wrapper is still emitted unchanged (dual selector). A non-element root can't be
+// host-extracted: the target warns (INK0111) and emits only the wrapper.
+
+import { describe, it, expect } from "vitest";
+import { compileTo } from "../../../../testing/codegen.ts";
+import { compileFixture } from "../../../../testing/harness.ts";
+import { angularAttrSelector } from "../selector.ts";
+
+describe("angularAttrSelector", () => {
+  it("binds the ink-* token to the root element tag", () => {
+    expect(angularAttrSelector("IButtonBase", "button")).toBe("button[ink-button-base]");
+    expect(angularAttrSelector("HeadlessBox", "div")).toBe("div[ink-headless-box]");
+  });
+});
+
+describe("headless host-extraction (HeadlessButton)", () => {
+  it("keeps the element-selector wrapper variant unchanged (display: contents)", async () => {
+    const out = await compileTo("HeadlessButton", "angular");
+    expect(out).toContain("selector: 'ink-headless-button', host: { style: 'display: contents' }");
+    expect(out).toContain("export class HeadlessButtonComponent");
+  });
+
+  it("emits an attribute-selector host variant binding to the native <button>", async () => {
+    const out = await compileTo("HeadlessButton", "angular");
+    expect(out).toContain("selector: 'button[ink-headless-button]'");
+    expect(out).toContain("export class HeadlessButtonHostComponent");
+  });
+
+  it("extracts the root element's attrs/events as host bindings", async () => {
+    const out = await compileTo("HeadlessButton", "angular");
+    // class merges the forwarded klass; static attr stays literal; KEEP_PROPERTY stays a property
+    // binding; every other dynamic attr is an [attr.*] binding omitted when nullish; the root event
+    // becomes a host event binding with the param mapped to $event.
+    expect(out).toContain(
+      `host: { '[class]': "'hb' + (klass() ? ' ' + klass() : '')", 'type': 'button', '[disabled]': "disabled()", '[attr.aria-label]': "(label()) ?? null", '(click)': "$event.preventDefault()" }`,
+    );
+  });
+
+  it("emits a children-only template (the <button> wrapper is gone — it became the host)", async () => {
+    const out = await compileTo("HeadlessButton", "angular");
+    // The host variant's template is exactly the root's children: the @if spinner + projected slot,
+    // with no surrounding <button> tag.
+    expect(out).toContain(
+      'template: `@if (loading()) {\n<span class="hb-spinner" aria-hidden="true"></span>\n}\n<ng-content>{{ label() }}</ng-content>`',
+    );
+  });
+
+  it("shares the signal-input class body (klass + props) across both variants", async () => {
+    const out = await compileTo("HeadlessButton", "angular");
+    expect(out).toContain("klass = input<string>()");
+    expect(out).toContain("disabled = input<boolean>()");
+    // Two @Component blocks, two class declarations, one shared body shape.
+    expect(out.match(/@Component\(\{/g)).toHaveLength(2);
+    expect(out.match(/export class HeadlessButton\w*Component/g)).toHaveLength(2);
+  });
+});
+
+describe("headless host-extraction (HeadlessBox: no class, inline child)", () => {
+  it("falls back to `[class]: klass()` when the root has no class attribute", async () => {
+    const out = await compileTo("HeadlessBox", "angular");
+    expect(out).toContain("selector: 'div[ink-headless-box]', host: { '[class]': \"klass()\" }");
+  });
+
+  it("emits an inline children-only template", async () => {
+    const out = await compileTo("HeadlessBox", "angular");
+    expect(out).toContain("export class HeadlessBoxHostComponent");
+    expect(out).toContain(
+      "selector: 'div[ink-headless-box]', host: { '[class]': \"klass()\" }, template: `{{ label() }}`",
+    );
+  });
+});
+
+describe("headless host-extraction guard (HeadlessFragmentRoot)", () => {
+  it("warns (INK0111) and emits only the element-selector wrapper for a non-element root", async () => {
+    const result = await compileFixture("HeadlessFragmentRoot", ["angular"]);
+    expect(result.diagnostics.some((d) => d.code === "INK0111")).toBe(true);
+
+    const out = result.files.angular![0]!.contents;
+    expect(out).toContain("export class HeadlessFragmentRootComponent");
+    expect(out).not.toContain("HostComponent");
+    expect(out).not.toContain("[ink-headless-fragment-root]");
+  });
+});

--- a/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
@@ -73,6 +73,64 @@ describe("headless host-extraction (HeadlessBox: no class, inline child)", () =>
   });
 });
 
+describe("styled inline-collapse (CollapseStyled → CollapseBase)", () => {
+  it("collapses onto the headless child's host element via an attribute selector", async () => {
+    const out = await compileTo("CollapseStyled", "angular");
+    expect(out).toContain("selector: 'button[ink-collapse-styled]'");
+    expect(out).toContain("export class CollapseStyledHostComponent");
+  });
+
+  it("merges base + recipe + klass into the host class and forwards props as host bindings", async () => {
+    const out = await compileTo("CollapseStyled", "angular");
+    expect(out).toContain(
+      `host: { '[class]': "'cb' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')", '[disabled]': "disabled()", 'ink-collapse-base': '' }`,
+    );
+  });
+
+  it("uses the child's children as the template and declares no imports on the collapsed variant", async () => {
+    const out = await compileTo("CollapseStyled", "angular");
+    // host object is immediately followed by `template:` — the inlined child is not instantiated, so
+    // the collapsed @Component has no `imports: [...]`.
+    expect(out).toContain(
+      "'ink-collapse-base': '' }, template: `<ng-content>{{ label() }}</ng-content>`",
+    );
+  });
+
+  it("keeps the element-selector wrapper variant (which still instantiates the child)", async () => {
+    const out = await compileTo("CollapseStyled", "angular");
+    expect(out).toContain("selector: 'ink-collapse-styled', host: { style: 'display: contents' }");
+    expect(out).toContain("imports: [CollapseBase]");
+    expect(out).toContain("<ink-collapse-base");
+  });
+
+  it("emits the headless child's own attribute-selector variant when compiled standalone", async () => {
+    const out = await compileTo("CollapseBase", "angular");
+    expect(out).toContain("selector: 'button[ink-collapse-base]'");
+    expect(out).toContain("export class CollapseBaseHostComponent");
+  });
+
+  it("merges only recipe + klass when the headless child root has no base class", async () => {
+    const out = await compileTo("CollapseNoClassStyled", "angular");
+    expect(out).toContain(
+      `selector: 'div[ink-collapse-no-class-styled]', host: { '[class]': "(cls()) + (klass() ? ' ' + klass() : '')", 'ink-headless-box': '' }`,
+    );
+  });
+
+  it("warns (INK0111) and skips the collapse when the child root is not a single element", async () => {
+    const result = await compileFixture("CollapseInvalid", ["angular"]);
+    expect(result.diagnostics.some((d) => d.code === "INK0111")).toBe(true);
+    const out = result.files.angular![0]!.contents;
+    expect(out).not.toContain("CollapseInvalidHostComponent");
+  });
+
+  it("collapses with only the child base class + klass when the wrapper adds no recipe", async () => {
+    const out = await compileTo("CollapseNoRecipe", "angular");
+    expect(out).toContain(
+      `selector: 'button[ink-collapse-no-recipe]', host: { '[class]': "'cb' + (klass() ? ' ' + klass() : '')", '[disabled]': "disabled()", 'ink-collapse-base': '' }`,
+    );
+  });
+});
+
 describe("headless host-extraction guard (HeadlessFragmentRoot)", () => {
   it("warns (INK0111) and emits only the element-selector wrapper for a non-element root", async () => {
     const result = await compileFixture("HeadlessFragmentRoot", ["angular"]);

--- a/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/headless.test.ts
@@ -139,6 +139,20 @@ describe("styled inline-collapse (CollapseStyled → CollapseBase)", () => {
     // Both variants share the model declaration.
     expect(out.match(/open = model<boolean>\(\)/g)).toHaveLength(2);
   });
+
+  it("collapses a composite: substitutes the shell slot + renders the nested child as an attribute directive", async () => {
+    const out = await compileTo("CollapseNested", "angular");
+    // The shell is the host; its slot is replaced by the styled's content (the leaf), which renders
+    // as an attribute-selector child (zero wrapper) and pulls in its HostComponent import.
+    expect(out).toContain(
+      `selector: 'div[ink-collapse-nested]', host: { '[class]': "'shell' + ((shellCls()) ? ' ' + (shellCls()) : '') + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", 'ink-collapse-nested-shell': '' }, imports: [CollapseNestedLeafHostComponent]`,
+    );
+    expect(out).toContain(
+      'import { CollapseNestedLeafHostComponent } from "./CollapseNestedLeaf.component";',
+    );
+    expect(out).toContain('<span ink-collapse-nested-leaf [klass]="(leafCls())">');
+    expect(out).toContain("<ng-content></ng-content>");
+  });
 });
 
 describe("headless host-extraction guard (HeadlessFragmentRoot)", () => {

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -1,7 +1,13 @@
-import type { Target, CodegenContext, CodeModule, RewriteRules } from "../../context.ts";
+import type {
+  Target,
+  CodegenContext,
+  CodeModule,
+  RewriteRules,
+  CollapseContext,
+} from "../../context.ts";
 import { angularConformance } from "./conformance.ts";
 import type { Code } from "../../code-ir/nodes.ts";
-import type { IRComponent, IRElement, IRNode } from "../../../ir/render/nodes.ts";
+import type { IRAttribute, IRComponent, IRElement, IRNode } from "../../../ir/render/nodes.ts";
 import { cFile, cImport, cStmt, cRaw, cGroup } from "../../code-ir/builders.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
@@ -193,6 +199,25 @@ function appendClass(base: string, extra: string | undefined): string {
 }
 
 /**
+ * Collapse: true when `value` is solely a `props.X` read the styled wrapper didn't forward (its
+ * `propArgs` entry is `null`), so the inlined host binding is omitted rather than bound to the
+ * styled's same-named prop.
+ */
+function isUnforwardedProp(
+  value: IRAttribute["value"],
+  collapse: CollapseContext | undefined,
+): boolean {
+  if (!collapse?.propArgs || value.kind !== "Expression") return false;
+  const e = value.expr;
+  return (
+    ts.isPropertyAccessExpression(e) &&
+    ts.isIdentifier(e.expression) &&
+    e.expression.text === "props" &&
+    collapse.propArgs.get(e.name.text) === null
+  );
+}
+
+/**
  * Map a headless component's root element to Angular `host: { … }` binding entries. Reuses the exact
  * attribute classification of `emitNode`'s Element case, rendered as host-binding keys so the native
  * host element (the attribute-selector variant) carries them directly with no wrapper: the class
@@ -220,6 +245,9 @@ function headlessHostBindings(root: IRElement, rules: RewriteRules, recipeExpr?:
       entries.push(`'${name}': '${a.value.value}'`);
       continue;
     }
+    // Collapse: omit a binding that is solely a child prop the styled wrapper didn't forward, so it
+    // doesn't leak onto the inlined host (see `CollapseContext.propArgs`).
+    if (isUnforwardedProp(a.value, rules.collapse)) continue;
     const expr = rewriteExpr(a.value.expr, rules);
     entries.push(
       KEEP_PROPERTY.has(name) ? `'[${name}]': "${expr}"` : `'[attr.${name}]': "(${expr}) ?? null"`,
@@ -343,7 +371,7 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       const localName = node.resolved?.name ?? node.reference.getText();
       // In a collapsed template a headless child renders as an attribute selector on its own root tag
       // (`<span ink-input-prefix-base>`, zero wrapper); otherwise as its element selector (`<ink-x>`).
-      const collapseChild = rules.collapseChildren?.get(localName);
+      const collapseChild = rules.collapse?.children?.get(localName);
       const childRoot = collapseChild?.render.kind === "Element" ? collapseChild.render : undefined;
       const openTag = childRoot
         ? `${childRoot.tag} ${angularSelector(localName)}`
@@ -406,8 +434,11 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       // Collapse: project the styled component's own slot body into the inlined headless root's slot.
       // Clear slotBodies for the substituted content so ITS slots still become `<ng-content>` for the
       // consumer (one level of projection, not infinite).
-      if (rules.slotBodies?.has(node.name)) {
-        return emitNode(rules.slotBodies.get(node.name)!, { ...rules, slotBodies: undefined });
+      if (rules.collapse?.slotBodies?.has(node.name)) {
+        return emitNode(rules.collapse.slotBodies.get(node.name)!, {
+          ...rules,
+          collapse: { ...rules.collapse, slotBodies: undefined },
+        });
       }
       // Angular has no scoped-slot mechanism: a slot with `args` can't receive per-row data from a
       // parent. Best-effort: render the authored fallback (the component's default content, whose
@@ -743,17 +774,45 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         // `setOpen(...)` from `defineModel("open")`); map those names onto the same model so they
         // emit against the merged component, which declares that model under the styled binding.
         const childSetters = Object.fromEntries(child.models.map((m) => [m.setterName, m.name]));
+        const collapse: CollapseContext = {
+          children: ctx.headlessRegistry,
+          slotBodies: new Map(root.slots.map((s) => [s.name, s.body] as const)),
+        };
         const collapseRules: RewriteRules = {
           ...templateRules,
           setters: { ...templateRules.setters, ...childSetters },
-          slotBodies: new Map(root.slots.map((s) => [s.name, s.body] as const)),
-          collapseChildren: ctx.headlessRegistry,
+          collapse,
         };
         const classAttr = root.attrs.find(
           (a) => rewriteAttrName(a.name, collapseRules) === "class",
         );
         const recipeExpr = classAttr ? ownClassExpr(classAttr, collapseRules) : undefined;
-        const hostEntries = headlessHostBindings(childRoot, collapseRules, recipeExpr);
+        // Bind the inlined host's own attrs against the styled instance's actual arguments: map each
+        // of the child's props to what the wrapper forwarded (or the child's default), or `null` when
+        // the wrapper passed nothing — so an unforwarded child-root prop is omitted rather than
+        // resolving to the styled component's same-named prop. `class`/two-way args are handled
+        // separately (recipeExpr / childSetters), and `propArgs` lives only on the host ruleset; the
+        // projected slot content keeps rewriting in the styled namespace via `collapseRules`.
+        const propArgs = new Map<string, string | null>();
+        for (const a of root.attrs) {
+          if (a.binding === "class" || a.binding === "twoWay") continue;
+          const argExpr =
+            a.value.kind === "Static"
+              ? typeof a.value.value === "string"
+                ? `'${a.value.value}'`
+                : String(a.value.value)
+              : rewriteExpr(a.value.expr, collapseRules);
+          propArgs.set(a.name, argExpr);
+        }
+        for (const p of child.props) {
+          if (propArgs.has(p.name)) continue;
+          propArgs.set(
+            p.name,
+            p.defaultValue ? rewriteExpr(p.defaultValue.expr, collapseRules) : null,
+          );
+        }
+        const hostRules: RewriteRules = { ...collapseRules, collapse: { ...collapse, propArgs } };
+        const hostEntries = headlessHostBindings(childRoot, hostRules, recipeExpr);
         hostEntries.push(`'${angularSelector(child.name)}': ''`);
 
         // The collapsed template instantiates the styled's slot-content headless siblings as

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -341,7 +341,14 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       return node.children.map((c) => emitNode(c, rules)).join("\n");
     case "ComponentInstance": {
       const localName = node.resolved?.name ?? node.reference.getText();
-      const tag = angularSelector(localName);
+      // In a collapsed template a headless child renders as an attribute selector on its own root tag
+      // (`<span ink-input-prefix-base>`, zero wrapper); otherwise as its element selector (`<ink-x>`).
+      const collapseChild = rules.collapseChildren?.get(localName);
+      const childRoot = collapseChild?.render.kind === "Element" ? collapseChild.render : undefined;
+      const openTag = childRoot
+        ? `${childRoot.tag} ${angularSelector(localName)}`
+        : angularSelector(localName);
+      const closeTag = childRoot ? childRoot.tag : angularSelector(localName);
       // Ivy always treats a `[class]` binding as a host class — it never reaches an input — so a
       // class passed to a compiled child travels through its synthesized `klass` input instead,
       // and the child's root element merges it (see the Element case above).
@@ -378,7 +385,7 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       const ciAttrStr = ciParts.join(" ");
       if (node.slots.length === 0) {
         // Non-self-closing: Angular's template parser mishandles self-closed component tags in JIT.
-        return `<${tag}${ciAttrStr ? " " + ciAttrStr : ""}></${tag}>`;
+        return `<${openTag}${ciAttrStr ? " " + ciAttrStr : ""}></${closeTag}>`;
       }
       const slotContent = node.slots
         .map((s) => {
@@ -386,11 +393,17 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
           return `<ng-container slot="${s.name}">\n${emitNode(s.body, rules)}\n</ng-container>`;
         })
         .join("\n");
-      return `<${tag}${ciAttrStr ? " " + ciAttrStr : ""}>\n${slotContent}\n</${tag}>`;
+      return `<${openTag}${ciAttrStr ? " " + ciAttrStr : ""}>\n${slotContent}\n</${closeTag}>`;
     }
     case "Transition":
       return emitNode(node.child, rules);
     case "SlotPlaceholder":
+      // Collapse: project the styled component's own slot body into the inlined headless root's slot.
+      // Clear slotBodies for the substituted content so ITS slots still become `<ng-content>` for the
+      // consumer (one level of projection, not infinite).
+      if (rules.slotBodies?.has(node.name)) {
+        return emitNode(rules.slotBodies.get(node.name)!, { ...rules, slotBodies: undefined });
+      }
       // Angular has no scoped-slot mechanism: a slot with `args` can't receive per-row data from a
       // parent. Best-effort: render the authored fallback (the component's default content, whose
       // loop/scope variables are in scope here) so the component still renders standalone.
@@ -697,6 +710,10 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     );
   };
 
+  // Extra imports a collapsed host variant needs for the nested headless children it instantiates as
+  // attribute-selector directives (their `HostComponent` variants).
+  const extraImports: Code[] = [];
+
   if (component.meta?.headless) {
     const root = component.render;
     if (root.kind === "Element") {
@@ -710,9 +727,9 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     } else if (root.kind === "ComponentInstance") {
       // Collapse: the styled root renders a single headless child (resolved from the registry). Inline
       // that child's root as the host — its host bindings with the styled's recipe class merged in,
-      // plus the child's own selector as a static host attribute (`ink-button-base`) — and use the
-      // child's children as the template (assumes pass-through slot content; richer styled content is
-      // not yet inlined). The child is not instantiated, so the host variant declares no imports.
+      // plus the child's own selector as a static host attribute (`ink-button-base`). The styled's slot
+      // bodies project into the inlined child's slots, and nested headless siblings in that content
+      // render as attribute-selector children (zero wrapper), each importing its `HostComponent`.
       const childName = root.resolved?.name ?? root.reference.getText();
       const child = ctx.headlessRegistry?.get(childName);
       if (child && child.render.kind === "Element") {
@@ -724,6 +741,8 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         const collapseRules: RewriteRules = {
           ...templateRules,
           setters: { ...templateRules.setters, ...childSetters },
+          slotBodies: new Map(root.slots.map((s) => [s.name, s.body] as const)),
+          collapseChildren: ctx.headlessRegistry,
         };
         const classAttr = root.attrs.find(
           (a) => rewriteAttrName(a.name, collapseRules) === "class",
@@ -731,11 +750,33 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         const recipeExpr = classAttr ? ownClassExpr(classAttr, collapseRules) : undefined;
         const hostEntries = headlessHostBindings(childRoot, collapseRules, recipeExpr);
         hostEntries.push(`'${angularSelector(child.name)}': ''`);
+
+        // The collapsed template instantiates the styled's slot-content headless siblings as
+        // attribute directives; declare + import their `HostComponent` variants.
+        const nested = new Set<string>();
+        for (const s of root.slots) {
+          walkRenderTree(s.body, {
+            enter(n) {
+              if (n.kind !== "ComponentInstance") return;
+              const nm = n.resolved?.name ?? n.reference.getText();
+              if (ctx.headlessRegistry?.get(nm)?.render.kind === "Element") nested.add(nm);
+            },
+          });
+        }
+        for (const nm of nested) {
+          const imp = ctx.componentImports.find((i) => i.localName === nm);
+          const path = imp ? `${imp.relativePath}.component` : `./${nm}.component`;
+          extraImports.push(cRaw({ text: `import { ${nm}HostComponent } from "${path}";` }));
+        }
+        const nestedImports =
+          nested.size > 0
+            ? `, imports: [${[...nested].map((n) => `${n}HostComponent`).join(", ")}]`
+            : "";
         pushHostVariant(
           angularAttrSelector(component.name, childRoot.tag),
           `host: { ${hostEntries.join(", ")} }`,
           headlessTemplate(childRoot, collapseRules),
-          "",
+          nestedImports,
         );
       } else {
         ctx.diagnostics.push("INK0111", component.loc, { name: component.name });
@@ -754,6 +795,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       }),
       ...emitComponentImports(ctx.componentImports, ".component", false, "Component"),
       ...sameFileImports,
+      ...extraImports,
       ...ctx.externalImports,
       ...styleImport,
       ...(ctx.typeDeclarations.length > 0 ? [cRaw({ text: "" }), ...ctx.typeDeclarations] : []),

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -717,16 +717,24 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       const child = ctx.headlessRegistry?.get(childName);
       if (child && child.render.kind === "Element") {
         const childRoot = child.render;
+        // The child's host bindings/events reference the child's own model setters (e.g.
+        // `setOpen(...)` from `defineModel("open")`); map those names onto the same model so they
+        // emit against the merged component, which declares that model under the styled binding.
+        const childSetters = Object.fromEntries(child.models.map((m) => [m.setterName, m.name]));
+        const collapseRules: RewriteRules = {
+          ...templateRules,
+          setters: { ...templateRules.setters, ...childSetters },
+        };
         const classAttr = root.attrs.find(
-          (a) => rewriteAttrName(a.name, templateRules) === "class",
+          (a) => rewriteAttrName(a.name, collapseRules) === "class",
         );
-        const recipeExpr = classAttr ? ownClassExpr(classAttr, templateRules) : undefined;
-        const hostEntries = headlessHostBindings(childRoot, templateRules, recipeExpr);
+        const recipeExpr = classAttr ? ownClassExpr(classAttr, collapseRules) : undefined;
+        const hostEntries = headlessHostBindings(childRoot, collapseRules, recipeExpr);
         hostEntries.push(`'${angularSelector(child.name)}': ''`);
         pushHostVariant(
           angularAttrSelector(component.name, childRoot.tag),
           `host: { ${hostEntries.join(", ")} }`,
-          headlessTemplate(childRoot, templateRules),
+          headlessTemplate(childRoot, collapseRules),
           "",
         );
       } else {

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -1,7 +1,7 @@
 import type { Target, CodegenContext, CodeModule, RewriteRules } from "../../context.ts";
 import { angularConformance } from "./conformance.ts";
 import type { Code } from "../../code-ir/nodes.ts";
-import type { IRComponent, IRNode } from "../../../ir/render/nodes.ts";
+import type { IRComponent, IRElement, IRNode } from "../../../ir/render/nodes.ts";
 import { cFile, cImport, cStmt, cRaw, cGroup } from "../../code-ir/builders.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
@@ -15,7 +15,7 @@ import {
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { assertNever } from "../../../core/assert.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
-import { angularSelector } from "./selector.ts";
+import { angularSelector, angularAttrSelector } from "./selector.ts";
 import * as ts from "typescript";
 
 /**
@@ -185,6 +185,55 @@ function ownClassExpr(
 ): string {
   if (a.value.kind === "Static") return `'${String(a.value.value)}'`;
   return `(${rewriteExpr(a.value.expr!, rules)})`;
+}
+
+/**
+ * Map a headless component's root element to Angular `host: { … }` binding entries. Reuses the exact
+ * attribute classification of `emitNode`'s Element case, rendered as host-binding keys so the native
+ * host element (the attribute-selector variant) carries them directly with no wrapper: the class
+ * merges with the parent-forwarded `klass()`, KEEP_PROPERTY attrs stay property bindings, every other
+ * dynamic attr binds via `[attr.name]` (`?? null` so a nullish value omits it), statics become literal
+ * host attributes, and root events become host event bindings.
+ */
+function headlessHostBindings(root: IRElement, rules: RewriteRules): string[] {
+  // The render root is always a fallthrough root (markRootFallthrough marks every Element root), so
+  // the class always merges the parent-forwarded `klass()`.
+  const entries: string[] = [];
+  let classBound = false;
+  for (const a of root.attrs) {
+    const name = rewriteAttrName(a.name, rules);
+    if (name === "class") {
+      classBound = true;
+      entries.push(`'[class]': "${mergedClassExpr(ownClassExpr(a, rules), rules)}"`);
+      continue;
+    }
+    if (a.value.kind === "Static") {
+      entries.push(`'${name}': '${a.value.value}'`);
+      continue;
+    }
+    const expr = rewriteExpr(a.value.expr, rules);
+    entries.push(
+      KEEP_PROPERTY.has(name) ? `'[${name}]': "${expr}"` : `'[attr.${name}]': "(${expr}) ?? null"`,
+    );
+  }
+  if (!classBound) {
+    entries.push(`'[class]': "${mergedClassExpr(undefined, rules)}"`);
+  }
+  for (const e of root.events) {
+    const evName = rewriteEventName(e.name, rules).replace(/^on/, "").toLowerCase();
+    entries.push(`'(${evName})': "${angularEventExpr(e.handler.expr, rules)}"`);
+  }
+  return entries;
+}
+
+/**
+ * The children-only template for a headless host variant: the root element's children emitted with
+ * the same inline/whitespace decision as the Element case, so the body matches the wrapper variant's
+ * exactly — only the surrounding root tag is gone (it became the host).
+ */
+function headlessTemplate(root: IRElement, rules: RewriteRules): string {
+  const inline = childrenArePhrasing(root.children);
+  return root.children.map((c) => emitNode(c, rules)).join(inline ? "" : "\n");
 }
 
 function emitNode(node: IRNode, rules: RewriteRules): string {
@@ -605,6 +654,40 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     cRaw({ text: `import { ${n}Component as ${n} } from "./${n}.component";` }),
   );
 
+  // Escape a template body for embedding in the `@Component({ template: `…` })` backticks.
+  const escTemplate = (t: string) => t.replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+  const classBody = () => [cRaw({ text: "{" }), cGroup({ children: body }), cRaw({ text: "}" })];
+
+  // The element-selector component (`<ink-x>`, a `display: contents` wrapper). Unchanged for every
+  // component — the backward-compatible form.
+  const classBlocks: Code[] = [
+    cRaw({
+      text: `@Component({ standalone: true, selector: '${angularSelector(component.name)}', host: { style: 'display: contents' }${importsStr}${providersStr}, template: \`${escTemplate(template)}\` })`,
+    }),
+    cStmt({ body: `export class ${component.name}Component` }),
+    ...classBody(),
+  ];
+
+  // A headless component additionally emits an attribute-selector variant whose single static-element
+  // root IS the Angular host (`<button ink-button-base>`, zero wrapper). A non-element root (fragment/
+  // conditional) can't be host-extracted — warn and keep only the element-selector variant.
+  if (component.meta?.headless) {
+    if (component.render.kind === "Element") {
+      const root = component.render;
+      const hostStr = `host: { ${headlessHostBindings(root, templateRules).join(", ")} }`;
+      classBlocks.push(
+        cRaw({ text: "" }),
+        cRaw({
+          text: `@Component({ standalone: true, selector: '${angularAttrSelector(component.name, root.tag)}', ${hostStr}${importsStr}${providersStr}, template: \`${escTemplate(headlessTemplate(root, templateRules))}\` })`,
+        }),
+        cStmt({ body: `export class ${component.name}HostComponent` }),
+        ...classBody(),
+      );
+    } else {
+      ctx.diagnostics.push("INK0111", component.loc, { name: component.name });
+    }
+  }
+
   const file = cFile({
     flavor: "ts",
     children: [
@@ -619,13 +702,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       ...(ctx.typeDeclarations.length > 0 ? [cRaw({ text: "" }), ...ctx.typeDeclarations] : []),
       ...(contextDefs.length > 0 ? [cRaw({ text: "" }), ...contextDefs] : []),
       cRaw({ text: "" }),
-      cRaw({
-        text: `@Component({ standalone: true, selector: '${angularSelector(component.name)}', host: { style: 'display: contents' }${importsStr}${providersStr}, template: \`${template.replace(/`/g, "\\`").replace(/\$\{/g, "\\${")}\` })`,
-      }),
-      cStmt({ body: `export class ${component.name}Component` }),
-      cRaw({ text: "{" }),
-      cGroup({ children: body }),
-      cRaw({ text: "}" }),
+      ...classBlocks,
     ],
   });
 

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -384,7 +384,12 @@ function emitNode(node: IRNode, rules: RewriteRules): string {
       }
       const ciAttrStr = ciParts.join(" ");
       if (node.slots.length === 0) {
-        // Non-self-closing: Angular's template parser mishandles self-closed component tags in JIT.
+        // A collapsed attribute-child on a void element (`<input ink-x>`) must self-close — Angular
+        // rejects `</input>`. Otherwise non-self-closing: Angular's JIT mishandles self-closed
+        // component (element-selector) tags.
+        if (childRoot && VOID_ELEMENTS.has(childRoot.tag)) {
+          return `<${openTag}${ciAttrStr ? " " + ciAttrStr : ""} />`;
+        }
         return `<${openTag}${ciAttrStr ? " " + ciAttrStr : ""}></${closeTag}>`;
       }
       const slotContent = node.slots

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -187,6 +187,11 @@ function ownClassExpr(
   return `(${rewriteExpr(a.value.expr!, rules)})`;
 }
 
+/** Append a conditional class fragment: `base + (extra ? ' ' + extra : '')`, or just `base` if absent. */
+function appendClass(base: string, extra: string | undefined): string {
+  return extra === undefined ? base : `${base} + (${extra} ? ' ' + ${extra} : '')`;
+}
+
 /**
  * Map a headless component's root element to Angular `host: { … }` binding entries. Reuses the exact
  * attribute classification of `emitNode`'s Element case, rendered as host-binding keys so the native
@@ -194,8 +199,11 @@ function ownClassExpr(
  * merges with the parent-forwarded `klass()`, KEEP_PROPERTY attrs stay property bindings, every other
  * dynamic attr binds via `[attr.name]` (`?? null` so a nullish value omits it), statics become literal
  * host attributes, and root events become host event bindings.
+ *
+ * `recipeExpr` (set when a styled component collapses onto this root) is the styled's forwarded class
+ * expression, merged between the root's own class and the inherited `klass()`.
  */
-function headlessHostBindings(root: IRElement, rules: RewriteRules): string[] {
+function headlessHostBindings(root: IRElement, rules: RewriteRules, recipeExpr?: string): string[] {
   // The render root is always a fallthrough root (markRootFallthrough marks every Element root), so
   // the class always merges the parent-forwarded `klass()`.
   const entries: string[] = [];
@@ -204,7 +212,8 @@ function headlessHostBindings(root: IRElement, rules: RewriteRules): string[] {
     const name = rewriteAttrName(a.name, rules);
     if (name === "class") {
       classBound = true;
-      entries.push(`'[class]': "${mergedClassExpr(ownClassExpr(a, rules), rules)}"`);
+      const own = appendClass(ownClassExpr(a, rules), recipeExpr);
+      entries.push(`'[class]': "${mergedClassExpr(own, rules)}"`);
       continue;
     }
     if (a.value.kind === "Static") {
@@ -217,7 +226,7 @@ function headlessHostBindings(root: IRElement, rules: RewriteRules): string[] {
     );
   }
   if (!classBound) {
-    entries.push(`'[class]': "${mergedClassExpr(undefined, rules)}"`);
+    entries.push(`'[class]': "${mergedClassExpr(recipeExpr, rules)}"`);
   }
   for (const e of root.events) {
     const evName = rewriteEventName(e.name, rules).replace(/^on/, "").toLowerCase();
@@ -669,20 +678,60 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   ];
 
   // A headless component additionally emits an attribute-selector variant whose single static-element
-  // root IS the Angular host (`<button ink-button-base>`, zero wrapper). A non-element root (fragment/
-  // conditional) can't be host-extracted — warn and keep only the element-selector variant.
+  // root IS the Angular host (`<button ink-button>`, zero wrapper). The element-selector wrapper above
+  // is kept (dual selector). `imports` is passed through only for direct extraction — a collapsed host
+  // inlines its child and instantiates nothing.
+  const pushHostVariant = (
+    selector: string,
+    hostStr: string,
+    tmpl: string,
+    imports: string,
+  ): void => {
+    classBlocks.push(
+      cRaw({ text: "" }),
+      cRaw({
+        text: `@Component({ standalone: true, selector: '${selector}', ${hostStr}${imports}${providersStr}, template: \`${escTemplate(tmpl)}\` })`,
+      }),
+      cStmt({ body: `export class ${component.name}HostComponent` }),
+      ...classBody(),
+    );
+  };
+
   if (component.meta?.headless) {
-    if (component.render.kind === "Element") {
-      const root = component.render;
-      const hostStr = `host: { ${headlessHostBindings(root, templateRules).join(", ")} }`;
-      classBlocks.push(
-        cRaw({ text: "" }),
-        cRaw({
-          text: `@Component({ standalone: true, selector: '${angularAttrSelector(component.name, root.tag)}', ${hostStr}${importsStr}${providersStr}, template: \`${escTemplate(headlessTemplate(root, templateRules))}\` })`,
-        }),
-        cStmt({ body: `export class ${component.name}HostComponent` }),
-        ...classBody(),
+    const root = component.render;
+    if (root.kind === "Element") {
+      // Direct extraction: the root element becomes the host; its children become the template.
+      pushHostVariant(
+        angularAttrSelector(component.name, root.tag),
+        `host: { ${headlessHostBindings(root, templateRules).join(", ")} }`,
+        headlessTemplate(root, templateRules),
+        importsStr,
       );
+    } else if (root.kind === "ComponentInstance") {
+      // Collapse: the styled root renders a single headless child (resolved from the registry). Inline
+      // that child's root as the host — its host bindings with the styled's recipe class merged in,
+      // plus the child's own selector as a static host attribute (`ink-button-base`) — and use the
+      // child's children as the template (assumes pass-through slot content; richer styled content is
+      // not yet inlined). The child is not instantiated, so the host variant declares no imports.
+      const childName = root.resolved?.name ?? root.reference.getText();
+      const child = ctx.headlessRegistry?.get(childName);
+      if (child && child.render.kind === "Element") {
+        const childRoot = child.render;
+        const classAttr = root.attrs.find(
+          (a) => rewriteAttrName(a.name, templateRules) === "class",
+        );
+        const recipeExpr = classAttr ? ownClassExpr(classAttr, templateRules) : undefined;
+        const hostEntries = headlessHostBindings(childRoot, templateRules, recipeExpr);
+        hostEntries.push(`'${angularSelector(child.name)}': ''`);
+        pushHostVariant(
+          angularAttrSelector(component.name, childRoot.tag),
+          `host: { ${hostEntries.join(", ")} }`,
+          headlessTemplate(childRoot, templateRules),
+          "",
+        );
+      } else {
+        ctx.diagnostics.push("INK0111", component.loc, { name: component.name });
+      }
     } else {
       ctx.diagnostics.push("INK0111", component.loc, { name: component.name });
     }

--- a/core/compiler/src/codegen/targets/angular/selector.ts
+++ b/core/compiler/src/codegen/targets/angular/selector.ts
@@ -20,3 +20,15 @@ export function angularSelector(componentName: string): string {
     .toLowerCase();
   return `ink-${kebab}`;
 }
+
+/**
+ * The attribute-selector form for a headless component, binding the directive to a native element
+ * via an attribute (the Angular Material `button[mat-button]` pattern). The element tag is the
+ * headless component's static root tag and the attribute token reuses {@link angularSelector}:
+ *
+ * - `IButtonBase` on `<button>` → `button[ink-button-base]`
+ * - `IBadgeBase` on `<div>` → `div[ink-badge-base]`
+ */
+export function angularAttrSelector(componentName: string, tag: string): string {
+  return `${tag}[${angularSelector(componentName)}]`;
+}

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -31,6 +31,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0090",
       "INK0100",
       "INK0110",
+      "INK0111",
       "INK0120",
     ];
     expect(codes.sort()).toEqual(expected.sort());
@@ -64,7 +65,7 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
-  it("codes with placeholders: INK0030, INK0044, INK0080, INK0090, INK0100, INK0110, INK0120", () => {
+  it("codes with placeholders: INK0030, INK0044, INK0080, INK0090, INK0100, INK0110, INK0111, INK0120", () => {
     const withPlaceholders = codes.filter((c) => /\{\w+\}/.test(DIAGNOSTICS[c].title));
     expect(withPlaceholders.sort()).toEqual([
       "INK0030",
@@ -73,6 +74,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0090",
       "INK0100",
       "INK0110",
+      "INK0111",
       "INK0120",
     ]);
   });

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -157,6 +157,13 @@ export const DIAGNOSTICS = {
     help: "Please file an issue with the source file attached." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0110" as const,
   },
+  INK0111: {
+    severity: "warning" as const,
+    title:
+      "Headless component '{name}' root must be a single static element to extract a host selector" as const,
+    help: "Give the headless component a single static-tag root element (e.g. <button>, <div>). A conditional or fragment root keeps the element-selector wrapper and no attribute-selector variant is emitted." as const,
+    url: "https://docs.inkline.dev/diagnostics/INK0111" as const,
+  },
   INK0120: {
     severity: "warning" as const,
     title: "Attributes passed to <{name}> cannot be inherited" as const,

--- a/core/compiler/src/ir/migration.test.ts
+++ b/core/compiler/src/ir/migration.test.ts
@@ -50,8 +50,8 @@ describe("migrate", () => {
     expect(result.version).toBe(1);
   });
 
-  it("IR_VERSION is 2", () => {
-    expect(IR_VERSION).toBe(2);
+  it("IR_VERSION is 3", () => {
+    expect(IR_VERSION).toBe(3);
   });
 
   it("v1 → v2 defaults `models` to [] on each component", () => {
@@ -75,5 +75,30 @@ describe("migrate", () => {
     const result = migrate(v1, 2);
     expect(result.version).toBe(2);
     expect(result.components[0]!.models).toEqual([]);
+  });
+
+  it("v2 → v3 is a pure version bump (meta is optional)", () => {
+    const sf = ts.createSourceFile("t.tsx", "", ts.ScriptTarget.Latest, true);
+    const v2Component = {
+      kind: "Component",
+      id: "t.tsx#T",
+      name: "T",
+      props: [],
+      events: [],
+      state: [],
+      models: [],
+    } as unknown as IRModule["components"][number];
+    const v2: IRModule = {
+      version: 2,
+      fileName: "t.tsx",
+      components: [v2Component],
+      contexts: [],
+      imports: [],
+      sourceFile: sf,
+    };
+    const result = migrate(v2, 3);
+    expect(result.version).toBe(3);
+    expect(result.components[0]).toBe(v2Component);
+    expect(result.components[0]!.meta).toBeUndefined();
   });
 });

--- a/core/compiler/src/ir/migration.ts
+++ b/core/compiler/src/ir/migration.ts
@@ -31,6 +31,15 @@ const migrations: IRMigration[] = [
       };
     },
   },
+  {
+    from: 2,
+    to: 3,
+    // IRComponent gained an optional `meta` ({ headless? }). It is optional, so absent `meta` already
+    // means "not headless" — no component rewrite is needed, only a version bump.
+    migrate(module) {
+      return { ...module, version: 3 };
+    },
+  },
 ];
 
 export function migrate(module: IRModule, target: number = IR_VERSION): IRModule {

--- a/core/compiler/src/ir/render/nodes.ts
+++ b/core/compiler/src/ir/render/nodes.ts
@@ -394,6 +394,12 @@ export interface IRComponent {
   readonly expose?: readonly string[];
   readonly styles: readonly IRStyleBlock[];
   readonly runtime: IRRuntimeMode;
+  /**
+   * Author-supplied component metadata (`defineComponent({ meta: … })`). `headless` marks a
+   * behavior-only component whose single static-element root the Angular target extracts as the
+   * host (attribute-selector emission). Absent === not headless.
+   */
+  readonly meta?: { readonly headless?: boolean };
   readonly targetOverrides: Readonly<Partial<Record<TargetName, IRTargetOverride>>>;
   readonly slotBindings?: ReadonlyMap<string, string>;
 }
@@ -403,7 +409,7 @@ export interface IRTargetOverride {
   readonly render?: IRNode;
 }
 
-export const IR_VERSION = 2;
+export const IR_VERSION = 3;
 
 export interface IRModule {
   readonly version: number;

--- a/core/compiler/src/pipeline/compile.test.ts
+++ b/core/compiler/src/pipeline/compile.test.ts
@@ -4,6 +4,7 @@ import type { Plugin } from "../plugin/types.ts";
 import type { GeneratedFile, Target } from "../codegen/context.ts";
 import { createRegistry } from "../codegen/registry.ts";
 import { UNKNOWN_LOCATION } from "../ir/types.ts";
+import { compileFixture } from "../testing/harness.ts";
 
 describe("compile", () => {
   it("returns a CompileResult with empty files for a non-component source", async () => {
@@ -35,6 +36,16 @@ describe("compile", () => {
     );
     expect("react" in result.files).toBe(true);
     expect("vue" in result.files).toBe(true);
+  });
+
+  it("skips the Angular-only headless registry for a non-Angular target but still emits", async () => {
+    // CollapseStyled is a headless component whose root is a ComponentInstance — the only shape that
+    // would build the cross-file registry. Only Angular consumes it, so a React-only compile must not
+    // re-parse siblings to build it, yet must still produce correct React output.
+    const result = await compileFixture("CollapseStyled", ["react"]);
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    expect(result.files.react?.length).toBeGreaterThan(0);
+    expect(result.files.angular).toBeUndefined();
   });
 
   it("throws when registry does not support a requested target", async () => {

--- a/core/compiler/src/pipeline/compile.ts
+++ b/core/compiler/src/pipeline/compile.ts
@@ -1,7 +1,11 @@
 import * as ts from "typescript";
 import type { Diagnostic } from "../core/diagnostics/codes.ts";
 import { createDiagnosticCollector } from "../core/diagnostics/collector.ts";
-import { resolveOptions, type InklineConfig } from "../core/options.ts";
+import {
+  resolveOptions,
+  type InklineConfig,
+  type ResolvedCompilerOptions,
+} from "../core/options.ts";
 import { SymbolTable } from "../ir/reactivity.ts";
 import type { IRComponent, IRModule } from "../ir/render/nodes.ts";
 import type { Code } from "../codegen/code-ir/nodes.ts";
@@ -11,7 +15,7 @@ import { print } from "../codegen/print/printer.ts";
 import { PluginRunner } from "../plugin/runner.ts";
 import type { PluginContext } from "../plugin/types.ts";
 import { analyzePass, type AnalyzedModule } from "./passes/04-analyze/index.ts";
-import { programPass, type CompileInput } from "./passes/01-program.ts";
+import { programPass, type CompileInput, type TsProgramArtifact } from "./passes/01-program.ts";
 import { parsePass } from "./passes/02-parse/index.ts";
 import { lower } from "./passes/03-lower/index.ts";
 import { resolveSiblings } from "./passes/01-program/resolver.ts";
@@ -86,6 +90,47 @@ function extractTypeDeclarations(module: IRModule): readonly Code[] {
     .map((s) => cRaw({ text: s.getText(module.sourceFile) }));
 }
 
+/**
+ * The Angular target inlines a headless child's root host bindings + template when a styled component
+ * collapses onto it (zero-wrapper) — which needs that child's lowered IR, but `compile` only parses
+ * the entry file. Re-parse + lower each imported `.ink` sibling (their source files are already in the
+ * TS program) with a throwaway context (own SymbolTable + discarded diagnostics — the sibling reports
+ * its own when compiled as an entry), and index the headless ones by name. Resolution is one level
+ * deep: a styled root is a single headless instance whose own root is an element, so no recursion is
+ * needed and no import cycle can form.
+ */
+async function buildHeadlessRegistry(
+  module: IRModule,
+  artifact: TsProgramArtifact,
+  options: ResolvedCompilerOptions,
+): Promise<ReadonlyMap<string, IRComponent>> {
+  const registry = new Map<string, IRComponent>();
+  const { checker, program } = artifact;
+  for (const decl of module.imports) {
+    const spec = (decl.moduleSpecifier as ts.StringLiteral).text;
+    if (!/\.ink(\.[jt]sx?)?$/.test(spec)) continue;
+    const sf = checker
+      .getSymbolAtLocation(decl.moduleSpecifier)
+      ?.declarations?.find(ts.isSourceFile);
+    if (!sf) continue;
+    const subCtx: PassContext = {
+      diagnostics: createDiagnosticCollector(),
+      options,
+      symbols: new SymbolTable(),
+      registry: options.registry,
+    };
+    try {
+      const parsed = await parsePass.run({ program, sourceFile: sf, checker }, subCtx);
+      for (const c of lower(parsed, subCtx).components) {
+        if (c.meta?.headless) registry.set(c.name, c);
+      }
+    } catch {
+      // A sibling we can't parse simply doesn't collapse — codegen falls back to the wrapper variant.
+    }
+  }
+  return registry;
+}
+
 function emitComponent(
   component: IRComponent,
   target: Target,
@@ -94,6 +139,7 @@ function emitComponent(
   externalImports: readonly Code[],
   componentImports: readonly ComponentImport[],
   typeDeclarations: readonly Code[],
+  headlessRegistry: ReadonlyMap<string, IRComponent> | undefined,
 ): GeneratedFile[] {
   const codeModule = target.emit(component, {
     diagnostics: ctx.diagnostics,
@@ -104,6 +150,7 @@ function emitComponent(
     externalImports,
     componentImports,
     typeDeclarations,
+    headlessRegistry,
   });
   const result = print(codeModule.root, { sourceMap: ctx.options.sourceMap });
   const files: GeneratedFile[] = [
@@ -216,6 +263,15 @@ export async function compile(
   const componentImports = extractComponentImports(analyzedModule.module);
   const typeDeclarations = extractTypeDeclarations(analyzedModule.module);
 
+  // Only a headless component whose root is another component (a styled wrapper collapsing onto its
+  // headless child) needs the cross-file registry; building it re-parses imported siblings.
+  const needsHeadlessRegistry = analyzedModule.module.components.some(
+    (c) => c.meta?.headless && c.render.kind === "ComponentInstance",
+  );
+  const headlessRegistry = needsHeadlessRegistry
+    ? await buildHeadlessRegistry(analyzedModule.module, artifact, options)
+    : undefined;
+
   for (const targetName of options.targets) {
     const target = options.registry.get(targetName);
     if (!target) continue;
@@ -233,6 +289,7 @@ export async function compile(
             externalImports,
             componentImports,
             typeDeclarations,
+            headlessRegistry,
           ),
         );
       } catch (err) {

--- a/core/compiler/src/pipeline/compile.ts
+++ b/core/compiler/src/pipeline/compile.ts
@@ -263,11 +263,14 @@ export async function compile(
   const componentImports = extractComponentImports(analyzedModule.module);
   const typeDeclarations = extractTypeDeclarations(analyzedModule.module);
 
-  // Only a headless component whose root is another component (a styled wrapper collapsing onto its
-  // headless child) needs the cross-file registry; building it re-parses imported siblings.
-  const needsHeadlessRegistry = analyzedModule.module.components.some(
-    (c) => c.meta?.headless && c.render.kind === "ComponentInstance",
-  );
+  // Only the Angular target consumes the cross-file headless registry, and building it re-parses +
+  // lowers imported `.ink` siblings — so build it only when Angular is requested AND a headless
+  // component's root is another component (a styled wrapper collapsing onto its headless child).
+  const needsHeadlessRegistry =
+    options.targets.includes("angular") &&
+    analyzedModule.module.components.some(
+      (c) => c.meta?.headless && c.render.kind === "ComponentInstance",
+    );
   const headlessRegistry = needsHeadlessRegistry
     ? await buildHeadlessRegistry(analyzedModule.module, artifact, options)
     : undefined;

--- a/core/compiler/src/pipeline/passes/02-parse/index.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/index.test.ts
@@ -59,6 +59,23 @@ describe("parsePass", () => {
     expect(ctx.diagnostics.freeze()).toHaveLength(0);
   });
 
+  it("populates component.meta from meta.headless and leaves it undefined otherwise", async () => {
+    const source = `
+      import { defineComponent } from "@inkline/core";
+      export const Headless = defineComponent({ meta: { headless: true } }, () => <button>x</button>);
+      export const Plain = defineComponent(() => <button>y</button>);
+    `;
+    const ctx = makeCtx();
+    const artifact = await programPass.run({ fileName: "Meta.ink.tsx", source }, ctx);
+    const module = parsePass.run(artifact, ctx);
+    const resolved = module instanceof Promise ? await module : module;
+
+    const headless = resolved.components.find((c) => c.name === "Headless")!;
+    const plain = resolved.components.find((c) => c.name === "Plain")!;
+    expect(headless.meta?.headless).toBe(true);
+    expect(plain.meta).toBeUndefined();
+  });
+
   it("parses JSX elements and text", async () => {
     const source = `
       import { defineComponent } from "@inkline/core";

--- a/core/compiler/src/pipeline/passes/02-parse/index.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/index.ts
@@ -106,6 +106,7 @@ export const parsePass: Pass<TsProgramArtifact, IRModule> = {
         primitives,
         styles,
         runtime,
+        meta: optionsResult?.headless ? { headless: true } : undefined,
         targetOverrides: {},
         slotBindings: setupResult.slotBindings.size > 0 ? setupResult.slotBindings : undefined,
       };

--- a/core/compiler/src/pipeline/passes/02-parse/options.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.test.ts
@@ -125,6 +125,50 @@ describe("parseOptions", () => {
     });
   });
 
+  describe("meta parsing", () => {
+    it("parses meta.headless: true", () => {
+      const { obj, sf } = getObjectLiteral(`{ meta: { headless: true } }`);
+      const ctx = makeCtx();
+      const result = parseOptions(obj, "test#X", sf, ctx);
+      expect(result.headless).toBe(true);
+    });
+
+    it("treats meta.headless: false (or absent) as not headless", () => {
+      const falseForm = parseOptions(
+        getObjectLiteral(`{ meta: { headless: false } }`).obj,
+        "test#X",
+        getObjectLiteral(`{ meta: { headless: false } }`).sf,
+        makeCtx(),
+      );
+      expect(falseForm.headless).toBe(false);
+      const absentForm = parseOptions(
+        getObjectLiteral(`{ meta: {} }`).obj,
+        "test#X",
+        getObjectLiteral(`{ meta: {} }`).sf,
+        makeCtx(),
+      );
+      expect(absentForm.headless).toBe(false);
+    });
+
+    it("ignores a non-object meta value", () => {
+      const { obj, sf } = getObjectLiteral(`{ meta: someVar }`);
+      const result = parseOptions(obj, "test#X", sf, makeCtx());
+      expect(result.headless).toBe(false);
+    });
+
+    it("reads headless among other meta keys and ignores non-headless keys", () => {
+      const { obj, sf } = getObjectLiteral(`{ meta: { variant: "x", headless: true } }`);
+      const result = parseOptions(obj, "test#X", sf, makeCtx());
+      expect(result.headless).toBe(true);
+    });
+
+    it("skips a shorthand meta property (not a static name/value assignment)", () => {
+      const { obj, sf } = getObjectLiteral(`{ meta: { headless } }`);
+      const result = parseOptions(obj, "test#X", sf, makeCtx());
+      expect(result.headless).toBe(false);
+    });
+  });
+
   it("ignores unknown option keys", () => {
     const { obj, sf } = getObjectLiteral(`{ name: "Comp", props: { x: String } }`);
     const ctx = makeCtx();
@@ -139,6 +183,7 @@ describe("parseOptions", () => {
     expect(result.props).toBeUndefined();
     expect(result.slots).toHaveLength(0);
     expect(result.events).toHaveLength(0);
+    expect(result.headless).toBe(false);
   });
 });
 

--- a/core/compiler/src/pipeline/passes/02-parse/options.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.ts
@@ -17,6 +17,7 @@ export interface ParsedOptions {
   readonly events: IREventDeclaration[];
   readonly styles: IRStyleBlock[];
   readonly runtime: IRRuntimeMode;
+  readonly headless?: boolean;
 }
 
 function makeExprNode(expr: ts.Expression, sf: ts.SourceFile): IRExprNode {
@@ -43,6 +44,7 @@ export function parseOptions(
   const events: IREventDeclaration[] = [];
   const styles: IRStyleBlock[] = [];
   let runtime: IRRuntimeMode = "iso";
+  let headless = false;
 
   for (const prop of options.properties) {
     if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
@@ -71,10 +73,21 @@ export function parseOptions(
         }
         break;
       }
+      case "meta": {
+        if (ts.isObjectLiteralExpression(prop.initializer)) {
+          for (const m of prop.initializer.properties) {
+            if (!ts.isPropertyAssignment(m) || !ts.isIdentifier(m.name)) continue;
+            if (m.name.text === "headless") {
+              headless = m.initializer.kind === ts.SyntaxKind.TrueKeyword;
+            }
+          }
+        }
+        break;
+      }
     }
   }
 
-  return { props, slots, events, styles, runtime };
+  return { props, slots, events, styles, runtime, headless };
 }
 
 function parseStyleFromValue(

--- a/core/core/src/index.ts
+++ b/core/core/src/index.ts
@@ -7,6 +7,13 @@ interface ComponentOptions {
   events?: Record<string, Record<string, never>>;
   runtime?: "client" | "server" | "iso";
   name?: string;
+  /**
+   * Component-level metadata read by the compiler. `headless: true` marks a behavior-only component
+   * (no styling) whose single static-element root the Angular target extracts as the host — emitting
+   * an attribute-selector component (`button[ink-x]`) alongside the element-selector one, so the
+   * native element carries the behavior with no wrapper.
+   */
+  meta?: { headless?: boolean };
 }
 
 export type InkComponent<P = {}> = (

--- a/tooling/test-utils/src/mount.ts
+++ b/tooling/test-utils/src/mount.ts
@@ -36,6 +36,7 @@ export async function mountForTarget(
   file: GeneratedFile,
   props?: Record<string, unknown>,
   supportingFiles?: readonly GeneratedFile[],
+  options?: { readonly componentName?: string },
 ): Promise<MountResult> {
   if (!isMountable(target)) {
     throw new Error(
@@ -48,7 +49,13 @@ export async function mountForTarget(
   console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
 
   try {
-    const { html, stderr } = await mountViaTempFile(target, file, props, supportingFiles ?? []);
+    const { html, stderr } = await mountViaTempFile(
+      target,
+      file,
+      props,
+      supportingFiles ?? [],
+      options?.componentName,
+    );
     // The sandbox routes runtime logging to stderr; surface it as warnings for debuggability.
     if (stderr.trim()) warnings.push(...stderr.trim().split("\n"));
     return { html, warnings };
@@ -62,6 +69,7 @@ async function mountViaTempFile(
   file: GeneratedFile,
   props: Record<string, unknown> | undefined,
   supportingFiles: readonly GeneratedFile[],
+  componentName: string | undefined,
 ): Promise<{ html: string; stderr: string }> {
   const tmp = mkdtempSync(join(tmpdir(), "ink-mount-"));
 
@@ -86,7 +94,7 @@ async function mountViaTempFile(
       symlinkSync(nodeModulesSource, nodeModulesDest, "dir");
     }
 
-    const mountScript = buildMountScript(target, `./${entryPath}`, props);
+    const mountScript = buildMountScript(target, `./${entryPath}`, props, componentName);
     const mountPath = join(tmp, "__mount__.mjs");
     writeFileSync(mountPath, mountScript, "utf-8");
 
@@ -116,38 +124,47 @@ async function mountViaTempFile(
  * harness by emitting the equivalent runtime decorator calls for the shapes our codegen produces.
  */
 function jitSignalMetadata(source: string): string {
-  const className = source.match(/export class (\w+)/)?.[1];
-  if (!className) return "";
+  // A file may declare more than one component class (a headless component emits both an
+  // element-selector wrapper and an attribute-selector host variant). Register each class's signal
+  // members against that class, scoping by source region so members aren't cross-registered.
+  const classMatches = [...source.matchAll(/export class (\w+)/g)];
+  if (classMatches.length === 0) return "";
 
   const lines: string[] = [];
   const memberRe = /^(\w+) = (input\.required|input|model|output|viewChild)(?:<.*?>)?\((.*)\)$/gm;
-  for (const m of source.matchAll(memberRe)) {
-    const [, field, kind, args] = m as unknown as [string, string, string, string];
-    const proto = `${className}.prototype, ${JSON.stringify(field)}`;
-    switch (kind) {
-      case "input":
-      case "input.required":
-        lines.push(
-          `__NgInput({ isSignal: true, alias: ${JSON.stringify(field)}, required: ${kind === "input.required"} })(${proto});`,
-        );
-        break;
-      case "model": {
-        const alias = args.match(/alias:\s*["']([^"']+)["']/)?.[1] ?? field;
-        lines.push(
-          `__NgInput({ isSignal: true, alias: ${JSON.stringify(alias)}, required: false })(${proto});`,
-          `__NgOutput(${JSON.stringify(`${alias}Change`)})(${proto});`,
-        );
-        break;
-      }
-      case "output":
-        lines.push(`__NgOutput()(${proto});`);
-        break;
-      case "viewChild": {
-        const marker = args.match(/["']([^"']+)["']/)?.[1];
-        if (marker) {
-          lines.push(`__NgViewChild(${JSON.stringify(marker)}, { isSignal: true })(${proto});`);
+  for (let i = 0; i < classMatches.length; i++) {
+    const className = classMatches[i]![1]!;
+    const start = classMatches[i]!.index!;
+    const end = i + 1 < classMatches.length ? classMatches[i + 1]!.index! : source.length;
+    const region = source.slice(start, end);
+    for (const m of region.matchAll(memberRe)) {
+      const [, field, kind, args] = m as unknown as [string, string, string, string];
+      const proto = `${className}.prototype, ${JSON.stringify(field)}`;
+      switch (kind) {
+        case "input":
+        case "input.required":
+          lines.push(
+            `__NgInput({ isSignal: true, alias: ${JSON.stringify(field)}, required: ${kind === "input.required"} })(${proto});`,
+          );
+          break;
+        case "model": {
+          const alias = args.match(/alias:\s*["']([^"']+)["']/)?.[1] ?? field;
+          lines.push(
+            `__NgInput({ isSignal: true, alias: ${JSON.stringify(alias)}, required: false })(${proto});`,
+            `__NgOutput(${JSON.stringify(`${alias}Change`)})(${proto});`,
+          );
+          break;
         }
-        break;
+        case "output":
+          lines.push(`__NgOutput()(${proto});`);
+          break;
+        case "viewChild": {
+          const marker = args.match(/["']([^"']+)["']/)?.[1];
+          if (marker) {
+            lines.push(`__NgViewChild(${JSON.stringify(marker)}, { isSignal: true })(${proto});`);
+          }
+          break;
+        }
       }
     }
   }
@@ -208,8 +225,12 @@ function buildMountScript(
   target: TargetName,
   componentPath: string,
   props?: Record<string, unknown>,
+  componentName?: string,
 ): string {
   const propsJson = JSON.stringify(props ?? {});
+  // When a file exports more than one component (a headless component's element-selector wrapper +
+  // its attribute-selector host variant), pick the requested export by name; otherwise fall back.
+  const pick = componentName ? `mod[${JSON.stringify(componentName)}] ?? ` : "";
 
   switch (target) {
     case "react":
@@ -262,10 +283,15 @@ console.log = (...args) => console.error(...args);
 console.info = (...args) => console.error(...args);
 
 const candidates = Object.values(mod).filter((v) => typeof v === "function");
-const C = mod.default ?? candidates.find((v) => reflectComponentType(v) != null);
+const C = ${pick}mod.default ?? candidates.find((v) => reflectComponentType(v) != null);
 const mirror = reflectComponentType(C);
 if (!mirror) throw new Error("No Angular component found in module");
-const selector = mirror.selector.split(",")[0].trim();
+// A selector may be an element (\`ink-button\`) or an attribute on a native element
+// (\`button[ink-button]\`); split the latter into its tag + attribute for the host template.
+const selectorRaw = mirror.selector.split(",")[0].trim();
+const br = selectorRaw.indexOf("[");
+const hostTag = br === -1 ? selectorRaw : selectorRaw.slice(0, br);
+const hostAttr = br === -1 ? "" : " " + selectorRaw.slice(br + 1, -1);
 
 const allProps = ${propsJson};
 const { __slots = {}, ...props } = allProps;
@@ -279,7 +305,7 @@ const Host = Component({
   standalone: true,
   selector: "mount-host",
   imports: [C],
-  template: \`<\${selector} \${bindings}>\${slotContent}</\${selector}>\`,
+  template: \`<\${hostTag}\${hostAttr} \${bindings}>\${slotContent}</\${hostTag}>\`,
 })(HostBase) ?? HostBase;
 
 const providers = [provideZonelessChangeDetection()];

--- a/ui/components/src/components/angular-ssr-helper.ts
+++ b/ui/components/src/components/angular-ssr-helper.ts
@@ -36,6 +36,7 @@ export async function mountStyledOnAngular(
   styledRel: string,
   headlessRels: readonly string[],
   props?: Record<string, unknown>,
+  componentName?: string,
 ): Promise<MountResult> {
   // Drive the same component (same props) through the React target so V8 coverage attributes the
   // executed `.ink.tsx` logic back to its authored source. A no-op unless a coverage run is active,
@@ -55,7 +56,7 @@ export async function mountStyledOnAngular(
     supporting.push(...files.map((f) => ({ ...f, path: `headless/${f.path}` })));
   }
 
-  const result = await mountForTarget("angular", entry, props, supporting);
+  const result = await mountForTarget("angular", entry, props, supporting, { componentName });
   const { warnings } = await coverage;
   return warnings.length > 0 ? { ...result, warnings: [...result.warnings, ...warnings] } : result;
 }

--- a/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
+++ b/ui/components/src/components/badge/headless/IBadgeBase.ink.tsx
@@ -6,6 +6,7 @@ export interface BadgeBaseProps {
 
 export default defineComponent(
   {
+    meta: { headless: true },
     slots: { default: {} },
   },
   (props: BadgeBaseProps) => {

--- a/ui/components/src/components/badge/headless/__snapshots__/IBadgeBase.ink.test.ts.snap
+++ b/ui/components/src/components/badge/headless/__snapshots__/IBadgeBase.ink.test.ts.snap
@@ -14,6 +14,12 @@ export class IBadgeBaseComponent
 klass = input<string>()
 label = input<string>()
 }
+@Component({ standalone: true, selector: 'div[ink-badge-base]', host: { '[class]': "'badge' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content>{{ label() }}</ng-content>\` })
+export class IBadgeBaseHostComponent
+{
+klass = input<string>()
+label = input<string>()
+}
 ",
   "astro/IBadgeBase.astro": "---
 export interface BadgeBaseProps {

--- a/ui/components/src/components/badge/styled/IBadge.ink.tsx
+++ b/ui/components/src/components/badge/styled/IBadge.ink.tsx
@@ -4,13 +4,16 @@ import { badgeRecipe, type BadgeRecipeProps as BadgeStylingProps } from "virtual
 
 export interface BadgeProps extends BadgeBaseProps, BadgeStylingProps {}
 
-export default defineComponent({ slots: { default: {} } }, (props: BadgeProps) => {
-  const className = createMemo(() =>
-    badgeRecipe({ color: props.color, variant: props.variant, size: props.size }),
-  );
-  return (
-    <IBadgeBase class={className()}>
-      <Slot>{props.label}</Slot>
-    </IBadgeBase>
-  );
-});
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: BadgeProps) => {
+    const className = createMemo(() =>
+      badgeRecipe({ color: props.color, variant: props.variant, size: props.size }),
+    );
+    return (
+      <IBadgeBase class={className()}>
+        <Slot>{props.label}</Slot>
+      </IBadgeBase>
+    );
+  },
+);

--- a/ui/components/src/components/button/headless/IButtonBase.ink.tsx
+++ b/ui/components/src/components/button/headless/IButtonBase.ink.tsx
@@ -9,6 +9,7 @@ export interface ButtonBaseProps {
 
 export default defineComponent(
   {
+    meta: { headless: true },
     slots: { default: {} },
   },
   (props: ButtonBaseProps) => {

--- a/ui/components/src/components/button/headless/__snapshots__/IButtonBase.ink.test.ts.snap
+++ b/ui/components/src/components/button/headless/__snapshots__/IButtonBase.ink.test.ts.snap
@@ -23,6 +23,18 @@ type = input<"button" | "submit" | "reset">()
 disabled = input<boolean>()
 loading = input<boolean>()
 }
+@Component({ standalone: true, selector: 'button[ink-button-base]', host: { '[class]': "'button' + (klass() ? ' ' + klass() : '')", '[attr.type]': "(type() ?? 'button') ?? null", '[disabled]': "disabled() || loading()", '[attr.aria-busy]': "(loading() ? 'true' : 'false') ?? null" }, template: \`@if (!!loading()) {
+<span class="button-spinner" aria-hidden="true"></span>
+}
+<ng-content>{{ label() }}</ng-content>\` })
+export class IButtonBaseHostComponent
+{
+klass = input<string>()
+label = input<string>()
+type = input<"button" | "submit" | "reset">()
+disabled = input<boolean>()
+loading = input<boolean>()
+}
 ",
   "astro/IButtonBase.astro": "---
 export interface ButtonBaseProps {

--- a/ui/components/src/components/button/styled/IButton.ink.test.ts
+++ b/ui/components/src/components/button/styled/IButton.ink.test.ts
@@ -37,4 +37,22 @@ describe("IButton (styled) on Angular SSR", () => {
 
     expect(html).toMatch(/<button[^>]*disabled/);
   });
+
+  // The attribute-selector host variant collapses both the styled and headless layers onto the real
+  // <button>: zero wrapper elements, both ink-* attributes present, recipe classes merged directly.
+  it("host variant renders a zero-wrapper <button ink-button ink-button-base>", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./IButton.ink.tsx",
+      ["../headless/IButtonBase.ink.tsx"],
+      { label: "Save", color: "primary", size: "md" },
+      "IButtonHostComponent",
+    );
+
+    expect(html).toMatch(/<button[^>]*class="button button--color-primary button--size-md"/);
+    expect(html).toContain('ink-button=""');
+    expect(html).toContain('ink-button-base=""');
+    expect(html).not.toContain("<ink-button"); // no display:contents wrapper element
+    expect(html).toContain("Save");
+  });
 });

--- a/ui/components/src/components/button/styled/IButton.ink.tsx
+++ b/ui/components/src/components/button/styled/IButton.ink.tsx
@@ -6,23 +6,26 @@ export interface ButtonProps extends ButtonBaseProps, ButtonStylingProps {
   block?: boolean;
 }
 
-export default defineComponent({ slots: { default: {} } }, (props: ButtonProps) => {
-  const className = createMemo(() =>
-    [
-      buttonRecipe({ color: props.color, variant: props.variant, size: props.size }),
-      props.block && "button--block",
-    ]
-      .filter(Boolean)
-      .join(" "),
-  );
-  return (
-    <IButtonBase
-      class={className()}
-      type={props.type}
-      disabled={props.disabled}
-      loading={props.loading}
-    >
-      <Slot>{props.label}</Slot>
-    </IButtonBase>
-  );
-});
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: ButtonProps) => {
+    const className = createMemo(() =>
+      [
+        buttonRecipe({ color: props.color, variant: props.variant, size: props.size }),
+        props.block && "button--block",
+      ]
+        .filter(Boolean)
+        .join(" "),
+    );
+    return (
+      <IButtonBase
+        class={className()}
+        type={props.type}
+        disabled={props.disabled}
+        loading={props.loading}
+      >
+        <Slot>{props.label}</Slot>
+      </IButtonBase>
+    );
+  },
+);

--- a/ui/components/src/components/field-group/headless/IFieldGroupBase.ink.tsx
+++ b/ui/components/src/components/field-group/headless/IFieldGroupBase.ink.tsx
@@ -5,10 +5,13 @@ export interface FieldGroupBaseProps {
   id?: string;
 }
 
-export default defineComponent({ slots: { default: {} } }, (props: FieldGroupBaseProps) => {
-  return (
-    <div class="field-group" id={props.id}>
-      <Slot />
-    </div>
-  );
-});
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: FieldGroupBaseProps) => {
+    return (
+      <div class="field-group" id={props.id}>
+        <Slot />
+      </div>
+    );
+  },
+);

--- a/ui/components/src/components/field-group/headless/__snapshots__/IFieldGroupBase.ink.test.ts.snap
+++ b/ui/components/src/components/field-group/headless/__snapshots__/IFieldGroupBase.ink.test.ts.snap
@@ -15,6 +15,12 @@ export class IFieldGroupBaseComponent
 klass = input<string>()
 id = input<string>()
 }
+@Component({ standalone: true, selector: 'div[ink-field-group-base]', host: { '[class]': "'field-group' + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null" }, template: \`<ng-content></ng-content>\` })
+export class IFieldGroupBaseHostComponent
+{
+klass = input<string>()
+id = input<string>()
+}
 ",
   "astro/IFieldGroupBase.astro": "---
 export interface FieldGroupBaseProps {

--- a/ui/components/src/components/field-group/styled/IFieldGroup.ink.tsx
+++ b/ui/components/src/components/field-group/styled/IFieldGroup.ink.tsx
@@ -14,14 +14,17 @@ export interface FieldGroupProps extends FieldGroupBaseProps, FieldGroupStylingP
  * `prepend`/`append` addons used to serve). `orientation` and `block` map to the recipe's styling
  * axes.
  */
-export default defineComponent({ slots: { default: {} } }, (props: FieldGroupProps) => {
-  const className = createMemo(() =>
-    fieldGroupRecipe({ orientation: props.orientation, block: props.block }),
-  );
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: FieldGroupProps) => {
+    const className = createMemo(() =>
+      fieldGroupRecipe({ orientation: props.orientation, block: props.block }),
+    );
 
-  return (
-    <IFieldGroupBase id={props.id} class={className()}>
-      <Slot />
-    </IFieldGroupBase>
-  );
-});
+    return (
+      <IFieldGroupBase id={props.id} class={className()}>
+        <Slot />
+      </IFieldGroupBase>
+    );
+  },
+);

--- a/ui/components/src/components/field-group/styled/__snapshots__/IFieldGroup.ink.test.ts.snap
+++ b/ui/components/src/components/field-group/styled/__snapshots__/IFieldGroup.ink.test.ts.snap
@@ -20,6 +20,14 @@ klass = input<string>()
 className = computed(() => fieldGroupRecipe({ orientation: this.orientation(), block: this.block() }))
 id = input<string>()
 }
+@Component({ standalone: true, selector: 'div[ink-field-group]', host: { '[class]': "'field-group' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", 'ink-field-group-base': '' }, template: \`<ng-content></ng-content>\` })
+export class IFieldGroupHostComponent
+{
+fieldGroupRecipe = fieldGroupRecipe
+klass = input<string>()
+className = computed(() => fieldGroupRecipe({ orientation: this.orientation(), block: this.block() }))
+id = input<string>()
+}
 ",
   "astro/IFieldGroup.astro": "---
 import IFieldGroupBase, { type FieldGroupBaseProps } from "../headless/IFieldGroupBase.astro";

--- a/ui/components/src/components/hamburger-menu/headless/IHamburgerMenuBase.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/headless/IHamburgerMenuBase.ink.tsx
@@ -9,7 +9,7 @@ export interface HamburgerMenuBaseProps {
   disabled?: boolean;
 }
 
-export default defineComponent((props: HamburgerMenuBaseProps) => {
+export default defineComponent({ meta: { headless: true } }, (props: HamburgerMenuBaseProps) => {
   // Two-way disclosure state: an `open` prop + paired `update:open` event, so a parent can `$bind:open`.
   const [open, setOpen] = defineModel<boolean>("open");
 

--- a/ui/components/src/components/hamburger-menu/headless/__snapshots__/IHamburgerMenuBase.ink.test.ts.snap
+++ b/ui/components/src/components/hamburger-menu/headless/__snapshots__/IHamburgerMenuBase.ink.test.ts.snap
@@ -22,6 +22,15 @@ ariaControls = input<string>()
 disabled = input<boolean>()
 open = model<boolean>()
 }
+@Component({ standalone: true, selector: 'button[ink-hamburger-menu-base]', host: { '[class]': "'hamburger-menu' + (klass() ? ' ' + klass() : '')", 'type': 'button', '[attr.aria-expanded]': "(open() ? 'true' : 'false') ?? null", '[attr.aria-controls]': "(ariaControls() ?? '') ?? null", '[attr.aria-label]': "(ariaLabel() ?? 'Toggle menu') ?? null", '[disabled]': "disabled()", '(click)': "open.set(!open())" }, template: \`<span class="hamburger-menu-inner" aria-hidden="true"></span>\` })
+export class IHamburgerMenuBaseHostComponent
+{
+klass = input<string>()
+ariaLabel = input<string>()
+ariaControls = input<string>()
+disabled = input<boolean>()
+open = model<boolean>()
+}
 ",
   "astro/IHamburgerMenuBase.astro": "---
 export interface HamburgerMenuBaseProps {

--- a/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.test.ts
+++ b/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.test.ts
@@ -125,4 +125,22 @@ describe("IHamburgerMenu (styled) on Angular SSR", () => {
     expect(html).toMatch(/<button[^>]*aria-label="Toggle menu"/);
     expect(html).toMatch(/<button[^>]*aria-controls=""/);
   });
+
+  // The collapsed host variant carries the model-driven behavior (aria-expanded, the click that
+  // toggles `open`) directly on the native button — zero wrappers, both ink-* attributes.
+  it("host variant renders a zero-wrapper <button ink-hamburger-menu ink-hamburger-menu-base>", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./IHamburgerMenu.ink.tsx",
+      HEADLESS,
+      { open: true, color: "dark", size: "md", ariaLabel: "Open navigation", ariaControls: "nav" },
+      "IHamburgerMenuHostComponent",
+    );
+    expect(html).toMatch(/<button[^>]*class="hamburger-menu[^"]*hamburger-menu--active-true[^"]*"/);
+    expect(html).toContain('ink-hamburger-menu=""');
+    expect(html).toContain('ink-hamburger-menu-base=""');
+    expect(html).toMatch(/<button[^>]*aria-expanded="true"/);
+    expect(html).not.toContain("<ink-hamburger-menu"); // no wrapper element
+    expect(html).toContain('class="hamburger-menu-inner"');
+  });
 });

--- a/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.tsx
+++ b/ui/components/src/components/hamburger-menu/styled/IHamburgerMenu.ink.tsx
@@ -19,7 +19,7 @@ export interface HamburgerMenuProps extends HamburgerMenuBaseProps {
   animation?: HamburgerMenuStylingProps["animation"];
 }
 
-export default defineComponent((props: HamburgerMenuProps) => {
+export default defineComponent({ meta: { headless: true } }, (props: HamburgerMenuProps) => {
   const [open, _setOpen] = defineModel<boolean>("open");
 
   const className = createMemo(() =>

--- a/ui/components/src/components/hamburger-menu/styled/__snapshots__/IHamburgerMenu.ink.test.ts.snap
+++ b/ui/components/src/components/hamburger-menu/styled/__snapshots__/IHamburgerMenu.ink.test.ts.snap
@@ -31,6 +31,20 @@ ariaControls = input<string>()
 disabled = input<boolean>()
 open = model<boolean>()
 }
+@Component({ standalone: true, selector: 'button[ink-hamburger-menu]', host: { '[class]': "'hamburger-menu' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')", 'type': 'button', '[attr.aria-expanded]': "(open() ? 'true' : 'false') ?? null", '[attr.aria-controls]': "(ariaControls() ?? '') ?? null", '[attr.aria-label]': "(ariaLabel() ?? 'Toggle menu') ?? null", '[disabled]': "disabled()", '(click)': "open.set(!open())", 'ink-hamburger-menu-base': '' }, template: \`<span class="hamburger-menu-inner" aria-hidden="true"></span>\` })
+export class IHamburgerMenuHostComponent
+{
+hamburgerMenuRecipe = hamburgerMenuRecipe
+klass = input<string>()
+className = computed(() => hamburgerMenuRecipe({ color: this.color(), size: this.size(), animation: this.animation(), active: this.open() ? 'true' : 'false' }))
+color = input<HamburgerMenuStylingProps["color"]>()
+size = input<HamburgerMenuStylingProps["size"]>()
+animation = input<HamburgerMenuStylingProps["animation"]>()
+ariaLabel = input<string>()
+ariaControls = input<string>()
+disabled = input<boolean>()
+open = model<boolean>()
+}
 ",
   "astro/IHamburgerMenu.astro": "---
 import IHamburgerMenuBase, { type HamburgerMenuBaseProps } from "../headless/IHamburgerMenuBase.astro";

--- a/ui/components/src/components/input/headless/IInputBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputBase.ink.tsx
@@ -7,6 +7,7 @@ export interface InputBaseProps {
 
 export default defineComponent(
   {
+    meta: { headless: true },
     slots: { default: {} },
   },
   (props: InputBaseProps) => {

--- a/ui/components/src/components/input/headless/IInputPrefixBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputPrefixBase.ink.tsx
@@ -2,10 +2,13 @@ import { defineComponent, Slot } from "@inkline/core";
 
 export interface InputPrefixBaseProps {}
 
-export default defineComponent({ slots: { default: {} } }, (_props: InputPrefixBaseProps) => {
-  return (
-    <span class="input-prefix">
-      <Slot />
-    </span>
-  );
-});
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: InputPrefixBaseProps) => {
+    return (
+      <span class="input-prefix">
+        <Slot />
+      </span>
+    );
+  },
+);

--- a/ui/components/src/components/input/headless/IInputSuffixBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputSuffixBase.ink.tsx
@@ -2,10 +2,13 @@ import { defineComponent, Slot } from "@inkline/core";
 
 export interface InputSuffixBaseProps {}
 
-export default defineComponent({ slots: { default: {} } }, (_props: InputSuffixBaseProps) => {
-  return (
-    <span class="input-suffix">
-      <Slot />
-    </span>
-  );
-});
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: InputSuffixBaseProps) => {
+    return (
+      <span class="input-suffix">
+        <Slot />
+      </span>
+    );
+  },
+);

--- a/ui/components/src/components/input/headless/IInputTextareaBase.ink.test.ts
+++ b/ui/components/src/components/input/headless/IInputTextareaBase.ink.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const INPUT_TEXTAREA = resolveComponent(import.meta.url, "./IInputTextareaBase.ink.tsx");
+
+describe("InputTextarea", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(INPUT_TEXTAREA);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("emits only the expected Astro two-way notice (INK0045)", async () => {
+    // The `defineModel` value is two-way; on the static Astro target that can't be interactive, so the
+    // compiler emits an info-level notice (INK0045). Every other target compiles cleanly.
+    const result = await compileComponent(INPUT_TEXTAREA);
+    const unexpected = result.diagnostics.filter((d) => d.code !== "INK0045");
+    expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(INPUT_TEXTAREA));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(INPUT_TEXTAREA));
+  });
+
+  it("host-extracts to a native textarea[ink-input-textarea-base] on Angular", async () => {
+    const result = await compileComponent(INPUT_TEXTAREA);
+    expectOutputContains(
+      result.files.angular ?? [],
+      "selector: 'textarea[ink-input-textarea-base]'",
+    );
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(INPUT_TEXTAREA))).toMatchSnapshot();
+  });
+
+  it('Solid coalesces the bound value so an unset model never renders the string "undefined"', async () => {
+    const result = await compileComponent(INPUT_TEXTAREA);
+    expectOutputContains(result.files.solid ?? [], 'value={props.value ?? ""}');
+  });
+});

--- a/ui/components/src/components/input/headless/IInputTextareaBase.ink.tsx
+++ b/ui/components/src/components/input/headless/IInputTextareaBase.ink.tsx
@@ -1,12 +1,10 @@
 import { defineComponent, defineModel } from "@inkline/core";
 
-export interface InputControlBaseProps {
+export interface InputTextareaBaseProps {
   /** Id of the native control. */
   id?: string;
   /** Name of the native control. */
   name?: string;
-  /** Input type (e.g. `"text"`, `"email"`). Use `IInputTextareaBase` for a `<textarea>`. */
-  type?: string;
   /** Placeholder text. */
   placeholder?: string;
   /** Disables the control. */
@@ -15,24 +13,23 @@ export interface InputControlBaseProps {
   readonly?: boolean;
 }
 
-// The native `<input>` control: a single static root, so it host-extracts to
-// `input[ink-input-control-base]`. The `<textarea>` variant is a sibling component
-// (`IInputTextareaBase`); the styled Input picks between them by `type`.
-export default defineComponent({ meta: { headless: true } }, (props: InputControlBaseProps) => {
+// The native `<textarea>` control: a single static root, so it host-extracts to
+// `textarea[ink-input-textarea-base]`. The styled Input renders this instead of IInputControlBase
+// when `type === "textarea"`.
+export default defineComponent({ meta: { headless: true } }, (props: InputTextareaBaseProps) => {
   // Two-way-bindable value: a `value` prop + an `update:value` event, so a parent can `$bind:value`.
   const [value, setValue] = defineModel<string>("value");
 
   return (
-    <input
+    <textarea
       class="input-field"
       id={props.id}
       name={props.name}
-      type={props.type}
       value={value() ?? ""}
       placeholder={props.placeholder}
       disabled={props.disabled}
       readonly={props.readonly}
-      onInput={(e: { currentTarget: HTMLInputElement }) => setValue(e.currentTarget.value)}
+      onInput={(e: { currentTarget: HTMLTextAreaElement }) => setValue(e.currentTarget.value)}
     />
   );
 });

--- a/ui/components/src/components/input/headless/__snapshots__/IInputBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputBase.ink.test.ts.snap
@@ -15,6 +15,12 @@ export class IInputBaseComponent
 klass = input<string>()
 id = input<string>()
 }
+@Component({ standalone: true, selector: 'div[ink-input-base]', host: { '[class]': "'input' + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null" }, template: \`<ng-content></ng-content>\` })
+export class IInputBaseHostComponent
+{
+klass = input<string>()
+id = input<string>()
+}
 ",
   "astro/IInputBase.astro": "---
 export interface InputBaseProps {

--- a/ui/components/src/components/input/headless/__snapshots__/IInputControlBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputControlBase.ink.test.ts.snap
@@ -8,7 +8,7 @@ export interface InputControlBaseProps {
   id?: string;
   /** Name of the native control. */
   name?: string;
-  /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+  /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
   type?: string;
   /** Placeholder text. */
   placeholder?: string;
@@ -17,13 +17,22 @@ export interface InputControlBaseProps {
   /** Marks the control as read-only. */
   readonly?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-input-control-base', host: { style: 'display: contents' }, template: \`@if (type() === 'textarea') {
-<textarea class="input-field" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [value]="value() ?? ''" [attr.placeholder]="(placeholder()) ?? null" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)"></textarea>
-} @else {
-<input class="input-field" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [attr.type]="(type()) ?? null" [value]="value() ?? ''" [attr.placeholder]="(placeholder()) ?? null" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)" />
-}\` })
+@Component({ standalone: true, selector: 'ink-input-control-base', host: { style: 'display: contents' }, template: \`<input [class]="'input-field' + (klass() ? ' ' + klass() : '')" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [attr.type]="(type()) ?? null" [value]="value() ?? ''" [attr.placeholder]="(placeholder()) ?? null" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)" />\` })
 export class IInputControlBaseComponent
 {
+klass = input<string>()
+id = input<string>()
+name = input<string>()
+type = input<string>()
+placeholder = input<string>()
+disabled = input<boolean>()
+readonly = input<boolean>()
+value = model<string>()
+}
+@Component({ standalone: true, selector: 'input[ink-input-control-base]', host: { '[class]': "'input-field' + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[attr.type]': "(type()) ?? null", '[value]': "value() ?? ''", '[attr.placeholder]': "(placeholder()) ?? null", '[disabled]': "disabled()", '[readonly]': "readonly()", '(input)': "value.set($event.currentTarget.value)" }, template: \`\` })
+export class IInputControlBaseHostComponent
+{
+klass = input<string>()
 id = input<string>()
 name = input<string>()
 type = input<string>()
@@ -39,7 +48,7 @@ export interface InputControlBaseProps {
   id?: string;
   /** Name of the native control. */
   name?: string;
-  /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+  /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
   type?: string;
   /** Placeholder text. */
   placeholder?: string;
@@ -48,12 +57,12 @@ export interface InputControlBaseProps {
   /** Marks the control as read-only. */
   readonly?: boolean;
 }
-type Props = InputControlBaseProps
+type Props = InputControlBaseProps & Record<string, any>
 const props = Astro.props as Props;
-const { id, name, type, placeholder, disabled, readonly } = props;
+const { id, name, type, placeholder, disabled, readonly, ...__attrs } = props;
 let value = props.value
 ---
-{type === "textarea" ? (<textarea class="input-field" id={id} name={name} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} onInput={(e: { currentTarget: HTMLTextAreaElement }) => value = e.currentTarget.value} />) : (<input class="input-field" id={id} name={name} type={type} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} onInput={(e: { currentTarget: HTMLInputElement }) => value = e.currentTarget.value} />)}
+<input {...__attrs} class={["input-field", __attrs.class].filter(Boolean).join(" ")} id={id} name={name} type={type} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} onInput={(e: { currentTarget: HTMLInputElement }) => value = e.currentTarget.value} />
 ",
   "qwik/IInputControlBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
 export interface InputControlBaseProps {
@@ -61,7 +70,7 @@ export interface InputControlBaseProps {
   id?: string;
   /** Name of the native control. */
   name?: string;
-  /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+  /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
   type?: string;
   /** Placeholder text. */
   placeholder?: string;
@@ -72,8 +81,10 @@ export interface InputControlBaseProps {
 }
 export const IInputControlBase = component$((props: InputControlBaseProps & { value?: string; onUpdateValue$?: QRL<(value: string) => void> } & Record<string, any>) =>
 {
+const { id, name, type, placeholder, disabled, readonly, value, onUpdateValue$, ...__attrs } = props
 return (
-props.type === "textarea" ? (<><textarea class="input-field" id={props.id} name={props.name} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onInput={$((e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue$?.(e.currentTarget.value))} /></>) : (<><input class="input-field" id={props.id} name={props.name} type={props.type} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onInput={$((e: { currentTarget: HTMLInputElement }) => props.onUpdateValue$?.(e.currentTarget.value))} /></>))
+<input {...__attrs} class={["input-field", props.class].filter(Boolean).join(" ")} id={props.id} name={props.name} type={props.type} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onInput={$((e: { currentTarget: HTMLInputElement }) => props.onUpdateValue$?.(e.currentTarget.value))} />
+)
 });
 ",
   "react/IInputControlBase.tsx": "export interface InputControlBaseProps {
@@ -81,7 +92,7 @@ props.type === "textarea" ? (<><textarea class="input-field" id={props.id} name=
   id?: string;
   /** Name of the native control. */
   name?: string;
-  /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+  /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
   type?: string;
   /** Placeholder text. */
   placeholder?: string;
@@ -90,19 +101,22 @@ props.type === "textarea" ? (<><textarea class="input-field" id={props.id} name=
   /** Marks the control as read-only. */
   readonly?: boolean;
 }
-export function IInputControlBase(props: InputControlBaseProps & { value?: string; onUpdateValue?: (value: string) => void })
+export function IInputControlBase(props: InputControlBaseProps & { value?: string; onUpdateValue?: (value: string) => void } & React.HTMLAttributes<HTMLElement>)
 {
+const { id, name, type, placeholder, disabled, readonly, value, onUpdateValue, ...__attrs } = props
 return (
-props.type === "textarea" ? <textarea className="input-field" id={props.id} name={props.name} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onInput={(e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue?.(e.currentTarget.value)} /> : <input className="input-field" id={props.id} name={props.name} type={props.type} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onInput={(e: { currentTarget: HTMLInputElement }) => props.onUpdateValue?.(e.currentTarget.value)} />)
+<input {...__attrs} className={["input-field", props.className].filter(Boolean).join(" ")} id={props.id} name={props.name} type={props.type} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onInput={(e: { currentTarget: HTMLInputElement }) => props.onUpdateValue?.(e.currentTarget.value)} />
+)
 }
 ",
-  "solid/IInputControlBase.tsx": "import { Show } from "solid-js";
+  "solid/IInputControlBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
 export interface InputControlBaseProps {
   /** Id of the native control. */
   id?: string;
   /** Name of the native control. */
   name?: string;
-  /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+  /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
   type?: string;
   /** Placeholder text. */
   placeholder?: string;
@@ -111,12 +125,11 @@ export interface InputControlBaseProps {
   /** Marks the control as read-only. */
   readonly?: boolean;
 }
-export default function IInputControlBase(props: InputControlBaseProps & { value?: string; onUpdateValue?: (value: string) => void })
+export default function IInputControlBase(props: InputControlBaseProps & { value?: string; onUpdateValue?: (value: string) => void } & JSX.HTMLAttributes<HTMLElement>)
 {
+const [, __attrs] = splitProps(props, ["id", "name", "type", "placeholder", "disabled", "readonly", "value", "onUpdateValue"])
 return (
-<Show when={props.type === "textarea"} fallback={<><input class="input-field" id={props.id} name={props.name} type={props.type} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} oninput={(e: { currentTarget: HTMLInputElement }) => props.onUpdateValue?.(e.currentTarget.value)} /></>}>
-  <textarea class="input-field" id={props.id} name={props.name} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} oninput={(e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue?.(e.currentTarget.value)} />
-</Show>
+<input {...__attrs} class={["input-field", props.class].filter(Boolean).join(" ")} id={props.id} name={props.name} type={props.type} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} oninput={(e: { currentTarget: HTMLInputElement }) => props.onUpdateValue?.(e.currentTarget.value)} />
 )
 }
 ",
@@ -126,7 +139,7 @@ return (
     id?: string;
     /** Name of the native control. */
     name?: string;
-    /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+    /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
     type?: string;
     /** Placeholder text. */
     placeholder?: string;
@@ -135,11 +148,9 @@ return (
     /** Marks the control as read-only. */
     readonly?: boolean;
   }
-  let { id, name, type, placeholder, disabled, readonly, value = $bindable() }: InputControlBaseProps & { value?: string } = $props()
+  let { id, name, type, placeholder, disabled, readonly, value = $bindable(), ...__attrs }: InputControlBaseProps & { value?: string } & Record<string, any> = $props()
 </script>
-{#if type === "textarea"}<textarea class="input-field" id={id} name={name} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} oninput={(e: { currentTarget: HTMLTextAreaElement }) => value = e.currentTarget.value}></textarea>
-{:else}<input class="input-field" id={id} name={name} type={type} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} oninput={(e: { currentTarget: HTMLInputElement }) => value = e.currentTarget.value} />
-{/if}
+<input {...__attrs} class={["input-field", __attrs.class].filter(Boolean).join(" ")} id={id} name={name} type={type} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} oninput={(e: { currentTarget: HTMLInputElement }) => value = e.currentTarget.value} />
 ",
   "vue/IInputControlBase.vue": "<script setup lang="ts">
   export interface InputControlBaseProps {
@@ -147,7 +158,7 @@ return (
     id?: string;
     /** Name of the native control. */
     name?: string;
-    /** Input type; \`"textarea"\` renders a \`<textarea>\`. */
+    /** Input type (e.g. \`"text"\`, \`"email"\`). Use \`IInputTextareaBase\` for a \`<textarea>\`. */
     type?: string;
     /** Placeholder text. */
     placeholder?: string;
@@ -160,8 +171,7 @@ return (
   const value = defineModel<string>("value")
 </script>
 <template>
-<textarea v-if='type === "textarea"' class="input-field" :id="id" :name="name" :value='value ?? ""' :placeholder="placeholder" :disabled="disabled" :readonly="readonly" @input="(e: { currentTarget: HTMLTextAreaElement }) => value = e.currentTarget.value" />
-<input v-else class="input-field" :id="id" :name="name" :type="type" :value='value ?? ""' :placeholder="placeholder" :disabled="disabled" :readonly="readonly" @input="(e: { currentTarget: HTMLInputElement }) => value = e.currentTarget.value" />
+<input class="input-field" :id="id" :name="name" :type="type" :value='value ?? ""' :placeholder="placeholder" :disabled="disabled" :readonly="readonly" @input="(e: { currentTarget: HTMLInputElement }) => value = e.currentTarget.value" />
 </template>
 ",
 }

--- a/ui/components/src/components/input/headless/__snapshots__/IInputPrefixBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputPrefixBase.ink.test.ts.snap
@@ -11,6 +11,11 @@ export class IInputPrefixBaseComponent
 {
 klass = input<string>()
 }
+@Component({ standalone: true, selector: 'span[ink-input-prefix-base]', host: { '[class]': "'input-prefix' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content></ng-content>\` })
+export class IInputPrefixBaseHostComponent
+{
+klass = input<string>()
+}
 ",
   "astro/IInputPrefixBase.astro": "---
 export interface InputPrefixBaseProps {}

--- a/ui/components/src/components/input/headless/__snapshots__/IInputSuffixBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputSuffixBase.ink.test.ts.snap
@@ -11,6 +11,11 @@ export class IInputSuffixBaseComponent
 {
 klass = input<string>()
 }
+@Component({ standalone: true, selector: 'span[ink-input-suffix-base]', host: { '[class]': "'input-suffix' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content></ng-content>\` })
+export class IInputSuffixBaseHostComponent
+{
+klass = input<string>()
+}
 ",
   "astro/IInputSuffixBase.astro": "---
 export interface InputSuffixBaseProps {}

--- a/ui/components/src/components/input/headless/__snapshots__/IInputTextareaBase.ink.test.ts.snap
+++ b/ui/components/src/components/input/headless/__snapshots__/IInputTextareaBase.ink.test.ts.snap
@@ -1,0 +1,162 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`InputTextarea > output matches snapshots 1`] = `
+{
+  "angular/IInputTextareaBase.component.ts": "import { Component, signal, computed, effect, input, model } from "@angular/core";
+export interface InputTextareaBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control. */
+  name?: string;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+  /** Marks the control as read-only. */
+  readonly?: boolean;
+}
+@Component({ standalone: true, selector: 'ink-input-textarea-base', host: { style: 'display: contents' }, template: \`<textarea [class]="'input-field' + (klass() ? ' ' + klass() : '')" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [value]="value() ?? ''" [attr.placeholder]="(placeholder()) ?? null" [disabled]="disabled()" [readonly]="readonly()" (input)="value.set($event.currentTarget.value)"></textarea>\` })
+export class IInputTextareaBaseComponent
+{
+klass = input<string>()
+id = input<string>()
+name = input<string>()
+placeholder = input<string>()
+disabled = input<boolean>()
+readonly = input<boolean>()
+value = model<string>()
+}
+@Component({ standalone: true, selector: 'textarea[ink-input-textarea-base]', host: { '[class]': "'input-field' + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[value]': "value() ?? ''", '[attr.placeholder]': "(placeholder()) ?? null", '[disabled]': "disabled()", '[readonly]': "readonly()", '(input)': "value.set($event.currentTarget.value)" }, template: \`\` })
+export class IInputTextareaBaseHostComponent
+{
+klass = input<string>()
+id = input<string>()
+name = input<string>()
+placeholder = input<string>()
+disabled = input<boolean>()
+readonly = input<boolean>()
+value = model<string>()
+}
+",
+  "astro/IInputTextareaBase.astro": "---
+export interface InputTextareaBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control. */
+  name?: string;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+  /** Marks the control as read-only. */
+  readonly?: boolean;
+}
+type Props = InputTextareaBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { id, name, placeholder, disabled, readonly, ...__attrs } = props;
+let value = props.value
+---
+<textarea {...__attrs} class={["input-field", __attrs.class].filter(Boolean).join(" ")} id={id} name={name} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} onInput={(e: { currentTarget: HTMLTextAreaElement }) => value = e.currentTarget.value} />
+",
+  "qwik/IInputTextareaBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
+export interface InputTextareaBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control. */
+  name?: string;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+  /** Marks the control as read-only. */
+  readonly?: boolean;
+}
+export const IInputTextareaBase = component$((props: InputTextareaBaseProps & { value?: string; onUpdateValue$?: QRL<(value: string) => void> } & Record<string, any>) =>
+{
+const { id, name, placeholder, disabled, readonly, value, onUpdateValue$, ...__attrs } = props
+return (
+<textarea {...__attrs} class={["input-field", props.class].filter(Boolean).join(" ")} id={props.id} name={props.name} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onInput={$((e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue$?.(e.currentTarget.value))} />
+)
+});
+",
+  "react/IInputTextareaBase.tsx": "export interface InputTextareaBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control. */
+  name?: string;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+  /** Marks the control as read-only. */
+  readonly?: boolean;
+}
+export function IInputTextareaBase(props: InputTextareaBaseProps & { value?: string; onUpdateValue?: (value: string) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const { id, name, placeholder, disabled, readonly, value, onUpdateValue, ...__attrs } = props
+return (
+<textarea {...__attrs} className={["input-field", props.className].filter(Boolean).join(" ")} id={props.id} name={props.name} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onInput={(e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue?.(e.currentTarget.value)} />
+)
+}
+",
+  "solid/IInputTextareaBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface InputTextareaBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control. */
+  name?: string;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+  /** Marks the control as read-only. */
+  readonly?: boolean;
+}
+export default function IInputTextareaBase(props: InputTextareaBaseProps & { value?: string; onUpdateValue?: (value: string) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["id", "name", "placeholder", "disabled", "readonly", "value", "onUpdateValue"])
+return (
+<textarea {...__attrs} class={["input-field", props.class].filter(Boolean).join(" ")} id={props.id} name={props.name} value={props.value ?? ""} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} oninput={(e: { currentTarget: HTMLTextAreaElement }) => props.onUpdateValue?.(e.currentTarget.value)} />
+)
+}
+",
+  "svelte/IInputTextareaBase.svelte": "<script lang="ts">
+  export interface InputTextareaBaseProps {
+    /** Id of the native control. */
+    id?: string;
+    /** Name of the native control. */
+    name?: string;
+    /** Placeholder text. */
+    placeholder?: string;
+    /** Disables the control. */
+    disabled?: boolean;
+    /** Marks the control as read-only. */
+    readonly?: boolean;
+  }
+  let { id, name, placeholder, disabled, readonly, value = $bindable(), ...__attrs }: InputTextareaBaseProps & { value?: string } & Record<string, any> = $props()
+</script>
+<textarea {...__attrs} class={["input-field", __attrs.class].filter(Boolean).join(" ")} id={id} name={name} value={value ?? ""} placeholder={placeholder} disabled={disabled} readonly={readonly} oninput={(e: { currentTarget: HTMLTextAreaElement }) => value = e.currentTarget.value}></textarea>
+",
+  "vue/IInputTextareaBase.vue": "<script setup lang="ts">
+  export interface InputTextareaBaseProps {
+    /** Id of the native control. */
+    id?: string;
+    /** Name of the native control. */
+    name?: string;
+    /** Placeholder text. */
+    placeholder?: string;
+    /** Disables the control. */
+    disabled?: boolean;
+    /** Marks the control as read-only. */
+    readonly?: boolean;
+  }
+  const props = defineProps<InputTextareaBaseProps>()
+  const value = defineModel<string>("value")
+</script>
+<template>
+<textarea class="input-field" :id="id" :name="name" :value='value ?? ""' :placeholder="placeholder" :disabled="disabled" :readonly="readonly" @input="(e: { currentTarget: HTMLTextAreaElement }) => value = e.currentTarget.value" />
+</template>
+",
+}
+`;

--- a/ui/components/src/components/input/styled/IInput.ink.test.ts
+++ b/ui/components/src/components/input/styled/IInput.ink.test.ts
@@ -110,6 +110,7 @@ describe("IInput (styled) on Angular SSR", () => {
     "../headless/IInputPrefixBase.ink.tsx",
     "../headless/IInputSuffixBase.ink.tsx",
     "../headless/IInputControlBase.ink.tsx",
+    "../headless/IInputTextareaBase.ink.tsx",
   ];
 
   const mount = (props?: Record<string, unknown>) =>
@@ -159,5 +160,36 @@ describe("IInput (styled) on Angular SSR", () => {
     const { html } = await mount({ placeholder: "Off", disabled: true });
 
     expect(html).toMatch(/<input[^>]*disabled/);
+  });
+
+  // The collapsed host variant inlines the whole composite onto native elements: the shell is the
+  // <div> host, the addons are <span ink-input-prefix-base>, and the control is a bare native
+  // <input ink-input-control-base> — zero wrapper elements around any of them.
+  it("host variant renders a fully zero-wrapper field (div > span / input / span)", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./IInput.ink.tsx",
+      HEADLESS,
+      { value: "hi", placeholder: "Name", color: "primary", size: "md" },
+      "IInputHostComponent",
+    );
+    expect(html).toMatch(
+      /<div[^>]*ink-input[^>]*class="input input--color-primary input--size-md"/,
+    );
+    expect(html).toMatch(/<input ink-input-control-base[^>]*value="hi"[^>]*class="input-field"/);
+    expect(html).toMatch(/<span ink-input-prefix-base[^>]*class="input-prefix/);
+    expect(html).not.toContain("<ink-input"); // no display:contents wrapper elements anywhere
+  });
+
+  it("host variant renders a native <textarea> for type=textarea, still zero-wrapper", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./IInput.ink.tsx",
+      HEADLESS,
+      { type: "textarea", placeholder: "Bio" },
+      "IInputHostComponent",
+    );
+    expect(html).toMatch(/<textarea ink-input-textarea-base[^>]*class="input-field"/);
+    expect(html).not.toContain("<ink-input");
   });
 });

--- a/ui/components/src/components/input/styled/IInput.ink.test.ts
+++ b/ui/components/src/components/input/styled/IInput.ink.test.ts
@@ -192,4 +192,19 @@ describe("IInput (styled) on Angular SSR", () => {
     expect(html).toMatch(/<textarea ink-input-textarea-base[^>]*class="input-field"/);
     expect(html).not.toContain("<ink-input");
   });
+
+  // IInput forwards `id` to the control, not to the shell. The collapsed host must keep that split:
+  // putting `id` on both the shell <div> and the inner <input> would be a duplicate id (invalid HTML,
+  // and label[for]/getElementById would resolve to the non-focusable shell).
+  it("host variant puts id on the control only, not the shell", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./IInput.ink.tsx",
+      HEADLESS,
+      { id: "email", placeholder: "Email", color: "primary", size: "md" },
+      "IInputHostComponent",
+    );
+    expect(html).toMatch(/<input[^>]*id="email"/);
+    expect(html).not.toMatch(/<div[^>]*id="email"/);
+  });
 });

--- a/ui/components/src/components/input/styled/IInput.ink.tsx
+++ b/ui/components/src/components/input/styled/IInput.ink.tsx
@@ -5,6 +5,7 @@ import IInputSuffixBase from "../headless/IInputSuffixBase.ink.tsx";
 import IInputControlBase, {
   type InputControlBaseProps,
 } from "../headless/IInputControlBase.ink.tsx";
+import IInputTextareaBase from "../headless/IInputTextareaBase.ink.tsx";
 import {
   inputRecipe,
   inputPrefixRecipe,
@@ -35,41 +36,58 @@ export interface InputProps extends InputControlBaseProps {
  * Qwik/Angular, which lack runtime slot presence). The two-way `value` is forwarded to the control
  * via `$bind:value`. To attach controls outside the field, wrap them in `IFieldGroup`.
  */
-export default defineComponent({ slots: { prefix: {}, suffix: {} } }, (props: InputProps) => {
-  const [value, _setValue] = defineModel<string>("value");
+export default defineComponent(
+  { meta: { headless: true }, slots: { prefix: {}, suffix: {} } },
+  (props: InputProps) => {
+    const [value, _setValue] = defineModel<string>("value");
 
-  const shellClassName = createMemo(() =>
-    inputRecipe({
-      color: props.color,
-      variant: props.variant,
-      size: props.size,
-      invalid: props.invalid,
-      disabled: props.disabled,
-      readonly: props.readonly,
-    }),
-  );
+    const shellClassName = createMemo(() =>
+      inputRecipe({
+        color: props.color,
+        variant: props.variant,
+        size: props.size,
+        invalid: props.invalid,
+        disabled: props.disabled,
+        readonly: props.readonly,
+      }),
+    );
 
-  return (
-    <IInputBase class={shellClassName()}>
-      <Show when={hasSlot("prefix")}>
-        <IInputPrefixBase class={inputPrefixRecipe({ size: props.size })}>
-          <Slot name="prefix" />
-        </IInputPrefixBase>
-      </Show>
-      <IInputControlBase
-        id={props.id}
-        name={props.name}
-        type={props.type}
-        $bind:value={value}
-        placeholder={props.placeholder}
-        disabled={props.disabled}
-        readonly={props.readonly}
-      />
-      <Show when={hasSlot("suffix")}>
-        <IInputSuffixBase class={inputSuffixRecipe({ size: props.size })}>
-          <Slot name="suffix" />
-        </IInputSuffixBase>
-      </Show>
-    </IInputBase>
-  );
-});
+    return (
+      <IInputBase class={shellClassName()}>
+        <Show when={hasSlot("prefix")}>
+          <IInputPrefixBase class={inputPrefixRecipe({ size: props.size })}>
+            <Slot name="prefix" />
+          </IInputPrefixBase>
+        </Show>
+        <Show
+          when={props.type === "textarea"}
+          fallback={
+            <IInputControlBase
+              id={props.id}
+              name={props.name}
+              type={props.type}
+              $bind:value={value}
+              placeholder={props.placeholder}
+              disabled={props.disabled}
+              readonly={props.readonly}
+            />
+          }
+        >
+          <IInputTextareaBase
+            id={props.id}
+            name={props.name}
+            $bind:value={value}
+            placeholder={props.placeholder}
+            disabled={props.disabled}
+            readonly={props.readonly}
+          />
+        </Show>
+        <Show when={hasSlot("suffix")}>
+          <IInputSuffixBase class={inputSuffixRecipe({ size: props.size })}>
+            <Slot name="suffix" />
+          </IInputSuffixBase>
+        </Show>
+      </IInputBase>
+    );
+  },
+);

--- a/ui/components/src/components/input/styled/__snapshots__/IInput.ink.test.ts.snap
+++ b/ui/components/src/components/input/styled/__snapshots__/IInput.ink.test.ts.snap
@@ -61,7 +61,7 @@ disabled = input<boolean>()
 readonly = input<boolean>()
 value = model<string>()
 }
-@Component({ standalone: true, selector: 'div[ink-input]', host: { '[class]': "'input' + ((shellClassName()) ? ' ' + (shellClassName()) : '') + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", 'ink-input-base': '' }, imports: [IInputPrefixBaseHostComponent, IInputTextareaBaseHostComponent, IInputControlBaseHostComponent, IInputSuffixBaseHostComponent], template: \`<span ink-input-prefix-base [klass]="(inputPrefixRecipe({ size: size() }))">
+@Component({ standalone: true, selector: 'div[ink-input]', host: { '[class]': "'input' + ((shellClassName()) ? ' ' + (shellClassName()) : '') + (klass() ? ' ' + klass() : '')", 'ink-input-base': '' }, imports: [IInputPrefixBaseHostComponent, IInputTextareaBaseHostComponent, IInputControlBaseHostComponent, IInputSuffixBaseHostComponent], template: \`<span ink-input-prefix-base [klass]="(inputPrefixRecipe({ size: size() }))">
 <ng-content select="[slot=prefix]"></ng-content>
 </span>
 @if (type() === 'textarea') {

--- a/ui/components/src/components/input/styled/__snapshots__/IInput.ink.test.ts.snap
+++ b/ui/components/src/components/input/styled/__snapshots__/IInput.ink.test.ts.snap
@@ -8,6 +8,11 @@ import { IInputPrefixBaseComponent as IInputPrefixBase } from "../headless/IInpu
 import { IInputSuffixBaseComponent as IInputSuffixBase } from "../headless/IInputSuffixBase.component";
 import { IInputControlBaseComponent as IInputControlBase } from "../headless/IInputControlBase.component";
 import { type InputControlBaseProps } from "../headless/IInputControlBase.component";
+import { IInputTextareaBaseComponent as IInputTextareaBase } from "../headless/IInputTextareaBase.component";
+import { IInputPrefixBaseHostComponent } from "../headless/IInputPrefixBase.component";
+import { IInputTextareaBaseHostComponent } from "../headless/IInputTextareaBase.component";
+import { IInputControlBaseHostComponent } from "../headless/IInputControlBase.component";
+import { IInputSuffixBaseHostComponent } from "../headless/IInputSuffixBase.component";
 import {
   inputRecipe,
   inputPrefixRecipe,
@@ -24,16 +29,50 @@ export interface InputProps extends InputControlBaseProps {
   /** Invalid-state styling. */
   invalid?: InputStylingProps["invalid"];
 }
-@Component({ standalone: true, selector: 'ink-input', host: { style: 'display: contents' }, imports: [IInputBase, IInputPrefixBase, IInputSuffixBase, IInputControlBase], template: \`<ink-input-base [klass]="(shellClassName()) + (klass() ? ' ' + klass() : '')">
+@Component({ standalone: true, selector: 'ink-input', host: { style: 'display: contents' }, imports: [IInputBase, IInputPrefixBase, IInputSuffixBase, IInputControlBase, IInputTextareaBase], template: \`<ink-input-base [klass]="(shellClassName()) + (klass() ? ' ' + klass() : '')">
 <ink-input-prefix-base [klass]="(inputPrefixRecipe({ size: size() }))">
 <ng-content select="[slot=prefix]"></ng-content>
 </ink-input-prefix-base>
+@if (type() === 'textarea') {
+<ink-input-textarea-base [id]="id()" [name]="name()" [value]="value()" [placeholder]="placeholder()" [disabled]="disabled()" [readonly]="readonly()" (valueChange)="value.set($event)"></ink-input-textarea-base>
+} @else {
 <ink-input-control-base [id]="id()" [name]="name()" [type]="type()" [value]="value()" [placeholder]="placeholder()" [disabled]="disabled()" [readonly]="readonly()" (valueChange)="value.set($event)"></ink-input-control-base>
+}
 <ink-input-suffix-base [klass]="(inputSuffixRecipe({ size: size() }))">
 <ng-content select="[slot=suffix]"></ng-content>
 </ink-input-suffix-base>
 </ink-input-base>\` })
 export class IInputComponent
+{
+inputRecipe = inputRecipe
+inputPrefixRecipe = inputPrefixRecipe
+inputSuffixRecipe = inputSuffixRecipe
+klass = input<string>()
+shellClassName = computed(() => inputRecipe({ color: this.color(), variant: this.variant(), size: this.size(), invalid: this.invalid(), disabled: this.disabled(), readonly: this.readonly() }))
+color = input<InputStylingProps["color"]>()
+variant = input<InputStylingProps["variant"]>()
+size = input<InputStylingProps["size"]>()
+invalid = input<InputStylingProps["invalid"]>()
+id = input<string>()
+name = input<string>()
+type = input<string>()
+placeholder = input<string>()
+disabled = input<boolean>()
+readonly = input<boolean>()
+value = model<string>()
+}
+@Component({ standalone: true, selector: 'div[ink-input]', host: { '[class]': "'input' + ((shellClassName()) ? ' ' + (shellClassName()) : '') + (klass() ? ' ' + klass() : '')", '[attr.id]': "(id()) ?? null", 'ink-input-base': '' }, imports: [IInputPrefixBaseHostComponent, IInputTextareaBaseHostComponent, IInputControlBaseHostComponent, IInputSuffixBaseHostComponent], template: \`<span ink-input-prefix-base [klass]="(inputPrefixRecipe({ size: size() }))">
+<ng-content select="[slot=prefix]"></ng-content>
+</span>
+@if (type() === 'textarea') {
+<textarea ink-input-textarea-base [id]="id()" [name]="name()" [value]="value()" [placeholder]="placeholder()" [disabled]="disabled()" [readonly]="readonly()" (valueChange)="value.set($event)"></textarea>
+} @else {
+<input ink-input-control-base [id]="id()" [name]="name()" [type]="type()" [value]="value()" [placeholder]="placeholder()" [disabled]="disabled()" [readonly]="readonly()" (valueChange)="value.set($event)" />
+}
+<span ink-input-suffix-base [klass]="(inputSuffixRecipe({ size: size() }))">
+<ng-content select="[slot=suffix]"></ng-content>
+</span>\` })
+export class IInputHostComponent
 {
 inputRecipe = inputRecipe
 inputPrefixRecipe = inputPrefixRecipe
@@ -58,6 +97,7 @@ import IInputBase from "../headless/IInputBase.astro";
 import IInputPrefixBase from "../headless/IInputPrefixBase.astro";
 import IInputSuffixBase from "../headless/IInputSuffixBase.astro";
 import IInputControlBase, { type InputControlBaseProps } from "../headless/IInputControlBase.astro";
+import IInputTextareaBase from "../headless/IInputTextareaBase.astro";
 import {
   inputRecipe,
   inputPrefixRecipe,
@@ -84,7 +124,7 @@ const shellClassName = inputRecipe({ color: color, variant: variant, size: size,
 {Astro.slots.has("prefix") ? (<IInputPrefixBase class={inputPrefixRecipe({ size: size })}>
 <slot name="prefix" />
 </IInputPrefixBase>) : null}
-<IInputControlBase id={id} name={name} type={type} value={value} placeholder={placeholder} disabled={disabled} readonly={readonly} />
+{type === "textarea" ? (<IInputTextareaBase id={id} name={name} value={value} placeholder={placeholder} disabled={disabled} readonly={readonly} />) : (<IInputControlBase id={id} name={name} type={type} value={value} placeholder={placeholder} disabled={disabled} readonly={readonly} />)}
 {Astro.slots.has("suffix") ? (<IInputSuffixBase class={inputSuffixRecipe({ size: size })}>
 <slot name="suffix" />
 </IInputSuffixBase>) : null}
@@ -96,6 +136,7 @@ import { IInputPrefixBase } from "../headless/IInputPrefixBase";
 import { IInputSuffixBase } from "../headless/IInputSuffixBase";
 import { IInputControlBase } from "../headless/IInputControlBase";
 import { type InputControlBaseProps } from "../headless/IInputControlBase";
+import { IInputTextareaBase } from "../headless/IInputTextareaBase";
 import {
   inputRecipe,
   inputPrefixRecipe,
@@ -120,7 +161,7 @@ return (
 <IInputBase {...__attrs} class={[shellClassName.value, props.class].filter(Boolean).join(" ")}>
   <>
     {(<><IInputPrefixBase class={inputPrefixRecipe({ size: props.size })}>{props.prefix}</IInputPrefixBase></>)}
-    <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue$={$(v => props.onUpdateValue$?.(v))} />
+    {props.type === "textarea" ? (<><IInputTextareaBase id={props.id} name={props.name} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue$={$(v => props.onUpdateValue$?.(v))} /></>) : (<><IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue$={$(v => props.onUpdateValue$?.(v))} /></>)}
     {(<><IInputSuffixBase class={inputSuffixRecipe({ size: props.size })}>{props.suffix}</IInputSuffixBase></>)}
   </>
 </IInputBase>
@@ -133,6 +174,7 @@ import { IInputPrefixBase } from "../headless/IInputPrefixBase";
 import { IInputSuffixBase } from "../headless/IInputSuffixBase";
 import { IInputControlBase } from "../headless/IInputControlBase";
 import { type InputControlBaseProps } from "../headless/IInputControlBase";
+import { IInputTextareaBase } from "../headless/IInputTextareaBase";
 import {
   inputRecipe,
   inputPrefixRecipe,
@@ -157,7 +199,7 @@ return (
 <IInputBase {...__attrs} className={[shellClassName, props.className].filter(Boolean).join(" ")}>
   <>
     {(props.prefix != null) ? <IInputPrefixBase className={inputPrefixRecipe({ size: props.size })}>{props.prefix}</IInputPrefixBase> : null}
-    <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} />
+    {props.type === "textarea" ? <IInputTextareaBase id={props.id} name={props.name} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} /> : <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readOnly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} />}
     {(props.suffix != null) ? <IInputSuffixBase className={inputSuffixRecipe({ size: props.size })}>{props.suffix}</IInputSuffixBase> : null}
   </>
 </IInputBase>
@@ -170,6 +212,7 @@ import IInputBase from "../headless/IInputBase";
 import IInputPrefixBase from "../headless/IInputPrefixBase";
 import IInputSuffixBase from "../headless/IInputSuffixBase";
 import IInputControlBase, { type InputControlBaseProps } from "../headless/IInputControlBase";
+import IInputTextareaBase from "../headless/IInputTextareaBase";
 import {
   inputRecipe,
   inputPrefixRecipe,
@@ -198,7 +241,9 @@ return (
         {props.prefix}
       </IInputPrefixBase>
     </Show>
-    <IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} />
+    <Show when={props.type === "textarea"} fallback={<><IInputControlBase id={props.id} name={props.name} type={props.type} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} /></>}>
+      <IInputTextareaBase id={props.id} name={props.name} value={props.value} placeholder={props.placeholder} disabled={props.disabled} readonly={props.readonly} onUpdateValue={v => props.onUpdateValue?.(v)} />
+    </Show>
     <Show when={(props.suffix != null)}>
       <IInputSuffixBase class={inputSuffixRecipe({ size: props.size })}>
         {props.suffix}
@@ -214,6 +259,7 @@ return (
   import IInputPrefixBase from "../headless/IInputPrefixBase.svelte";
   import IInputSuffixBase from "../headless/IInputSuffixBase.svelte";
   import IInputControlBase, { type InputControlBaseProps } from "../headless/IInputControlBase.svelte";
+  import IInputTextareaBase from "../headless/IInputTextareaBase.svelte";
   import {
     inputRecipe,
     inputPrefixRecipe,
@@ -238,8 +284,9 @@ return (
   {#if (prefixSnippet != null)}<IInputPrefixBase class={inputPrefixRecipe({ size: size })}>
     {@render prefixSnippet?.()}
   </IInputPrefixBase>
-  {/if}<IInputControlBase bind:value={value} id={id} name={name} type={type} placeholder={placeholder} disabled={disabled} readonly={readonly} />
-  {#if (suffixSnippet != null)}<IInputSuffixBase class={inputSuffixRecipe({ size: size })}>
+  {/if}{#if type === "textarea"}<IInputTextareaBase bind:value={value} id={id} name={name} placeholder={placeholder} disabled={disabled} readonly={readonly} />
+  {:else}<IInputControlBase bind:value={value} id={id} name={name} type={type} placeholder={placeholder} disabled={disabled} readonly={readonly} />
+  {/if}{#if (suffixSnippet != null)}<IInputSuffixBase class={inputSuffixRecipe({ size: size })}>
     {@render suffixSnippet?.()}
   </IInputSuffixBase>
   {/if}
@@ -251,6 +298,7 @@ return (
   import IInputPrefixBase from "../headless/IInputPrefixBase.vue";
   import IInputSuffixBase from "../headless/IInputSuffixBase.vue";
   import IInputControlBase, { type InputControlBaseProps } from "../headless/IInputControlBase.vue";
+  import IInputTextareaBase from "../headless/IInputTextareaBase.vue";
   import {
     inputRecipe,
     inputPrefixRecipe,
@@ -276,7 +324,8 @@ return (
   <IInputPrefixBase v-if="!!$slots.prefix" :class="inputPrefixRecipe({ size: size })">
     <slot name="prefix" />
   </IInputPrefixBase>
-  <IInputControlBase v-model:value="value" :id="id" :name="name" :type="type" :placeholder="placeholder" :disabled="disabled" :readonly="readonly" />
+  <IInputTextareaBase v-if='type === "textarea"' v-model:value="value" :id="id" :name="name" :placeholder="placeholder" :disabled="disabled" :readonly="readonly" />
+  <IInputControlBase v-else v-model:value="value" :id="id" :name="name" :type="type" :placeholder="placeholder" :disabled="disabled" :readonly="readonly" />
   <IInputSuffixBase v-if="!!$slots.suffix" :class="inputSuffixRecipe({ size: size })">
     <slot name="suffix" />
   </IInputSuffixBase>


### PR DESCRIPTION
## Summary

Introduces `meta.headless` + Angular attribute-selector host-extraction in the compiler, then applies a series of collapse passes that emit styled components as zero-wrapper Angular components (the headless host becomes the styled host). Covers Badge, Button, FieldGroup, HamburgerMenu, and the full Input family (IInput, IInputControl, IInputPrefix, IInputSuffix, IInputTextarea).

## Related issues

- Closes #

## Type of change

- [x] `feat` — new user-facing capability or public API

## Test plan

- [x] `vp run ready` passes locally
- [x] Angular headless unit tests added (`headless.test.ts`) covering all collapse paths
- [x] Component snapshot tests updated for all 7 affected headless + styled components
- [x] Collapse fixture suite added to compiler (`CollapseBase`, `CollapseNested`, `CollapseModelBase`, `CollapseStyled`, …)

## Checklist

- [x] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".