### PR TITLE
chore: rename skills from component-action to action-component pattern

### DIFF
--- a/.claude/skills/create-component/SKILL.md
+++ b/.claude/skills/create-component/SKILL.md
@@ -23,7 +23,7 @@ allowed-tools:
 
 Take a component from idea to release-ready across all 7 Inkline frameworks. This skill **orchestrates** five focused phase skills; it does not duplicate their detail. For each phase you **Read that phase's `SKILL.md` and execute its steps at full depth**, then stop at the gate.
 
-Each phase skill is also invocable on its own (e.g. `/component-stories` to add stories to an existing component). This orchestrator is for building a new one start-to-finish.
+Each phase skill is also invocable on its own (e.g. `/stories-component` to add stories to an existing component). This orchestrator is for building a new one start-to-finish.
 
 ## Working agreement (applies to every phase)
 
@@ -38,11 +38,11 @@ Each phase skill is also invocable on its own (e.g. `/component-stories` to add 
 
 | #   | Phase     | Skill file                                    | Output                                        | Commit on pass                          |
 | --- | --------- | --------------------------------------------- | --------------------------------------------- | --------------------------------------- |
-| 1   | Research  | `.claude/skills/component-research/SKILL.md`  | `.context/component-<name>-spec.md`           | — (spec is gitignored)                  |
-| 2   | Implement | `.claude/skills/component-implement/SKILL.md` | headless + styled + `.styleframe.ts` + export | `feat(components): add I<Name>`         |
-| 3   | Stories   | `.claude/skills/component-stories/SKILL.md`   | `defineStories` meta + render helpers         | `feat(components): add I<Name> stories` |
-| 4   | Test      | `.claude/skills/component-test/SKILL.md`      | colocated `.ink.test.ts` (+ Angular SSR)      | `test(components): cover I<Name>`       |
-| 5   | Document  | `.claude/skills/component-document/SKILL.md`  | TSDoc pass + changeset + freshness            | `docs(components): document I<Name>`    |
+| 1   | Research  | `.claude/skills/research-component/SKILL.md`  | `.context/component-<name>-spec.md`           | — (spec is gitignored)                  |
+| 2   | Implement | `.claude/skills/implement-component/SKILL.md` | headless + styled + `.styleframe.ts` + export | `feat(components): add I<Name>`         |
+| 3   | Stories   | `.claude/skills/stories-component/SKILL.md`   | `defineStories` meta + render helpers         | `feat(components): add I<Name> stories` |
+| 4   | Test      | `.claude/skills/test-component/SKILL.md`      | colocated `.ink.test.ts` (+ Angular SSR)      | `test(components): cover I<Name>`       |
+| 5   | Document  | `.claude/skills/document-component/SKILL.md`  | TSDoc pass + changeset + freshness            | `docs(components): document I<Name>`    |
 
 Shared reference (each phase skill points into these; read them when a phase tells you to):
 `create-component/reference/{conventions,primitives,verification}.md`.

--- a/.claude/skills/create-component/reference/primitives.md
+++ b/.claude/skills/create-component/reference/primitives.md
@@ -36,7 +36,7 @@ Everything here is **authoring-time only** — the compiler removes it from emit
 - **Astro is static SSR** — two-way binding (`defineModel` / `$bind`) lowers to a one-way value and emits the info notice **`INK0045`** (one per two-way binding). This is expected, not an error.
 - **Qwik & Angular have no runtime slot-presence API** — `hasSlot("x")` is `true` there, so a `<Show when={hasSlot("x")}>` wrapper is emitted unconditionally and must be collapsed with a CSS `:empty` rule in the `.styleframe.ts`. The compiler emits the info notice **`INK0068`** once per such target (so a single gated component → **2** `INK0068` notices: Qwik + Angular).
 
-These three notices (`INK0045`, `INK0068`) are **expected** for components that use two-way binding or `hasSlot` gating. Tests assert them explicitly rather than treating them as failures (see the `component-test` skill).
+These three notices (`INK0045`, `INK0068`) are **expected** for components that use two-way binding or `hasSlot` gating. Tests assert them explicitly rather than treating them as failures (see the `test-component` skill).
 
 ## How bindings & slots lower per target (useful for test assertions)
 

--- a/.claude/skills/document-component/SKILL.md
+++ b/.claude/skills/document-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: component-document
+name: document-component
 description: Phase 5 of building an Inkline component — finalize docs and the release. Complete TSDoc on the prop interfaces, add a changeset for the affected framework packages, confirm exports/freshness, and stage the future docs-site page (the docs website is not built yet — TBD). Use when wrapping up a component for release.
 triggers:
   - document a component

--- a/.claude/skills/implement-component/SKILL.md
+++ b/.claude/skills/implement-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: component-implement
+name: implement-component
 description: Phase 2 of building an Inkline component — write the .ink.tsx source. Author the headless part(s) (behavior + accessibility, no styling), then one styled component that composes them and applies a styleframe recipe, then the .styleframe.ts, then register the export. Compiles to all 7 frameworks. Use when implementing a component from a spec, or adding/fixing component source.
 triggers:
   - implement a component
@@ -20,7 +20,7 @@ Author the `.ink.tsx` source so it compiles cleanly to all 7 targets. Mirror the
 
 ## Read first
 
-1. The spec at `.context/component-<name>-spec.md` (from `component-research`). If it's missing and you're working standalone, read the existing source and infer the contract before changing it.
+1. The spec at `.context/component-<name>-spec.md` (from `research-component`). If it's missing and you're working standalone, read the existing source and infer the contract before changing it.
 2. `.claude/skills/create-component/reference/conventions.md` and `.../reference/primitives.md` — the split, the fallthrough rule, the primitives, and the **per-target gotchas**.
 3. The matching exemplar source: `badge/` (single part), `button/` (stateful + custom styles), `input/` (multi-part family with slots + two-way).
 
@@ -155,4 +155,4 @@ export { default as IBadgeBase } from "./badge/headless/IBadgeBase.ink.tsx";
 
 ## Exit criteria
 
-`pnpm build` is clean (only expected notices), the export is registered, every prop has TSDoc, and the source mirrors the exemplar's structure. Hand off to `component-stories` and `component-test`.
+`pnpm build` is clean (only expected notices), the export is registered, every prop has TSDoc, and the source mirrors the exemplar's structure. Hand off to `stories-component` and `test-component`.

--- a/.claude/skills/research-component/SKILL.md
+++ b/.claude/skills/research-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: component-research
+name: research-component
 description: Phase 1 of building an Inkline component — design the API. Survey the WAI-ARIA pattern and prior art, then write a complete component spec (props, slots, events, variants, accessibility, styling plan) to .context/ for sign-off before any code. Use when starting a new component or redesigning an existing one's API.
 triggers:
   - research a component
@@ -18,7 +18,7 @@ allowed-tools:
 
 # Component research — design the API before any code
 
-The goal of this phase is a **spec good enough that implementation is mechanical**. A great component is decided here: the right anatomy, the best prop names, the exact accessibility contract. Produce a written spec, get it signed off, then hand it to `component-implement`.
+The goal of this phase is a **spec good enough that implementation is mechanical**. A great component is decided here: the right anatomy, the best prop names, the exact accessibility contract. Produce a written spec, get it signed off, then hand it to `implement-component`.
 
 ## Read first
 

--- a/.claude/skills/stories-component/SKILL.md
+++ b/.claude/skills/stories-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: component-stories
+name: stories-component
 description: Phase 3 of building an Inkline component — author single-source Storybook stories. Write a defineStories meta with typed args/argTypes and per-variant render helpers as .ink.tsx; these compile to CSF3 for all 7 frameworks. Use when adding or improving the stories for a component.
 triggers:
   - add stories for a component

--- a/.claude/skills/test-component/SKILL.md
+++ b/.claude/skills/test-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: component-test
+name: test-component
 description: Phase 4 of building an Inkline component — write colocated cross-target tests. Assert compilation to all 7 targets, expected diagnostics, conformance, output composition/imports/bindings, snapshots, and real-DOM behavior via Angular SSR. Targets ~100% line+branch coverage. Use when adding or strengthening a component's tests.
 triggers:
   - test a component


### PR DESCRIPTION
## Summary

Renames the five component-phase skills from `component-<phase>` to `<phase>-component` (e.g. `component-research` → `research-component`) to match the invocation pattern used in the codebase. Updates references in `create-component/SKILL.md` and `primitives.md` to point to the new paths.

## Related issues

- Closes #

## Type of change

- [x] `chore` / `ci` — tooling, dependencies, or CI

## Test plan

- [ ] `vp run ready` passes locally
- [ ] Skill invocations (`/research-component`, `/implement-component`, etc.) resolve correctly

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [x] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".