### PR TITLE
feat(components): add ICallout component

### DIFF
--- a/.changeset/add-callout.md
+++ b/.changeset/add-callout.md
@@ -1,0 +1,25 @@
+---
+"@inkline/react": minor
+"@inkline/vue": minor
+"@inkline/svelte": minor
+"@inkline/solid": minor
+"@inkline/angular": minor
+"@inkline/qwik": minor
+"@inkline/astro": minor
+---
+
+feat(components): add Callout component
+
+Add `ICallout` (and its headless parts `ICalloutBase`, `ICalloutIconBase`, `ICalloutContentBase`,
+`ICalloutDismissBase`), a contextual feedback message styled with the Styleframe `callout` recipe.
+It renders a `role="note"` container (override via `role` for `alert`/`status` messages) and composes
+an optional leading `icon` slot, the content (`label` prop or default slot), and an optional dismiss
+button. Supports `color` (`primary` / `secondary` / `success` / `info` / `warning` / `error` /
+`light` / `dark` / `neutral`), `variant` (`solid` / `outline` / `soft` / `subtle`), `size`
+(`sm` / `md` / `lg`), and `orientation` (`horizontal` / `vertical`).
+
+Set `dismissible` to render an accessible close button (defaulted `dismissAriaLabel` of `"Dismiss"`,
+overridable, plus a `dismiss` slot for custom content). Visibility is two-way bindable via the
+`visible` model; when unbound, clicking dismiss hides the callout internally while keeping it mounted.
+
+The public docs-site page is pending the docs website implementation.

--- a/ui/components/src/components/callout/headless/ICalloutBase.ink.test.ts
+++ b/ui/components/src/components/callout/headless/ICalloutBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const CALLOUT_BASE = resolveComponent(import.meta.url, "./ICalloutBase.ink.tsx");
+
+describe("CalloutBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(CALLOUT_BASE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(CALLOUT_BASE));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(CALLOUT_BASE));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(CALLOUT_BASE));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(CALLOUT_BASE))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/callout/headless/ICalloutBase.ink.tsx
+++ b/ui/components/src/components/callout/headless/ICalloutBase.ink.tsx
@@ -3,13 +3,15 @@ import { defineComponent, Slot } from "@inkline/core";
 export interface CalloutBaseProps {
   /** ARIA role of the container; override with `"alert"`/`"status"` for dynamically-inserted messages. */
   role?: string;
+  /** Hides the container (kept mounted) — mirrors the native `hidden` attribute. */
+  hidden?: boolean;
 }
 
 export default defineComponent(
   { meta: { headless: true }, slots: { default: {} } },
   (props: CalloutBaseProps) => {
     return (
-      <div class="callout" role={props.role ?? "note"}>
+      <div class="callout" role={props.role ?? "note"} hidden={props.hidden}>
         <Slot />
       </div>
     );

--- a/ui/components/src/components/callout/headless/ICalloutBase.ink.tsx
+++ b/ui/components/src/components/callout/headless/ICalloutBase.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface CalloutBaseProps {
+  /** ARIA role of the container; override with `"alert"`/`"status"` for dynamically-inserted messages. */
+  role?: string;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CalloutBaseProps) => {
+    return (
+      <div class="callout" role={props.role ?? "note"}>
+        <Slot />
+      </div>
+    );
+  },
+);

--- a/ui/components/src/components/callout/headless/ICalloutContentBase.ink.test.ts
+++ b/ui/components/src/components/callout/headless/ICalloutContentBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const CALLOUT_CONTENT = resolveComponent(import.meta.url, "./ICalloutContentBase.ink.tsx");
+
+describe("CalloutContentBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(CALLOUT_CONTENT);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(CALLOUT_CONTENT));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(CALLOUT_CONTENT));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(CALLOUT_CONTENT));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(CALLOUT_CONTENT))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/callout/headless/ICalloutContentBase.ink.tsx
+++ b/ui/components/src/components/callout/headless/ICalloutContentBase.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface CalloutContentBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CalloutContentBaseProps) => {
+    return (
+      <div class="callout-content">
+        <Slot>{props.label}</Slot>
+      </div>
+    );
+  },
+);

--- a/ui/components/src/components/callout/headless/ICalloutDismissBase.ink.test.ts
+++ b/ui/components/src/components/callout/headless/ICalloutDismissBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const CALLOUT_DISMISS = resolveComponent(import.meta.url, "./ICalloutDismissBase.ink.tsx");
+
+describe("CalloutDismissBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(CALLOUT_DISMISS);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(CALLOUT_DISMISS));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(CALLOUT_DISMISS));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(CALLOUT_DISMISS));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(CALLOUT_DISMISS))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/callout/headless/ICalloutDismissBase.ink.tsx
+++ b/ui/components/src/components/callout/headless/ICalloutDismissBase.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface CalloutDismissBaseProps {
+  /** Accessible name for the icon-only dismiss button; sets `aria-label`. */
+  ariaLabel?: string;
+}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: CalloutDismissBaseProps) => {
+    return (
+      <button class="callout-dismiss" type="button" aria-label={props.ariaLabel ?? "Dismiss"}>
+        <Slot />
+      </button>
+    );
+  },
+);

--- a/ui/components/src/components/callout/headless/ICalloutIconBase.ink.test.ts
+++ b/ui/components/src/components/callout/headless/ICalloutIconBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const CALLOUT_ICON = resolveComponent(import.meta.url, "./ICalloutIconBase.ink.tsx");
+
+describe("CalloutIconBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(CALLOUT_ICON);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(CALLOUT_ICON));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(CALLOUT_ICON));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(CALLOUT_ICON));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(CALLOUT_ICON))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/callout/headless/ICalloutIconBase.ink.tsx
+++ b/ui/components/src/components/callout/headless/ICalloutIconBase.ink.tsx
@@ -1,0 +1,14 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface CalloutIconBaseProps {}
+
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: CalloutIconBaseProps) => {
+    return (
+      <span class="callout-icon" aria-hidden="true">
+        <Slot />
+      </span>
+    );
+  },
+);

--- a/ui/components/src/components/callout/headless/__snapshots__/ICalloutBase.ink.test.ts.snap
+++ b/ui/components/src/components/callout/headless/__snapshots__/ICalloutBase.ink.test.ts.snap
@@ -1,0 +1,125 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalloutBase > output matches snapshots 1`] = `
+{
+  "angular/ICalloutBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface CalloutBaseProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: string;
+  /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+  hidden?: boolean;
+}
+@Component({ standalone: true, selector: 'ink-callout-base', host: { style: 'display: contents' }, template: \`<div [class]="'callout' + (klass() ? ' ' + klass() : '')" [attr.role]="(role() ?? 'note') ?? null" [hidden]="hidden()">
+<ng-content></ng-content>
+</div>\` })
+export class ICalloutBaseComponent
+{
+klass = input<string>()
+role = input<string>()
+hidden = input<boolean>()
+}
+@Component({ standalone: true, selector: 'div[ink-callout-base]', host: { '[class]': "'callout' + (klass() ? ' ' + klass() : '')", '[attr.role]': "(role() ?? 'note') ?? null", '[hidden]': "hidden()" }, template: \`<ng-content></ng-content>\` })
+export class ICalloutBaseHostComponent
+{
+klass = input<string>()
+role = input<string>()
+hidden = input<boolean>()
+}
+",
+  "astro/ICalloutBase.astro": "---
+export interface CalloutBaseProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: string;
+  /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+  hidden?: boolean;
+}
+type Props = CalloutBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { role, hidden, ...__attrs } = props;
+---
+<div {...__attrs} class={["callout", __attrs.class].filter(Boolean).join(" ")} role={role ?? "note"} hidden={hidden}>
+<slot />
+</div>
+",
+  "qwik/ICalloutBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface CalloutBaseProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: string;
+  /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+  hidden?: boolean;
+}
+export const ICalloutBase = component$((props: CalloutBaseProps & Record<string, any>) =>
+{
+const { children, role, hidden, ...__attrs } = props
+return (
+<div {...__attrs} class={["callout", props.class].filter(Boolean).join(" ")} role={props.role ?? "note"} hidden={props.hidden}>
+  <Slot />
+</div>
+)
+});
+",
+  "react/ICalloutBase.tsx": "export interface CalloutBaseProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: string;
+  /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+  hidden?: boolean;
+}
+export function ICalloutBase(props: CalloutBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, role, hidden, ...__attrs } = props
+return (
+<div {...__attrs} className={["callout", props.className].filter(Boolean).join(" ")} role={props.role ?? "note"} hidden={props.hidden}>
+  {props.children}
+</div>
+)
+}
+",
+  "solid/ICalloutBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface CalloutBaseProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: string;
+  /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+  hidden?: boolean;
+}
+export default function ICalloutBase(props: CalloutBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children", "role", "hidden"])
+return (
+<div {...__attrs} class={["callout", props.class].filter(Boolean).join(" ")} role={props.role ?? "note"} hidden={props.hidden}>
+  {props.children}
+</div>
+)
+}
+",
+  "svelte/ICalloutBase.svelte": "<script lang="ts">
+  export interface CalloutBaseProps {
+    /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+    role?: string;
+    /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+    hidden?: boolean;
+  }
+  import type { Snippet } from "svelte";
+  let { role, hidden, children, ...__attrs }: CalloutBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<div {...__attrs} class={["callout", __attrs.class].filter(Boolean).join(" ")} role={role ?? "note"} hidden={hidden}>
+  {@render children?.()}
+</div>
+",
+  "vue/ICalloutBase.vue": "<script setup lang="ts">
+  export interface CalloutBaseProps {
+    /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+    role?: string;
+    /** Hides the container (kept mounted) — mirrors the native \`hidden\` attribute. */
+    hidden?: boolean;
+  }
+  const props = defineProps<CalloutBaseProps>()
+</script>
+<template>
+<div class="callout" :role='role ?? "note"' :hidden="hidden">
+  <slot />
+</div>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/callout/headless/__snapshots__/ICalloutContentBase.ink.test.ts.snap
+++ b/ui/components/src/components/callout/headless/__snapshots__/ICalloutContentBase.ink.test.ts.snap
@@ -1,0 +1,115 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalloutContentBase > output matches snapshots 1`] = `
+{
+  "angular/ICalloutContentBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface CalloutContentBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+@Component({ standalone: true, selector: 'ink-callout-content-base', host: { style: 'display: contents' }, template: \`<div [class]="'callout-content' + (klass() ? ' ' + klass() : '')">
+<ng-content>{{ label() }}</ng-content>
+</div>\` })
+export class ICalloutContentBaseComponent
+{
+klass = input<string>()
+label = input<string>()
+}
+@Component({ standalone: true, selector: 'div[ink-callout-content-base]', host: { '[class]': "'callout-content' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content>{{ label() }}</ng-content>\` })
+export class ICalloutContentBaseHostComponent
+{
+klass = input<string>()
+label = input<string>()
+}
+",
+  "astro/ICalloutContentBase.astro": "---
+export interface CalloutContentBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+type Props = CalloutContentBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { label, ...__attrs } = props;
+---
+<div {...__attrs} class={["callout-content", __attrs.class].filter(Boolean).join(" ")}>
+<slot>
+{label}
+</slot>
+</div>
+",
+  "qwik/ICalloutContentBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface CalloutContentBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+export const ICalloutContentBase = component$((props: CalloutContentBaseProps & Record<string, any>) =>
+{
+const { children, label, ...__attrs } = props
+return (
+<div {...__attrs} class={["callout-content", props.class].filter(Boolean).join(" ")}>
+  <Slot>
+    {props.label}
+  </Slot>
+</div>
+)
+});
+",
+  "react/ICalloutContentBase.tsx": "export interface CalloutContentBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+export function ICalloutContentBase(props: CalloutContentBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, label, ...__attrs } = props
+return (
+<div {...__attrs} className={["callout-content", props.className].filter(Boolean).join(" ")}>
+  {props.children ?? props.label}
+</div>
+)
+}
+",
+  "solid/ICalloutContentBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface CalloutContentBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+}
+export default function ICalloutContentBase(props: CalloutContentBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children", "label"])
+return (
+<div {...__attrs} class={["callout-content", props.class].filter(Boolean).join(" ")}>
+  {props.children ?? props.label}
+</div>
+)
+}
+",
+  "svelte/ICalloutContentBase.svelte": "<script lang="ts">
+  export interface CalloutContentBaseProps {
+    /** Text content; overridden by the default slot. */
+    label?: string;
+  }
+  import type { Snippet } from "svelte";
+  let { label, children, ...__attrs }: CalloutContentBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<div {...__attrs} class={["callout-content", __attrs.class].filter(Boolean).join(" ")}>
+  {#if children}{@render children()}{:else}{label}{/if}
+</div>
+",
+  "vue/ICalloutContentBase.vue": "<script setup lang="ts">
+  export interface CalloutContentBaseProps {
+    /** Text content; overridden by the default slot. */
+    label?: string;
+  }
+  const props = defineProps<CalloutContentBaseProps>()
+</script>
+<template>
+<div class="callout-content">
+  <slot>
+    {{ label }}
+  </slot>
+</div>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/callout/headless/__snapshots__/ICalloutDismissBase.ink.test.ts.snap
+++ b/ui/components/src/components/callout/headless/__snapshots__/ICalloutDismissBase.ink.test.ts.snap
@@ -1,0 +1,109 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalloutDismissBase > output matches snapshots 1`] = `
+{
+  "angular/ICalloutDismissBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface CalloutDismissBaseProps {
+  /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+  ariaLabel?: string;
+}
+@Component({ standalone: true, selector: 'ink-callout-dismiss-base', host: { style: 'display: contents' }, template: \`<button [class]="'callout-dismiss' + (klass() ? ' ' + klass() : '')" type="button" [attr.aria-label]="(ariaLabel() ?? 'Dismiss') ?? null">
+<ng-content></ng-content>
+</button>\` })
+export class ICalloutDismissBaseComponent
+{
+klass = input<string>()
+ariaLabel = input<string>()
+}
+@Component({ standalone: true, selector: 'button[ink-callout-dismiss-base]', host: { '[class]': "'callout-dismiss' + (klass() ? ' ' + klass() : '')", 'type': 'button', '[attr.aria-label]': "(ariaLabel() ?? 'Dismiss') ?? null" }, template: \`<ng-content></ng-content>\` })
+export class ICalloutDismissBaseHostComponent
+{
+klass = input<string>()
+ariaLabel = input<string>()
+}
+",
+  "astro/ICalloutDismissBase.astro": "---
+export interface CalloutDismissBaseProps {
+  /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+  ariaLabel?: string;
+}
+type Props = CalloutDismissBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ariaLabel, ...__attrs } = props;
+---
+<button {...__attrs} class={["callout-dismiss", __attrs.class].filter(Boolean).join(" ")} type="button" aria-label={ariaLabel ?? "Dismiss"}>
+<slot />
+</button>
+",
+  "qwik/ICalloutDismissBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface CalloutDismissBaseProps {
+  /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+  ariaLabel?: string;
+}
+export const ICalloutDismissBase = component$((props: CalloutDismissBaseProps & Record<string, any>) =>
+{
+const { children, ariaLabel, ...__attrs } = props
+return (
+<button {...__attrs} class={["callout-dismiss", props.class].filter(Boolean).join(" ")} type="button" aria-label={props.ariaLabel ?? "Dismiss"}>
+  <Slot />
+</button>
+)
+});
+",
+  "react/ICalloutDismissBase.tsx": "export interface CalloutDismissBaseProps {
+  /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+  ariaLabel?: string;
+}
+export function ICalloutDismissBase(props: CalloutDismissBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, ariaLabel, ...__attrs } = props
+return (
+<button {...__attrs} className={["callout-dismiss", props.className].filter(Boolean).join(" ")} type="button" aria-label={props.ariaLabel ?? "Dismiss"}>
+  {props.children}
+</button>
+)
+}
+",
+  "solid/ICalloutDismissBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface CalloutDismissBaseProps {
+  /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+  ariaLabel?: string;
+}
+export default function ICalloutDismissBase(props: CalloutDismissBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children", "ariaLabel"])
+return (
+<button {...__attrs} class={["callout-dismiss", props.class].filter(Boolean).join(" ")} type="button" aria-label={props.ariaLabel ?? "Dismiss"}>
+  {props.children}
+</button>
+)
+}
+",
+  "svelte/ICalloutDismissBase.svelte": "<script lang="ts">
+  export interface CalloutDismissBaseProps {
+    /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+    ariaLabel?: string;
+  }
+  import type { Snippet } from "svelte";
+  let { ariaLabel, children, ...__attrs }: CalloutDismissBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<button {...__attrs} class={["callout-dismiss", __attrs.class].filter(Boolean).join(" ")} type="button" aria-label={ariaLabel ?? "Dismiss"}>
+  {@render children?.()}
+</button>
+",
+  "vue/ICalloutDismissBase.vue": "<script setup lang="ts">
+  export interface CalloutDismissBaseProps {
+    /** Accessible name for the icon-only dismiss button; sets \`aria-label\`. */
+    ariaLabel?: string;
+  }
+  const props = defineProps<CalloutDismissBaseProps>()
+</script>
+<template>
+<button class="callout-dismiss" type="button" :aria-label='ariaLabel ?? "Dismiss"'>
+  <slot />
+</button>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/callout/headless/__snapshots__/ICalloutIconBase.ink.test.ts.snap
+++ b/ui/components/src/components/callout/headless/__snapshots__/ICalloutIconBase.ink.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CalloutIconBase > output matches snapshots 1`] = `
+{
+  "angular/ICalloutIconBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface CalloutIconBaseProps {}
+@Component({ standalone: true, selector: 'ink-callout-icon-base', host: { style: 'display: contents' }, template: \`<span [class]="'callout-icon' + (klass() ? ' ' + klass() : '')" aria-hidden="true">
+<ng-content></ng-content>
+</span>\` })
+export class ICalloutIconBaseComponent
+{
+klass = input<string>()
+}
+@Component({ standalone: true, selector: 'span[ink-callout-icon-base]', host: { '[class]': "'callout-icon' + (klass() ? ' ' + klass() : '')", 'aria-hidden': 'true' }, template: \`<ng-content></ng-content>\` })
+export class ICalloutIconBaseHostComponent
+{
+klass = input<string>()
+}
+",
+  "astro/ICalloutIconBase.astro": "---
+export interface CalloutIconBaseProps {}
+type Props = CalloutIconBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+---
+<span {...__attrs} class={["callout-icon", __attrs.class].filter(Boolean).join(" ")} aria-hidden="true">
+<slot />
+</span>
+",
+  "qwik/ICalloutIconBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface CalloutIconBaseProps {}
+export const ICalloutIconBase = component$((props) =>
+{
+const { children, ...__attrs } = props
+return (
+<span {...__attrs} class={["callout-icon", props.class].filter(Boolean).join(" ")} aria-hidden="true">
+  <Slot />
+</span>
+)
+});
+",
+  "react/ICalloutIconBase.tsx": "export interface CalloutIconBaseProps {}
+export function ICalloutIconBase(props: CalloutIconBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, ...__attrs } = props
+return (
+<span {...__attrs} className={["callout-icon", props.className].filter(Boolean).join(" ")} aria-hidden="true">
+  {props.children}
+</span>
+)
+}
+",
+  "solid/ICalloutIconBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface CalloutIconBaseProps {}
+export default function ICalloutIconBase(props: CalloutIconBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children"])
+return (
+<span {...__attrs} class={["callout-icon", props.class].filter(Boolean).join(" ")} aria-hidden="true">
+  {props.children}
+</span>
+)
+}
+",
+  "svelte/ICalloutIconBase.svelte": "<script lang="ts">
+  export interface CalloutIconBaseProps {}
+  import type { Snippet } from "svelte";
+  let { children, ...__attrs }: CalloutIconBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<span {...__attrs} class={["callout-icon", __attrs.class].filter(Boolean).join(" ")} aria-hidden="true">
+  {@render children?.()}
+</span>
+",
+  "vue/ICalloutIconBase.vue": "<script setup lang="ts">
+  export interface CalloutIconBaseProps {}
+  const props = defineProps<CalloutIconBaseProps>()
+</script>
+<template>
+<span class="callout-icon" aria-hidden="true">
+  <slot />
+</span>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/callout/stories/CalloutColors.ink.tsx
+++ b/ui/components/src/components/callout/stories/CalloutColors.ink.tsx
@@ -1,0 +1,18 @@
+import { defineComponent } from "@inkline/core";
+import ICallout from "../styled/ICallout.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ICallout color="primary" label="Primary" />
+      <ICallout color="secondary" label="Secondary" />
+      <ICallout color="success" label="Success" />
+      <ICallout color="info" label="Info" />
+      <ICallout color="warning" label="Warning" />
+      <ICallout color="error" label="Error" />
+      <ICallout color="light" label="Light" />
+      <ICallout color="dark" label="Dark" />
+      <ICallout color="neutral" label="Neutral" />
+    </div>
+  );
+});

--- a/ui/components/src/components/callout/stories/CalloutOrientation.ink.tsx
+++ b/ui/components/src/components/callout/stories/CalloutOrientation.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+import ICallout from "../styled/ICallout.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ICallout color="info" orientation="horizontal" icon={<>ℹ</>} label="Horizontal" />
+      <ICallout color="info" orientation="vertical" icon={<>ℹ</>} label="Vertical" />
+    </div>
+  );
+});

--- a/ui/components/src/components/callout/stories/CalloutSizes.ink.tsx
+++ b/ui/components/src/components/callout/stories/CalloutSizes.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent } from "@inkline/core";
+import ICallout from "../styled/ICallout.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ICallout size="sm" label="Small" />
+      <ICallout size="md" label="Medium" />
+      <ICallout size="lg" label="Large" />
+    </div>
+  );
+});

--- a/ui/components/src/components/callout/stories/CalloutVariants.ink.tsx
+++ b/ui/components/src/components/callout/stories/CalloutVariants.ink.tsx
@@ -1,0 +1,13 @@
+import { defineComponent } from "@inkline/core";
+import ICallout from "../styled/ICallout.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ICallout color="info" variant="solid" label="Solid" />
+      <ICallout color="info" variant="outline" label="Outline" />
+      <ICallout color="info" variant="soft" label="Soft" />
+      <ICallout color="info" variant="subtle" label="Subtle" />
+    </div>
+  );
+});

--- a/ui/components/src/components/callout/stories/CalloutWithIcon.ink.tsx
+++ b/ui/components/src/components/callout/stories/CalloutWithIcon.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent } from "@inkline/core";
+import ICallout from "../styled/ICallout.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ICallout color="success" icon={<>✓</>} label="Changes saved successfully." />
+      <ICallout color="warning" icon={<>⚠</>} label="Your session is about to expire." />
+      <ICallout
+        color="error"
+        icon={<>✕</>}
+        dismissible={true}
+        label="Something went wrong. Please retry."
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/callout/stories/ICallout.ink.stories.ts
+++ b/ui/components/src/components/callout/stories/ICallout.ink.stories.ts
@@ -1,0 +1,55 @@
+import { defineStories } from "@inkline/storybook";
+import type { CalloutProps } from "../styled/ICallout.ink.tsx";
+
+const meta = defineStories<CalloutProps>({
+  component: "ICallout",
+  title: "Components/Feedback/Callout",
+  args: {
+    label: "Heads up — this is a callout worth your attention.",
+    dismissible: false,
+  },
+  argTypes: {
+    label: { control: "text", description: "Callout text content" },
+    color: {
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "error",
+        "light",
+        "dark",
+        "neutral",
+      ],
+      description: "Color variant",
+    },
+    variant: {
+      control: "select",
+      options: ["solid", "outline", "soft", "subtle"],
+      description: "Style variant",
+    },
+    size: { control: "select", options: ["sm", "md", "lg"], description: "Size variant" },
+    orientation: {
+      control: "select",
+      options: ["horizontal", "vertical"],
+      description: "Stacking direction of the icon and content",
+    },
+    dismissible: { control: "boolean", description: "Shows a dismiss button" },
+    dismissAriaLabel: {
+      control: "text",
+      description: "Accessible name for the dismiss button",
+    },
+  },
+});
+
+export default meta;
+
+export const Default = {};
+export const Dismissible = { args: { dismissible: true } };
+export const Colors = { render: "./CalloutColors.ink.tsx" };
+export const Variants = { render: "./CalloutVariants.ink.tsx" };
+export const Sizes = { render: "./CalloutSizes.ink.tsx" };
+export const Orientation = { render: "./CalloutOrientation.ink.tsx" };
+export const WithIcon = { render: "./CalloutWithIcon.ink.tsx" };

--- a/ui/components/src/components/callout/styled/ICallout.ink.test.ts
+++ b/ui/components/src/components/callout/styled/ICallout.ink.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  expectImports,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+  type ComponentTestResult,
+  type TargetName,
+} from "@inkline/test-utils";
+import { mountStyledOnAngular } from "../../angular-ssr-helper.ts";
+
+const ICALLOUT = resolveComponent(import.meta.url, "./ICallout.ink.tsx");
+
+const out = (result: ComponentTestResult, target: TargetName) => result.files[target] ?? [];
+
+describe("ICallout (styled)", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(ICALLOUT);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("emits only the expected notices (Astro two-way INK0045, Qwik/Angular hasSlot INK0068)", async () => {
+    const result = await compileComponent(ICALLOUT);
+    const unexpected = result.diagnostics.filter(
+      (d) => d.code !== "INK0045" && d.code !== "INK0068",
+    );
+    expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+    // INK0068 fires once per target without runtime slot presence (Qwik + Angular).
+    expect(result.diagnostics.filter((d) => d.code === "INK0068")).toHaveLength(2);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(ICALLOUT));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(ICALLOUT));
+  });
+
+  it("composes every headless part (shell, icon, content, dismiss)", async () => {
+    const result = await compileComponent(ICALLOUT);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      const files = out(result, target);
+      expectOutputContains(files, "ICalloutBase");
+      expectOutputContains(files, "ICalloutIconBase");
+      expectOutputContains(files, "ICalloutContentBase");
+      expectOutputContains(files, "ICalloutDismissBase");
+    }
+  });
+
+  it("pulls the callout recipe from virtual:styleframe", async () => {
+    const result = await compileComponent(ICALLOUT);
+    for (const target of ["react", "vue", "solid"] as const) {
+      expectImports(out(result, target), "virtual:styleframe", ["calloutRecipe"]);
+    }
+  });
+
+  it("gates the icon addon by slot presence on targets with a runtime API", async () => {
+    const result = await compileComponent(ICALLOUT);
+    // React/Solid: node-prop presence check.
+    expectOutputContains(out(result, "react"), "props.icon != null");
+    expectOutputContains(out(result, "solid"), "props.icon != null");
+    // Vue: `$slots` presence check via v-if.
+    expectOutputContains(out(result, "vue"), "!!$slots.icon");
+  });
+
+  it("always renders the icon wrapper on Qwik/Angular (no runtime slot presence)", async () => {
+    const result = await compileComponent(ICALLOUT);
+    // No `true ?` / `@if (true)` constant condition — the wrapper is emitted unconditionally and
+    // collapses via CSS :empty. The named slot is read from props (Qwik) / projected (Angular).
+    expectOutputContains(out(result, "qwik"), "{props.icon}");
+    expectOutputContains(out(result, "angular"), 'select="[slot=icon]"');
+  });
+
+  it("gates the dismiss button by the `dismissible` prop per target", async () => {
+    const result = await compileComponent(ICALLOUT);
+    expectOutputContains(out(result, "react"), "props.dismissible");
+    expectOutputContains(out(result, "vue"), "!!dismissible");
+    expectOutputContains(out(result, "angular"), "@if (!!dismissible())");
+  });
+
+  it("wires the `visible` model + dismiss to hide the callout per target", async () => {
+    const result = await compileComponent(ICALLOUT);
+    // The model surfaces on the component's own boundary (not forwarded to a child).
+    expectOutputContains(out(result, "react"), "onUpdateVisible");
+    expectOutputContains(out(result, "angular"), "visible = model<boolean>()");
+    expectOutputContains(out(result, "svelte"), "$bindable()");
+    // Dismiss handler sets the internal signal + emits the model update (false).
+    expectOutputContains(out(result, "react"), "setDismissed(true)");
+    expectOutputContains(out(result, "angular"), "dismissed.set(true); visible.set(false)");
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(ICALLOUT))).toMatchSnapshot();
+  });
+});
+
+// Real-DOM verification on the Angular target (SSR via @angular/platform-server): the composed
+// callout renders with recipe classes on the shell, the icon/dismiss addons project and gate, the
+// role reflects, and dismissal collapses via the `hidden` attribute. Angular sorts recipe class
+// keys alphabetically (color, orientation, size, variant).
+describe("ICallout (styled) on Angular SSR", () => {
+  const HEADLESS = [
+    "../headless/ICalloutBase.ink.tsx",
+    "../headless/ICalloutIconBase.ink.tsx",
+    "../headless/ICalloutContentBase.ink.tsx",
+    "../headless/ICalloutDismissBase.ink.tsx",
+  ];
+
+  const mount = (props?: Record<string, unknown>) =>
+    mountStyledOnAngular(import.meta.url, "./ICallout.ink.tsx", HEADLESS, props);
+
+  it("renders the shell with sorted recipe classes, role=note, and the content label", async () => {
+    const { html } = await mount({
+      label: "Heads up",
+      color: "success",
+      variant: "soft",
+      size: "md",
+      orientation: "vertical",
+    });
+
+    expect(html).toMatch(
+      /<div[^>]*class="callout callout--color-success callout--orientation-vertical callout--size-md callout--variant-soft"/,
+    );
+    expect(html).toMatch(/<div[^>]*role="note"/);
+    expect(html).toMatch(/<div[^>]*class="callout-content[^"]*">Heads up<\/div>/);
+  });
+
+  it("renders a bare `callout` class with no variant modifiers when unstyled", async () => {
+    const { html } = await mount({ label: "Plain" });
+    expect(html).toMatch(/<div[^>]*class="callout"/);
+    expect(html).not.toContain("callout--");
+  });
+
+  it("reflects a custom role for dynamically-inserted messages", async () => {
+    const { html } = await mount({ label: "Saved", role: "status" });
+    expect(html).toMatch(/<div[^>]*role="status"/);
+  });
+
+  it("projects icon slot content into the icon wrapper", async () => {
+    const { html } = await mount({ label: "Info", __slots: { icon: "★" } });
+    expect(html).toMatch(/<span[^>]*class="callout-icon[^"]*">★<\/span>/);
+  });
+
+  it("keeps the unused icon wrapper present but empty (the CSS :empty contract)", async () => {
+    const { html } = await mount({ label: "No icon" });
+    // Angular always renders the wrapper (hasSlot → true); it must be truly empty so the shipped
+    // `.callout-icon:empty` rule collapses it.
+    expect(html).toMatch(/<span[^>]*class="callout-icon[^"]*"><\/span>/);
+  });
+
+  it("lets the default slot override the label fallback", async () => {
+    const { html } = await mount({
+      label: "fallback",
+      __slots: { default: "<strong>rich content</strong>" },
+    });
+    expect(html).toContain("<strong>rich content</strong>");
+    expect(html).not.toContain("fallback");
+  });
+
+  it("renders a dismiss button with the default accessible name when dismissible", async () => {
+    const { html } = await mount({ label: "Closable", dismissible: true });
+    expect(html).toMatch(/<button[^>]*class="callout-dismiss"/);
+    expect(html).toMatch(/<button[^>]*aria-label="Dismiss"/);
+    expect(html).toContain("×");
+  });
+
+  it("uses a custom dismiss accessible name", async () => {
+    const { html } = await mount({
+      label: "Closable",
+      dismissible: true,
+      dismissAriaLabel: "Close",
+    });
+    expect(html).toMatch(/<button[^>]*aria-label="Close"/);
+  });
+
+  it("lets the dismiss slot override the default × glyph", async () => {
+    const { html } = await mount({
+      label: "Closable",
+      dismissible: true,
+      __slots: { dismiss: "Close" },
+    });
+    expect(html).toMatch(/<button[^>]*class="callout-dismiss"[^>]*>[\s\S]*Close[\s\S]*<\/button>/);
+  });
+
+  it("omits the dismiss button when not dismissible", async () => {
+    const { html } = await mount({ label: "Static" });
+    expect(html).not.toContain("callout-dismiss");
+  });
+
+  it("hides the shell (hidden attribute) when the visible model is false", async () => {
+    const { html } = await mount({ label: "Gone", visible: false });
+    expect(html).toMatch(/<div[^>]*class="callout"[^>]* hidden/);
+  });
+
+  it("keeps the shell visible (no hidden attribute) when the visible model is true", async () => {
+    const { html } = await mount({ label: "Shown", visible: true });
+    const shell = html.match(/<div[^>]*class="callout"[^>]*>/);
+    expect(shell).toBeTruthy();
+    expect(shell![0]).not.toContain("hidden");
+  });
+
+  // The collapsed host variant inlines the whole composite onto native elements: the shell is the
+  // <div> host carrying the recipe classes + role, with zero display:contents wrapper elements.
+  it("host variant renders a zero-wrapper shell (div[ink-callout]) with recipe classes + role", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./ICallout.ink.tsx",
+      HEADLESS,
+      { label: "Hosted", color: "primary", size: "md" },
+      "ICalloutHostComponent",
+    );
+    expect(html).toMatch(
+      /<div[^>]*ink-callout[^>]*class="callout callout--color-primary callout--size-md"/,
+    );
+    expect(html).toMatch(/<div[^>]*role="note"/);
+    expect(html).not.toContain("<ink-callout"); // no display:contents wrapper elements anywhere
+  });
+});

--- a/ui/components/src/components/callout/styled/ICallout.ink.tsx
+++ b/ui/components/src/components/callout/styled/ICallout.ink.tsx
@@ -13,7 +13,13 @@ import ICalloutContentBase from "../headless/ICalloutContentBase.ink.tsx";
 import ICalloutDismissBase from "../headless/ICalloutDismissBase.ink.tsx";
 import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
 
-export interface CalloutProps extends CalloutBaseProps {
+// `hidden` is intentionally omitted from the public props: the styled component derives it from the
+// `visible` model / internal dismissal below and forwards it to the base, so inheriting the base's
+// `hidden` would collide with the local `hidden` memo. The remaining base member (`role`) is
+// referenced explicitly (the compiler only enumerates members of this directly-named interface).
+export interface CalloutProps {
+  /** ARIA role of the container; override with `"alert"`/`"status"` for dynamically-inserted messages. */
+  role?: CalloutBaseProps["role"];
   /** Text content; overridden by the default slot. */
   label?: string;
   /** Color variant. */

--- a/ui/components/src/components/callout/styled/ICallout.ink.tsx
+++ b/ui/components/src/components/callout/styled/ICallout.ink.tsx
@@ -1,0 +1,83 @@
+import {
+  defineComponent,
+  Slot,
+  Show,
+  defineModel,
+  createSignal,
+  createMemo,
+  hasSlot,
+} from "@inkline/core";
+import ICalloutBase, { type CalloutBaseProps } from "../headless/ICalloutBase.ink.tsx";
+import ICalloutIconBase from "../headless/ICalloutIconBase.ink.tsx";
+import ICalloutContentBase from "../headless/ICalloutContentBase.ink.tsx";
+import ICalloutDismissBase from "../headless/ICalloutDismissBase.ink.tsx";
+import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+
+export interface CalloutProps extends CalloutBaseProps {
+  /** Text content; overridden by the default slot. */
+  label?: string;
+  /** Color variant. */
+  color?: CalloutStylingProps["color"];
+  /** Style variant. */
+  variant?: CalloutStylingProps["variant"];
+  /** Size variant. */
+  size?: CalloutStylingProps["size"];
+  /** Stacking direction of the icon and content. */
+  orientation?: CalloutStylingProps["orientation"];
+  /** Shows a dismiss button that hides the callout. */
+  dismissible?: boolean;
+  /** Accessible name for the icon-only dismiss button. */
+  dismissAriaLabel?: string;
+}
+
+/**
+ * The styled Callout: a contextual feedback message that composes the shell, an optional leading
+ * icon, the content, and an optional dismiss button — styled together. The icon wrapper is gated
+ * by `hasSlot` so it isn't emitted when unused (and collapses via CSS `:empty` on Qwik/Angular,
+ * which lack runtime slot presence). Visibility is two-way bindable via `$bind:visible`; when
+ * unbound, dismissal is tracked internally and the callout stays mounted but `hidden`.
+ */
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {}, icon: {}, dismiss: {} } },
+  (props: CalloutProps) => {
+    const [visible, setVisible] = defineModel<boolean>("visible");
+    // Compiled models are controlled-only (a prop + event pair, no internal state), so an internal
+    // signal backs the unbound case: a bound `visible` wins, otherwise dismissal tracks locally.
+    const [dismissed, setDismissed] = createSignal(false);
+
+    const className = createMemo(() =>
+      calloutRecipe({
+        color: props.color,
+        variant: props.variant,
+        size: props.size,
+        orientation: props.orientation,
+      }),
+    );
+
+    const hidden = createMemo(() => (visible() === undefined ? dismissed() : visible() === false));
+
+    return (
+      <ICalloutBase class={className()} role={props.role} hidden={hidden()}>
+        <Show when={hasSlot("icon")}>
+          <ICalloutIconBase>
+            <Slot name="icon" />
+          </ICalloutIconBase>
+        </Show>
+        <ICalloutContentBase>
+          <Slot>{props.label}</Slot>
+        </ICalloutContentBase>
+        <Show when={!!props.dismissible}>
+          <ICalloutDismissBase
+            ariaLabel={props.dismissAriaLabel}
+            onClick={() => {
+              setDismissed(true);
+              setVisible(false);
+            }}
+          >
+            <Slot name="dismiss">{"×"}</Slot>
+          </ICalloutDismissBase>
+        </Show>
+      </ICalloutBase>
+    );
+  },
+);

--- a/ui/components/src/components/callout/styled/ICallout.ink.tsx
+++ b/ui/components/src/components/callout/styled/ICallout.ink.tsx
@@ -40,8 +40,15 @@ export interface CalloutProps {
  * The styled Callout: a contextual feedback message that composes the shell, an optional leading
  * icon, the content, and an optional dismiss button — styled together. The icon wrapper is gated
  * by `hasSlot` so it isn't emitted when unused (and collapses via CSS `:empty` on Qwik/Angular,
- * which lack runtime slot presence). Visibility is two-way bindable via `$bind:visible`; when
- * unbound, dismissal is tracked internally and the callout stays mounted but `hidden`.
+ * which lack runtime slot presence).
+ *
+ * Visibility is two-way bindable via the `visible` model (`$bind:visible`, emitting `update:visible`);
+ * when unbound, dismissal is tracked internally and the callout stays mounted but `hidden`.
+ *
+ * Slots:
+ * - `default` — the message content (overrides the `label` prop).
+ * - `icon` — a leading, decorative icon; the wrapper is omitted when this slot is empty.
+ * - `dismiss` — custom dismiss-button content; defaults to a `×` glyph.
  */
 export default defineComponent(
   { meta: { headless: true }, slots: { default: {}, icon: {}, dismiss: {} } },

--- a/ui/components/src/components/callout/styled/ICallout.styleframe.ts
+++ b/ui/components/src/components/callout/styled/ICallout.styleframe.ts
@@ -1,0 +1,33 @@
+import { styleframe } from "virtual:styleframe";
+import { useCalloutRecipe } from "@styleframe/theme";
+
+const s = styleframe();
+
+// Layered on top of the prebuilt recipe (which only styles color/variant/size/orientation on
+// `.callout`). The recipe's `display: flex` outranks the UA `[hidden]` rule, so dismissal needs an
+// explicit collapse.
+s.selector(".callout[hidden]", { display: "none" });
+
+s.selector(".callout-icon", { display: "inline-flex", flexShrink: "0" });
+
+// Qwik/Angular have no runtime slot presence and always render the gated icon wrapper.
+s.selector(".callout-icon:empty", { display: "none" });
+
+s.selector(".callout-content", { flex: "1 1 auto" });
+
+s.selector(".callout-dismiss", {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: "0",
+  marginInlineStart: "auto",
+  padding: "0",
+  borderWidth: "0",
+  background: "none",
+  color: "inherit",
+  font: "inherit",
+  lineHeight: "1",
+  cursor: "pointer",
+});
+
+export const calloutRecipe = useCalloutRecipe(s);

--- a/ui/components/src/components/callout/styled/__snapshots__/ICallout.ink.test.ts.snap
+++ b/ui/components/src/components/callout/styled/__snapshots__/ICallout.ink.test.ts.snap
@@ -1,0 +1,375 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ICallout (styled) > output matches snapshots 1`] = `
+{
+  "angular/ICallout.component.ts": "import { Component, signal, computed, effect, input, model } from "@angular/core";
+import { ICalloutBaseComponent as ICalloutBase } from "../headless/ICalloutBase.component";
+import { type CalloutBaseProps } from "../headless/ICalloutBase.component";
+import { ICalloutIconBaseComponent as ICalloutIconBase } from "../headless/ICalloutIconBase.component";
+import { ICalloutContentBaseComponent as ICalloutContentBase } from "../headless/ICalloutContentBase.component";
+import { ICalloutDismissBaseComponent as ICalloutDismissBase } from "../headless/ICalloutDismissBase.component";
+import { ICalloutIconBaseHostComponent } from "../headless/ICalloutIconBase.component";
+import { ICalloutContentBaseHostComponent } from "../headless/ICalloutContentBase.component";
+import { ICalloutDismissBaseHostComponent } from "../headless/ICalloutDismissBase.component";
+import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+export interface CalloutProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: CalloutBaseProps["role"];
+  /** Text content; overridden by the default slot. */
+  label?: string;
+  /** Color variant. */
+  color?: CalloutStylingProps["color"];
+  /** Style variant. */
+  variant?: CalloutStylingProps["variant"];
+  /** Size variant. */
+  size?: CalloutStylingProps["size"];
+  /** Stacking direction of the icon and content. */
+  orientation?: CalloutStylingProps["orientation"];
+  /** Shows a dismiss button that hides the callout. */
+  dismissible?: boolean;
+  /** Accessible name for the icon-only dismiss button. */
+  dismissAriaLabel?: string;
+}
+@Component({ standalone: true, selector: 'ink-callout', host: { style: 'display: contents' }, imports: [ICalloutBase, ICalloutIconBase, ICalloutContentBase, ICalloutDismissBase], template: \`<ink-callout-base [klass]="(className()) + (klass() ? ' ' + klass() : '')" [role]="role()" [hidden]="hidden()">
+<ink-callout-icon-base>
+<ng-content select="[slot=icon]"></ng-content>
+</ink-callout-icon-base>
+<ink-callout-content-base>
+<ng-content>{{ label() }}</ng-content>
+</ink-callout-content-base>
+@if (!!dismissible()) {
+<ink-callout-dismiss-base [ariaLabel]="dismissAriaLabel()" (click)="dismissed.set(true); visible.set(false)">
+<ng-content select="[slot=dismiss]">{{ '×' }}</ng-content>
+</ink-callout-dismiss-base>
+}
+</ink-callout-base>\` })
+export class ICalloutComponent
+{
+calloutRecipe = calloutRecipe
+klass = input<string>()
+dismissed = signal(false)
+className = computed(() => calloutRecipe({ color: this.color(), variant: this.variant(), size: this.size(), orientation: this.orientation() }))
+hidden = computed(() => (this.visible() === undefined ? this.dismissed() : this.visible() === false))
+role = input<CalloutBaseProps["role"]>()
+label = input<string>()
+color = input<CalloutStylingProps["color"]>()
+variant = input<CalloutStylingProps["variant"]>()
+size = input<CalloutStylingProps["size"]>()
+orientation = input<CalloutStylingProps["orientation"]>()
+dismissible = input<boolean>()
+dismissAriaLabel = input<string>()
+visible = model<boolean>()
+}
+@Component({ standalone: true, selector: 'div[ink-callout]', host: { '[class]': "'callout' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')", '[attr.role]': "(role() ?? 'note') ?? null", '[hidden]': "hidden()", 'ink-callout-base': '' }, imports: [ICalloutIconBaseHostComponent, ICalloutContentBaseHostComponent, ICalloutDismissBaseHostComponent], template: \`<span ink-callout-icon-base>
+<ng-content select="[slot=icon]"></ng-content>
+</span>
+<div ink-callout-content-base>
+<ng-content>{{ label() }}</ng-content>
+</div>
+@if (!!dismissible()) {
+<button ink-callout-dismiss-base [ariaLabel]="dismissAriaLabel()" (click)="dismissed.set(true); visible.set(false)">
+<ng-content select="[slot=dismiss]">{{ '×' }}</ng-content>
+</button>
+}\` })
+export class ICalloutHostComponent
+{
+calloutRecipe = calloutRecipe
+klass = input<string>()
+dismissed = signal(false)
+className = computed(() => calloutRecipe({ color: this.color(), variant: this.variant(), size: this.size(), orientation: this.orientation() }))
+hidden = computed(() => (this.visible() === undefined ? this.dismissed() : this.visible() === false))
+role = input<CalloutBaseProps["role"]>()
+label = input<string>()
+color = input<CalloutStylingProps["color"]>()
+variant = input<CalloutStylingProps["variant"]>()
+size = input<CalloutStylingProps["size"]>()
+orientation = input<CalloutStylingProps["orientation"]>()
+dismissible = input<boolean>()
+dismissAriaLabel = input<string>()
+visible = model<boolean>()
+}
+",
+  "astro/ICallout.astro": "---
+import ICalloutBase, { type CalloutBaseProps } from "../headless/ICalloutBase.astro";
+import ICalloutIconBase from "../headless/ICalloutIconBase.astro";
+import ICalloutContentBase from "../headless/ICalloutContentBase.astro";
+import ICalloutDismissBase from "../headless/ICalloutDismissBase.astro";
+import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+export interface CalloutProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: CalloutBaseProps["role"];
+  /** Text content; overridden by the default slot. */
+  label?: string;
+  /** Color variant. */
+  color?: CalloutStylingProps["color"];
+  /** Style variant. */
+  variant?: CalloutStylingProps["variant"];
+  /** Size variant. */
+  size?: CalloutStylingProps["size"];
+  /** Stacking direction of the icon and content. */
+  orientation?: CalloutStylingProps["orientation"];
+  /** Shows a dismiss button that hides the callout. */
+  dismissible?: boolean;
+  /** Accessible name for the icon-only dismiss button. */
+  dismissAriaLabel?: string;
+}
+type Props = CalloutProps & Record<string, any>
+const props = Astro.props as Props;
+const { role, label, color, variant, size, orientation, dismissible, dismissAriaLabel, ...__attrs } = props;
+let visible = props.visible
+let dismissed = false
+const className = calloutRecipe({ color: color, variant: variant, size: size, orientation: orientation })
+const hidden = (visible === undefined ? dismissed : visible === false)
+---
+<ICalloutBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")} role={role} hidden={hidden}>
+{Astro.slots.has("icon") ? (<ICalloutIconBase>
+<slot name="icon" />
+</ICalloutIconBase>) : null}
+<ICalloutContentBase>
+<slot>
+{label}
+</slot>
+</ICalloutContentBase>
+{!!dismissible ? (<ICalloutDismissBase ariaLabel={dismissAriaLabel} onClick={() => { dismissed = true; visible = false; }}>
+<slot name="dismiss">
+{"×"}
+</slot>
+</ICalloutDismissBase>) : null}
+</ICalloutBase>
+",
+  "qwik/ICallout.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL, Slot } from "@qwik.dev/core";
+import { ICalloutBase } from "../headless/ICalloutBase";
+import { type CalloutBaseProps } from "../headless/ICalloutBase";
+import { ICalloutIconBase } from "../headless/ICalloutIconBase";
+import { ICalloutContentBase } from "../headless/ICalloutContentBase";
+import { ICalloutDismissBase } from "../headless/ICalloutDismissBase";
+import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+export interface CalloutProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: CalloutBaseProps["role"];
+  /** Text content; overridden by the default slot. */
+  label?: string;
+  /** Color variant. */
+  color?: CalloutStylingProps["color"];
+  /** Style variant. */
+  variant?: CalloutStylingProps["variant"];
+  /** Size variant. */
+  size?: CalloutStylingProps["size"];
+  /** Stacking direction of the icon and content. */
+  orientation?: CalloutStylingProps["orientation"];
+  /** Shows a dismiss button that hides the callout. */
+  dismissible?: boolean;
+  /** Accessible name for the icon-only dismiss button. */
+  dismissAriaLabel?: string;
+}
+export const ICallout = component$((props: CalloutProps & { visible?: boolean; onUpdateVisible$?: QRL<(value: boolean) => void> } & Record<string, any>) =>
+{
+const dismissed = useSignal(false)
+const className = useComputed$(() => calloutRecipe({ color: props.color, variant: props.variant, size: props.size, orientation: props.orientation }))
+const hidden = useComputed$(() => (props.visible === undefined ? dismissed.value : props.visible === false))
+const { children, icon, dismiss, role, label, color, variant, size, orientation, dismissible, dismissAriaLabel, visible, onUpdateVisible$, ...__attrs } = props
+return (
+<ICalloutBase {...__attrs} class={[className.value, props.class].filter(Boolean).join(" ")} role={props.role} hidden={hidden.value}>
+  <>
+    {(<><ICalloutIconBase>{props.icon}</ICalloutIconBase></>)}
+    <ICalloutContentBase>
+      <Slot>
+        {props.label}
+      </Slot>
+    </ICalloutContentBase>
+    {!!props.dismissible ? (<><ICalloutDismissBase ariaLabel={props.dismissAriaLabel} onClick={$(() => { dismissed.value = true; props.onUpdateVisible$?.(false); })}>{props.dismiss ?? (<>{"×"}</>)}</ICalloutDismissBase></>) : null}
+  </>
+</ICalloutBase>
+)
+});
+",
+  "react/ICallout.tsx": "import { useState, useMemo } from "react";
+import { ICalloutBase } from "../headless/ICalloutBase";
+import { type CalloutBaseProps } from "../headless/ICalloutBase";
+import { ICalloutIconBase } from "../headless/ICalloutIconBase";
+import { ICalloutContentBase } from "../headless/ICalloutContentBase";
+import { ICalloutDismissBase } from "../headless/ICalloutDismissBase";
+import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+export interface CalloutProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: CalloutBaseProps["role"];
+  /** Text content; overridden by the default slot. */
+  label?: string;
+  /** Color variant. */
+  color?: CalloutStylingProps["color"];
+  /** Style variant. */
+  variant?: CalloutStylingProps["variant"];
+  /** Size variant. */
+  size?: CalloutStylingProps["size"];
+  /** Stacking direction of the icon and content. */
+  orientation?: CalloutStylingProps["orientation"];
+  /** Shows a dismiss button that hides the callout. */
+  dismissible?: boolean;
+  /** Accessible name for the icon-only dismiss button. */
+  dismissAriaLabel?: string;
+}
+export function ICallout(props: CalloutProps & { children?: React.ReactNode; icon?: React.ReactNode; dismiss?: React.ReactNode } & { visible?: boolean; onUpdateVisible?: (value: boolean) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const [dismissed, setDismissed] = useState(false)
+const className = useMemo(() => calloutRecipe({ color: props.color, variant: props.variant, size: props.size, orientation: props.orientation }), [props.color, props.variant, props.size, props.orientation])
+const hidden = useMemo(() => (props.visible === undefined ? dismissed : props.visible === false), [props.visible, dismissed])
+const { children, icon, dismiss, role, label, color, variant, size, orientation, dismissible, dismissAriaLabel, visible, onUpdateVisible, ...__attrs } = props
+return (
+<ICalloutBase {...__attrs} className={[className, props.className].filter(Boolean).join(" ")} role={props.role} hidden={hidden}>
+  <>
+    {(props.icon != null) ? <ICalloutIconBase>{props.icon}</ICalloutIconBase> : null}
+    <ICalloutContentBase>
+      {props.children ?? props.label}
+    </ICalloutContentBase>
+    {!!props.dismissible ? <ICalloutDismissBase ariaLabel={props.dismissAriaLabel} onClick={() => { setDismissed(true); props.onUpdateVisible?.(false); }}>{props.dismiss ?? "×"}</ICalloutDismissBase> : null}
+  </>
+</ICalloutBase>
+)
+}
+",
+  "solid/ICallout.tsx": "import { createSignal, createMemo, splitProps, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import ICalloutBase, { type CalloutBaseProps } from "../headless/ICalloutBase";
+import ICalloutIconBase from "../headless/ICalloutIconBase";
+import ICalloutContentBase from "../headless/ICalloutContentBase";
+import ICalloutDismissBase from "../headless/ICalloutDismissBase";
+import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+export interface CalloutProps {
+  /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+  role?: CalloutBaseProps["role"];
+  /** Text content; overridden by the default slot. */
+  label?: string;
+  /** Color variant. */
+  color?: CalloutStylingProps["color"];
+  /** Style variant. */
+  variant?: CalloutStylingProps["variant"];
+  /** Size variant. */
+  size?: CalloutStylingProps["size"];
+  /** Stacking direction of the icon and content. */
+  orientation?: CalloutStylingProps["orientation"];
+  /** Shows a dismiss button that hides the callout. */
+  dismissible?: boolean;
+  /** Accessible name for the icon-only dismiss button. */
+  dismissAriaLabel?: string;
+}
+export default function ICallout(props: CalloutProps & { children?: any; icon?: any; dismiss?: any } & { visible?: boolean; onUpdateVisible?: (value: boolean) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [dismissed, setDismissed] = createSignal(false)
+const className = createMemo(() => calloutRecipe({ color: props.color, variant: props.variant, size: props.size, orientation: props.orientation }))
+const hidden = createMemo(() => (props.visible === undefined ? dismissed() : props.visible === false))
+const [, __attrs] = splitProps(props, ["children", "icon", "dismiss", "role", "label", "color", "variant", "size", "orientation", "dismissible", "dismissAriaLabel", "visible", "onUpdateVisible"])
+return (
+<ICalloutBase {...__attrs} class={[className(), props.class].filter(Boolean).join(" ")} role={props.role} hidden={hidden()}>
+  <>
+    <Show when={(props.icon != null)}>
+      <ICalloutIconBase>
+        {props.icon}
+      </ICalloutIconBase>
+    </Show>
+    <ICalloutContentBase>
+      {props.children ?? props.label}
+    </ICalloutContentBase>
+    <Show when={!!props.dismissible}>
+      <ICalloutDismissBase ariaLabel={props.dismissAriaLabel} onClick={() => { setDismissed(true); props.onUpdateVisible?.(false); }}>
+        {props.dismiss ?? "×"}
+      </ICalloutDismissBase>
+    </Show>
+  </>
+</ICalloutBase>
+)
+}
+",
+  "svelte/ICallout.svelte": "<script lang="ts">
+  import ICalloutBase, { type CalloutBaseProps } from "../headless/ICalloutBase.svelte";
+  import ICalloutIconBase from "../headless/ICalloutIconBase.svelte";
+  import ICalloutContentBase from "../headless/ICalloutContentBase.svelte";
+  import ICalloutDismissBase from "../headless/ICalloutDismissBase.svelte";
+  import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+  export interface CalloutProps {
+    /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+    role?: CalloutBaseProps["role"];
+    /** Text content; overridden by the default slot. */
+    label?: string;
+    /** Color variant. */
+    color?: CalloutStylingProps["color"];
+    /** Style variant. */
+    variant?: CalloutStylingProps["variant"];
+    /** Size variant. */
+    size?: CalloutStylingProps["size"];
+    /** Stacking direction of the icon and content. */
+    orientation?: CalloutStylingProps["orientation"];
+    /** Shows a dismiss button that hides the callout. */
+    dismissible?: boolean;
+    /** Accessible name for the icon-only dismiss button. */
+    dismissAriaLabel?: string;
+  }
+  import type { Snippet } from "svelte";
+  let { role, label, color, variant, size, orientation, dismissible, dismissAriaLabel, visible = $bindable(), children, icon: iconSnippet, dismiss: dismissSnippet, ...__attrs }: CalloutProps & { visible?: boolean; children?: Snippet; icon?: Snippet; dismiss?: Snippet } & Record<string, any> = $props()
+  let dismissed = $state(false)
+  let className = $derived(calloutRecipe({ color: color, variant: variant, size: size, orientation: orientation }))
+  let hidden = $derived((visible === undefined ? dismissed : visible === false))
+</script>
+<ICalloutBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")} role={role} hidden={hidden}>
+  {#if (iconSnippet != null)}<ICalloutIconBase>
+    {@render iconSnippet?.()}
+  </ICalloutIconBase>
+  {/if}<ICalloutContentBase>
+    {#if children}{@render children()}{:else}{label}{/if}
+  </ICalloutContentBase>
+  {#if !!dismissible}<ICalloutDismissBase ariaLabel={dismissAriaLabel} onClick={() => { dismissed = true; visible = false; }}>
+    {#if dismissSnippet}{@render dismissSnippet()}{:else}{"×"}{/if}
+  </ICalloutDismissBase>
+  {/if}
+</ICalloutBase>
+",
+  "vue/ICallout.vue": "<script setup lang="ts">
+  import { ref, computed } from "vue";
+  import ICalloutBase, { type CalloutBaseProps } from "../headless/ICalloutBase.vue";
+  import ICalloutIconBase from "../headless/ICalloutIconBase.vue";
+  import ICalloutContentBase from "../headless/ICalloutContentBase.vue";
+  import ICalloutDismissBase from "../headless/ICalloutDismissBase.vue";
+  import { calloutRecipe, type CalloutRecipeProps as CalloutStylingProps } from "virtual:styleframe";
+  export interface CalloutProps {
+    /** ARIA role of the container; override with \`"alert"\`/\`"status"\` for dynamically-inserted messages. */
+    role?: CalloutBaseProps["role"];
+    /** Text content; overridden by the default slot. */
+    label?: string;
+    /** Color variant. */
+    color?: CalloutStylingProps["color"];
+    /** Style variant. */
+    variant?: CalloutStylingProps["variant"];
+    /** Size variant. */
+    size?: CalloutStylingProps["size"];
+    /** Stacking direction of the icon and content. */
+    orientation?: CalloutStylingProps["orientation"];
+    /** Shows a dismiss button that hides the callout. */
+    dismissible?: boolean;
+    /** Accessible name for the icon-only dismiss button. */
+    dismissAriaLabel?: string;
+  }
+  const props = defineProps<CalloutProps>()
+  const dismissed = ref(false)
+  const visible = defineModel<boolean>("visible")
+  const className = computed(() => calloutRecipe({ color: props.color, variant: props.variant, size: props.size, orientation: props.orientation }))
+  const hidden = computed(() => (visible.value === undefined ? dismissed.value : visible.value === false))
+</script>
+<template>
+<ICalloutBase :class="className" :role="role" :hidden="hidden">
+  <ICalloutIconBase v-if="!!$slots.icon">
+    <slot name="icon" />
+  </ICalloutIconBase>
+  <ICalloutContentBase>
+    <slot>
+      {{ label }}
+    </slot>
+  </ICalloutContentBase>
+  <ICalloutDismissBase v-if="!!dismissible" :ariaLabel="dismissAriaLabel" @click="() => { dismissed = true; visible = false; }">
+    <slot name="dismiss">
+      {{ "×" }}
+    </slot>
+  </ICalloutDismissBase>
+</ICalloutBase>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/index.ts
+++ b/ui/components/src/components/index.ts
@@ -4,6 +4,14 @@ export { default as IBadgeBase } from "./badge/headless/IBadgeBase.ink.tsx";
 export { default as IButton } from "./button/styled/IButton.ink.tsx";
 export { default as IButtonBase } from "./button/headless/IButtonBase.ink.tsx";
 
+// Callout ships as a single styled component (ICallout) that composes every headless part. The
+// headless parts remain individually exported for advanced/custom composition.
+export { default as ICallout } from "./callout/styled/ICallout.ink.tsx";
+export { default as ICalloutBase } from "./callout/headless/ICalloutBase.ink.tsx";
+export { default as ICalloutContentBase } from "./callout/headless/ICalloutContentBase.ink.tsx";
+export { default as ICalloutDismissBase } from "./callout/headless/ICalloutDismissBase.ink.tsx";
+export { default as ICalloutIconBase } from "./callout/headless/ICalloutIconBase.ink.tsx";
+
 export { default as IFieldGroup } from "./field-group/styled/IFieldGroup.ink.tsx";
 export { default as IFieldGroupBase } from "./field-group/headless/IFieldGroupBase.ink.tsx";
 


### PR DESCRIPTION
## Summary

Adds the `ICallout` component — a styled, dismissible callout/alert with headless base components (`ICalloutBase`, `ICalloutContentBase`, `ICalloutDismissBase`, `ICalloutIconBase`), Storybook stories, cross-target tests, and a changeset.

## Related issues

- Closes #

## Type of change

- [x] `feat` — new user-facing capability or public API
- [ ] `fix` — bug fix
- [ ] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `chore` / `ci` — tooling, dependencies, or CI

## Test plan

- [ ] `vp run ready` passes locally
- [ ] Storybook stories render correctly for all color/size/variant/orientation permutations
- [ ] Dismiss button toggles `hidden` state on the root element

## Checklist

- [x] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".