### PR TITLE
feat(components): add IAvatar and IAvatarGroup components

### DIFF
--- a/ui/components/src/components/avatar-group/headless/IAvatarGroupBase.ink.test.ts
+++ b/ui/components/src/components/avatar-group/headless/IAvatarGroupBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const AVATAR_GROUP_BASE = resolveComponent(import.meta.url, "./IAvatarGroupBase.ink.tsx");
+
+describe("AvatarGroupBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(AVATAR_GROUP_BASE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(AVATAR_GROUP_BASE));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(AVATAR_GROUP_BASE));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(AVATAR_GROUP_BASE));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(AVATAR_GROUP_BASE))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/avatar-group/headless/IAvatarGroupBase.ink.tsx
+++ b/ui/components/src/components/avatar-group/headless/IAvatarGroupBase.ink.tsx
@@ -1,0 +1,16 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface AvatarGroupBaseProps {}
+
+// A container that stacks its avatars with overlap. Avatars must be direct children so the theme's
+// `.avatar-group > .avatar` overlap and ring rules apply.
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: AvatarGroupBaseProps) => {
+    return (
+      <div class="avatar-group">
+        <Slot />
+      </div>
+    );
+  },
+);

--- a/ui/components/src/components/avatar-group/headless/__snapshots__/IAvatarGroupBase.ink.test.ts.snap
+++ b/ui/components/src/components/avatar-group/headless/__snapshots__/IAvatarGroupBase.ink.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AvatarGroupBase > output matches snapshots 1`] = `
+{
+  "angular/IAvatarGroupBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface AvatarGroupBaseProps {}
+@Component({ standalone: true, selector: 'ink-avatar-group-base', host: { style: 'display: contents' }, template: \`<div [class]="'avatar-group' + (klass() ? ' ' + klass() : '')">
+<ng-content></ng-content>
+</div>\` })
+export class IAvatarGroupBaseComponent
+{
+klass = input<string>()
+}
+@Component({ standalone: true, selector: 'div[ink-avatar-group-base]', host: { '[class]': "'avatar-group' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content></ng-content>\` })
+export class IAvatarGroupBaseHostComponent
+{
+klass = input<string>()
+}
+",
+  "astro/IAvatarGroupBase.astro": "---
+export interface AvatarGroupBaseProps {}
+type Props = AvatarGroupBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+---
+<div {...__attrs} class={["avatar-group", __attrs.class].filter(Boolean).join(" ")}>
+<slot />
+</div>
+",
+  "qwik/IAvatarGroupBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface AvatarGroupBaseProps {}
+export const IAvatarGroupBase = component$((props) =>
+{
+const { children, ...__attrs } = props
+return (
+<div {...__attrs} class={["avatar-group", props.class].filter(Boolean).join(" ")}>
+  <Slot />
+</div>
+)
+});
+",
+  "react/IAvatarGroupBase.tsx": "export interface AvatarGroupBaseProps {}
+export function IAvatarGroupBase(props: AvatarGroupBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, ...__attrs } = props
+return (
+<div {...__attrs} className={["avatar-group", props.className].filter(Boolean).join(" ")}>
+  {props.children}
+</div>
+)
+}
+",
+  "solid/IAvatarGroupBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface AvatarGroupBaseProps {}
+export default function IAvatarGroupBase(props: AvatarGroupBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children"])
+return (
+<div {...__attrs} class={["avatar-group", props.class].filter(Boolean).join(" ")}>
+  {props.children}
+</div>
+)
+}
+",
+  "svelte/IAvatarGroupBase.svelte": "<script lang="ts">
+  export interface AvatarGroupBaseProps {}
+  import type { Snippet } from "svelte";
+  let { children, ...__attrs }: AvatarGroupBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<div {...__attrs} class={["avatar-group", __attrs.class].filter(Boolean).join(" ")}>
+  {@render children?.()}
+</div>
+",
+  "vue/IAvatarGroupBase.vue": "<script setup lang="ts">
+  export interface AvatarGroupBaseProps {}
+  const props = defineProps<AvatarGroupBaseProps>()
+</script>
+<template>
+<div class="avatar-group">
+  <slot />
+</div>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/avatar-group/stories/AvatarGroupOverflow.ink.tsx
+++ b/ui/components/src/components/avatar-group/stories/AvatarGroupOverflow.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent } from "@inkline/core";
+import IAvatarGroup from "../styled/IAvatarGroup.ink.tsx";
+import IAvatar from "../../avatar/styled/IAvatar.ink.tsx";
+
+// The "+N" overflow is just another avatar with a label — no dedicated API needed.
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatarGroup>
+        <IAvatar color="primary" label="AB" />
+        <IAvatar color="light" label="CD" />
+        <IAvatar color="dark" label="EF" />
+        <IAvatar color="neutral" label="+5" />
+      </IAvatarGroup>
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar-group/stories/AvatarGroupSizes.ink.tsx
+++ b/ui/components/src/components/avatar-group/stories/AvatarGroupSizes.ink.tsx
@@ -1,0 +1,21 @@
+import { defineComponent } from "@inkline/core";
+import IAvatarGroup from "../styled/IAvatarGroup.ink.tsx";
+import IAvatar from "../../avatar/styled/IAvatar.ink.tsx";
+
+// `size` on the group only tunes the overlap; each child avatar sets its own matching size.
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatarGroup size="sm">
+        <IAvatar size="sm" color="primary" label="AB" />
+        <IAvatar size="sm" color="light" label="CD" />
+        <IAvatar size="sm" color="dark" label="EF" />
+      </IAvatarGroup>
+      <IAvatarGroup size="lg">
+        <IAvatar size="lg" color="primary" label="AB" />
+        <IAvatar size="lg" color="light" label="CD" />
+        <IAvatar size="lg" color="dark" label="EF" />
+      </IAvatarGroup>
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar-group/stories/AvatarGroupStack.ink.tsx
+++ b/ui/components/src/components/avatar-group/stories/AvatarGroupStack.ink.tsx
@@ -1,0 +1,16 @@
+import { defineComponent } from "@inkline/core";
+import IAvatarGroup from "../styled/IAvatarGroup.ink.tsx";
+import IAvatar from "../../avatar/styled/IAvatar.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatarGroup>
+        <IAvatar color="primary" label="AB" />
+        <IAvatar color="light" label="CD" />
+        <IAvatar color="dark" label="EF" />
+        <IAvatar color="neutral" label="GH" />
+      </IAvatarGroup>
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar-group/stories/IAvatarGroup.ink.stories.ts
+++ b/ui/components/src/components/avatar-group/stories/IAvatarGroup.ink.stories.ts
@@ -1,0 +1,21 @@
+import { defineStories } from "@inkline/storybook";
+import type { AvatarGroupProps } from "../styled/IAvatarGroup.ink.tsx";
+
+const meta = defineStories<AvatarGroupProps>({
+  component: "IAvatarGroup",
+  title: "Components/Data Display/AvatarGroup",
+  args: {},
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "Overlap spacing; set each child avatar's own size to match",
+    },
+  },
+});
+
+export default meta;
+
+export const Default = { render: "./AvatarGroupStack.ink.tsx" };
+export const Sizes = { render: "./AvatarGroupSizes.ink.tsx" };
+export const Overflow = { render: "./AvatarGroupOverflow.ink.tsx" };

--- a/ui/components/src/components/avatar-group/styled/IAvatarGroup.ink.test.ts
+++ b/ui/components/src/components/avatar-group/styled/IAvatarGroup.ink.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  expectOutputContains,
+  expectImports,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+  type ComponentTestResult,
+  type TargetName,
+} from "@inkline/test-utils";
+import { mountStyledOnAngular } from "../../angular-ssr-helper.ts";
+
+const IAVATAR_GROUP = resolveComponent(import.meta.url, "./IAvatarGroup.ink.tsx");
+
+const out = (result: ComponentTestResult, target: TargetName) => result.files[target] ?? [];
+
+describe("IAvatarGroup (styled)", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(IAVATAR_GROUP);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(IAVATAR_GROUP));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(IAVATAR_GROUP));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(IAVATAR_GROUP));
+  });
+
+  it("composes the headless base", async () => {
+    const result = await compileComponent(IAVATAR_GROUP);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      expectOutputContains(out(result, target), "IAvatarGroupBase");
+    }
+  });
+
+  it("pulls the group recipe from virtual:styleframe", async () => {
+    const result = await compileComponent(IAVATAR_GROUP);
+    for (const target of ["react", "vue", "solid"] as const) {
+      expectImports(out(result, target), "virtual:styleframe", ["avatarGroupRecipe"]);
+    }
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(IAVATAR_GROUP))).toMatchSnapshot();
+  });
+});
+
+describe("IAvatarGroup (styled) on Angular SSR", () => {
+  const HEADLESS = ["../headless/IAvatarGroupBase.ink.tsx"];
+
+  const mount = (props?: Record<string, unknown>) =>
+    mountStyledOnAngular(import.meta.url, "./IAvatarGroup.ink.tsx", HEADLESS, props);
+
+  it("renders the group shell with the size recipe class and projects its avatars", async () => {
+    const { html } = await mount({
+      size: "lg",
+      __slots: { default: '<span class="avatar">AB</span>' },
+    });
+
+    expect(html).toMatch(/<div[^>]*class="avatar-group[^"]*"/);
+    expect(html).toContain("avatar-group--size-lg");
+    expect(html).toContain('<span class="avatar">AB</span>');
+  });
+
+  it("renders the base class alone when no size is set", async () => {
+    const { html } = await mount({ __slots: { default: '<span class="avatar">CD</span>' } });
+
+    expect(html).toMatch(/<div[^>]*class="avatar-group"/);
+    expect(html).not.toContain("avatar-group--");
+  });
+});

--- a/ui/components/src/components/avatar-group/styled/IAvatarGroup.ink.tsx
+++ b/ui/components/src/components/avatar-group/styled/IAvatarGroup.ink.tsx
@@ -1,0 +1,25 @@
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+import IAvatarGroupBase, { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase.ink.tsx";
+import {
+  avatarGroupRecipe,
+  type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+} from "virtual:styleframe";
+
+export interface AvatarGroupProps extends AvatarGroupBaseProps, AvatarGroupStylingProps {}
+
+/**
+ * The styled Avatar group: lays out its child avatars in an overlapping stack. `size` tunes the
+ * overlap spacing only — it does not cascade to the child avatars, so set each avatar's own `size`
+ * to match.
+ */
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: AvatarGroupProps) => {
+    const className = createMemo(() => avatarGroupRecipe({ size: props.size }));
+    return (
+      <IAvatarGroupBase class={className()}>
+        <Slot />
+      </IAvatarGroupBase>
+    );
+  },
+);

--- a/ui/components/src/components/avatar-group/styled/IAvatarGroup.ink.tsx
+++ b/ui/components/src/components/avatar-group/styled/IAvatarGroup.ink.tsx
@@ -5,7 +5,13 @@ import {
   type AvatarGroupRecipeProps as AvatarGroupStylingProps,
 } from "virtual:styleframe";
 
-export interface AvatarGroupProps extends AvatarGroupBaseProps, AvatarGroupStylingProps {}
+// `size` is declared directly (indexed off the recipe's type) rather than via `extends
+// AvatarGroupStylingProps`: the compiler only enumerates members of a directly-named interface, so a
+// single inherited styling prop would otherwise not be tracked (its memo would report INK0011).
+export interface AvatarGroupProps extends AvatarGroupBaseProps {
+  /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+  size?: AvatarGroupStylingProps["size"];
+}
 
 /**
  * The styled Avatar group: lays out its child avatars in an overlapping stack. `size` tunes the

--- a/ui/components/src/components/avatar-group/styled/IAvatarGroup.styleframe.ts
+++ b/ui/components/src/components/avatar-group/styled/IAvatarGroup.styleframe.ts
@@ -1,0 +1,6 @@
+import { styleframe } from "virtual:styleframe";
+import { useAvatarGroupRecipe } from "@styleframe/theme";
+
+const s = styleframe();
+
+export const avatarGroupRecipe = useAvatarGroupRecipe(s);

--- a/ui/components/src/components/avatar-group/styled/__snapshots__/IAvatarGroup.ink.test.ts.snap
+++ b/ui/components/src/components/avatar-group/styled/__snapshots__/IAvatarGroup.ink.test.ts.snap
@@ -1,0 +1,159 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IAvatarGroup (styled) > output matches snapshots 1`] = `
+{
+  "angular/IAvatarGroup.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+import { IAvatarGroupBaseComponent as IAvatarGroupBase } from "../headless/IAvatarGroupBase.component";
+import { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase.component";
+import {
+  avatarGroupRecipe,
+  type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+} from "virtual:styleframe";
+export interface AvatarGroupProps extends AvatarGroupBaseProps {
+  /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+  size?: AvatarGroupStylingProps["size"];
+}
+@Component({ standalone: true, selector: 'ink-avatar-group', host: { style: 'display: contents' }, imports: [IAvatarGroupBase], template: \`<ink-avatar-group-base [klass]="(className()) + (klass() ? ' ' + klass() : '')">
+<ng-content></ng-content>
+</ink-avatar-group-base>\` })
+export class IAvatarGroupComponent
+{
+avatarGroupRecipe = avatarGroupRecipe
+klass = input<string>()
+className = computed(() => avatarGroupRecipe({ size: this.size() }))
+size = input<AvatarGroupStylingProps["size"]>()
+}
+@Component({ standalone: true, selector: 'div[ink-avatar-group]', host: { '[class]': "'avatar-group' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')", 'ink-avatar-group-base': '' }, template: \`<ng-content></ng-content>\` })
+export class IAvatarGroupHostComponent
+{
+avatarGroupRecipe = avatarGroupRecipe
+klass = input<string>()
+className = computed(() => avatarGroupRecipe({ size: this.size() }))
+size = input<AvatarGroupStylingProps["size"]>()
+}
+",
+  "astro/IAvatarGroup.astro": "---
+import IAvatarGroupBase, { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase.astro";
+import {
+  avatarGroupRecipe,
+  type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+} from "virtual:styleframe";
+export interface AvatarGroupProps extends AvatarGroupBaseProps {
+  /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+  size?: AvatarGroupStylingProps["size"];
+}
+type Props = AvatarGroupProps & Record<string, any>
+const props = Astro.props as Props;
+const { size, ...__attrs } = props;
+const className = avatarGroupRecipe({ size: size })
+---
+<IAvatarGroupBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")}>
+<slot />
+</IAvatarGroupBase>
+",
+  "qwik/IAvatarGroup.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+import { IAvatarGroupBase } from "../headless/IAvatarGroupBase";
+import { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase";
+import {
+  avatarGroupRecipe,
+  type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+} from "virtual:styleframe";
+export interface AvatarGroupProps extends AvatarGroupBaseProps {
+  /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+  size?: AvatarGroupStylingProps["size"];
+}
+export const IAvatarGroup = component$((props: AvatarGroupProps & Record<string, any>) =>
+{
+const className = useComputed$(() => avatarGroupRecipe({ size: props.size }))
+const { children, size, ...__attrs } = props
+return (
+<IAvatarGroupBase {...__attrs} class={[className.value, props.class].filter(Boolean).join(" ")}>
+  <Slot />
+</IAvatarGroupBase>
+)
+});
+",
+  "react/IAvatarGroup.tsx": "import { useMemo } from "react";
+import { IAvatarGroupBase } from "../headless/IAvatarGroupBase";
+import { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase";
+import {
+  avatarGroupRecipe,
+  type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+} from "virtual:styleframe";
+export interface AvatarGroupProps extends AvatarGroupBaseProps {
+  /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+  size?: AvatarGroupStylingProps["size"];
+}
+export function IAvatarGroup(props: AvatarGroupProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const className = useMemo(() => avatarGroupRecipe({ size: props.size }), [props.size])
+const { children, size, ...__attrs } = props
+return (
+<IAvatarGroupBase {...__attrs} className={[className, props.className].filter(Boolean).join(" ")}>
+  {props.children}
+</IAvatarGroupBase>
+)
+}
+",
+  "solid/IAvatarGroup.tsx": "import { createMemo, splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+import IAvatarGroupBase, { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase";
+import {
+  avatarGroupRecipe,
+  type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+} from "virtual:styleframe";
+export interface AvatarGroupProps extends AvatarGroupBaseProps {
+  /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+  size?: AvatarGroupStylingProps["size"];
+}
+export default function IAvatarGroup(props: AvatarGroupProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const className = createMemo(() => avatarGroupRecipe({ size: props.size }))
+const [, __attrs] = splitProps(props, ["children", "size"])
+return (
+<IAvatarGroupBase {...__attrs} class={[className(), props.class].filter(Boolean).join(" ")}>
+  {props.children}
+</IAvatarGroupBase>
+)
+}
+",
+  "svelte/IAvatarGroup.svelte": "<script lang="ts">
+  import IAvatarGroupBase, { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase.svelte";
+  import {
+    avatarGroupRecipe,
+    type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+  } from "virtual:styleframe";
+  export interface AvatarGroupProps extends AvatarGroupBaseProps {
+    /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+    size?: AvatarGroupStylingProps["size"];
+  }
+  import type { Snippet } from "svelte";
+  let { size, children, ...__attrs }: AvatarGroupProps & { children?: Snippet } & Record<string, any> = $props()
+  let className = $derived(avatarGroupRecipe({ size: size }))
+</script>
+<IAvatarGroupBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")}>
+  {@render children?.()}
+</IAvatarGroupBase>
+",
+  "vue/IAvatarGroup.vue": "<script setup lang="ts">
+  import { computed } from "vue";
+  import IAvatarGroupBase, { type AvatarGroupBaseProps } from "../headless/IAvatarGroupBase.vue";
+  import {
+    avatarGroupRecipe,
+    type AvatarGroupRecipeProps as AvatarGroupStylingProps,
+  } from "virtual:styleframe";
+  export interface AvatarGroupProps extends AvatarGroupBaseProps {
+    /** Overlap spacing between avatars; does not cascade to the children — set each avatar's own size. */
+    size?: AvatarGroupStylingProps["size"];
+  }
+  const props = defineProps<AvatarGroupProps>()
+  const className = computed(() => avatarGroupRecipe({ size: props.size }))
+</script>
+<template>
+<IAvatarGroupBase :class="className">
+  <slot />
+</IAvatarGroupBase>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/avatar/headless/IAvatarBadgeBase.ink.test.ts
+++ b/ui/components/src/components/avatar/headless/IAvatarBadgeBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const AVATAR_BADGE_BASE = resolveComponent(import.meta.url, "./IAvatarBadgeBase.ink.tsx");
+
+describe("AvatarBadgeBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(AVATAR_BADGE_BASE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(AVATAR_BADGE_BASE));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(AVATAR_BADGE_BASE));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(AVATAR_BADGE_BASE));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(AVATAR_BADGE_BASE))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/avatar/headless/IAvatarBadgeBase.ink.tsx
+++ b/ui/components/src/components/avatar/headless/IAvatarBadgeBase.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface AvatarBadgeBaseProps {}
+
+// The status-indicator dot overlaid on an avatar. Empty by default (a coloured dot); custom content
+// can be projected via the default slot. The dot is purely visual, so the styled Avatar marks it
+// `aria-hidden` — pair status with visible text, or project an accessible indicator here.
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: AvatarBadgeBaseProps) => {
+    return (
+      <span class="avatar-badge">
+        <Slot />
+      </span>
+    );
+  },
+);

--- a/ui/components/src/components/avatar/headless/IAvatarBase.ink.test.ts
+++ b/ui/components/src/components/avatar/headless/IAvatarBase.ink.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const AVATAR_BASE = resolveComponent(import.meta.url, "./IAvatarBase.ink.tsx");
+
+describe("AvatarBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(AVATAR_BASE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics", async () => {
+    expectNoDiagnostics(await compileComponent(AVATAR_BASE));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(AVATAR_BASE));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(AVATAR_BASE));
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(AVATAR_BASE))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/avatar/headless/IAvatarBase.ink.tsx
+++ b/ui/components/src/components/avatar/headless/IAvatarBase.ink.tsx
@@ -23,7 +23,8 @@ export default defineComponent(
     return (
       <div class="avatar">
         <Show when={!!props.src} fallback={<Slot>{props.label}</Slot>}>
-          <img src={props.src ?? ""} alt={props.alt ?? ""} />
+          {/* `src` is guarded truthy by the Show; `alt` is independent, so coalesce it for Solid. */}
+          <img src={props.src} alt={props.alt ?? ""} />
         </Show>
         <Show when={!!props.showBadge}>
           <Slot name="badge" />

--- a/ui/components/src/components/avatar/headless/IAvatarBase.ink.tsx
+++ b/ui/components/src/components/avatar/headless/IAvatarBase.ink.tsx
@@ -1,0 +1,34 @@
+import { defineComponent, Slot, Show } from "@inkline/core";
+
+export interface AvatarBaseProps {
+  /** Image URL. When absent, the `label` / default-slot fallback shows instead. */
+  src?: string;
+  /**
+   * Alternative text for the image. Empty by default (decorative — the common case when a visible
+   * username sits beside the avatar); set it when the avatar is the only representation of the user.
+   */
+  alt?: string;
+  /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+  label?: string;
+  /** Renders the `badge` slot as a status overlay. */
+  showBadge?: boolean;
+}
+
+export default defineComponent(
+  {
+    meta: { headless: true },
+    slots: { default: {}, badge: {} },
+  },
+  (props: AvatarBaseProps) => {
+    return (
+      <div class="avatar">
+        <Show when={!!props.src} fallback={<Slot>{props.label}</Slot>}>
+          <img src={props.src ?? ""} alt={props.alt ?? ""} />
+        </Show>
+        <Show when={!!props.showBadge}>
+          <Slot name="badge" />
+        </Show>
+      </div>
+    );
+  },
+);

--- a/ui/components/src/components/avatar/headless/__snapshots__/IAvatarBadgeBase.ink.test.ts.snap
+++ b/ui/components/src/components/avatar/headless/__snapshots__/IAvatarBadgeBase.ink.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AvatarBadgeBase > output matches snapshots 1`] = `
+{
+  "angular/IAvatarBadgeBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface AvatarBadgeBaseProps {}
+@Component({ standalone: true, selector: 'ink-avatar-badge-base', host: { style: 'display: contents' }, template: \`<span [class]="'avatar-badge' + (klass() ? ' ' + klass() : '')">
+<ng-content></ng-content>
+</span>\` })
+export class IAvatarBadgeBaseComponent
+{
+klass = input<string>()
+}
+@Component({ standalone: true, selector: 'span[ink-avatar-badge-base]', host: { '[class]': "'avatar-badge' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content></ng-content>\` })
+export class IAvatarBadgeBaseHostComponent
+{
+klass = input<string>()
+}
+",
+  "astro/IAvatarBadgeBase.astro": "---
+export interface AvatarBadgeBaseProps {}
+type Props = AvatarBadgeBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+---
+<span {...__attrs} class={["avatar-badge", __attrs.class].filter(Boolean).join(" ")}>
+<slot />
+</span>
+",
+  "qwik/IAvatarBadgeBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface AvatarBadgeBaseProps {}
+export const IAvatarBadgeBase = component$((props) =>
+{
+const { children, ...__attrs } = props
+return (
+<span {...__attrs} class={["avatar-badge", props.class].filter(Boolean).join(" ")}>
+  <Slot />
+</span>
+)
+});
+",
+  "react/IAvatarBadgeBase.tsx": "export interface AvatarBadgeBaseProps {}
+export function IAvatarBadgeBase(props: AvatarBadgeBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, ...__attrs } = props
+return (
+<span {...__attrs} className={["avatar-badge", props.className].filter(Boolean).join(" ")}>
+  {props.children}
+</span>
+)
+}
+",
+  "solid/IAvatarBadgeBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface AvatarBadgeBaseProps {}
+export default function IAvatarBadgeBase(props: AvatarBadgeBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children"])
+return (
+<span {...__attrs} class={["avatar-badge", props.class].filter(Boolean).join(" ")}>
+  {props.children}
+</span>
+)
+}
+",
+  "svelte/IAvatarBadgeBase.svelte": "<script lang="ts">
+  export interface AvatarBadgeBaseProps {}
+  import type { Snippet } from "svelte";
+  let { children, ...__attrs }: AvatarBadgeBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<span {...__attrs} class={["avatar-badge", __attrs.class].filter(Boolean).join(" ")}>
+  {@render children?.()}
+</span>
+",
+  "vue/IAvatarBadgeBase.vue": "<script setup lang="ts">
+  export interface AvatarBadgeBaseProps {}
+  const props = defineProps<AvatarBadgeBaseProps>()
+</script>
+<template>
+<span class="avatar-badge">
+  <slot />
+</span>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/avatar/headless/__snapshots__/IAvatarBase.ink.test.ts.snap
+++ b/ui/components/src/components/avatar/headless/__snapshots__/IAvatarBase.ink.test.ts.snap
@@ -1,0 +1,201 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AvatarBase > output matches snapshots 1`] = `
+{
+  "angular/IAvatarBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface AvatarBaseProps {
+  /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+  src?: string;
+  /**
+   * Alternative text for the image. Empty by default (decorative — the common case when a visible
+   * username sits beside the avatar); set it when the avatar is the only representation of the user.
+   */
+  alt?: string;
+  /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+  label?: string;
+  /** Renders the \`badge\` slot as a status overlay. */
+  showBadge?: boolean;
+}
+@Component({ standalone: true, selector: 'ink-avatar-base', host: { style: 'display: contents' }, template: \`<div [class]="'avatar' + (klass() ? ' ' + klass() : '')">
+@if (!!src()) {
+<img [attr.src]="(src()) ?? null" [attr.alt]="(alt() ?? '') ?? null" />
+} @else {
+<ng-content>{{ label() }}</ng-content>
+}
+@if (!!showBadge()) {
+<ng-content select="[slot=badge]"></ng-content>
+}
+</div>\` })
+export class IAvatarBaseComponent
+{
+klass = input<string>()
+src = input<string>()
+alt = input<string>()
+label = input<string>()
+showBadge = input<boolean>()
+}
+@Component({ standalone: true, selector: 'div[ink-avatar-base]', host: { '[class]': "'avatar' + (klass() ? ' ' + klass() : '')" }, template: \`@if (!!src()) {
+<img [attr.src]="(src()) ?? null" [attr.alt]="(alt() ?? '') ?? null" />
+} @else {
+<ng-content>{{ label() }}</ng-content>
+}
+@if (!!showBadge()) {
+<ng-content select="[slot=badge]"></ng-content>
+}\` })
+export class IAvatarBaseHostComponent
+{
+klass = input<string>()
+src = input<string>()
+alt = input<string>()
+label = input<string>()
+showBadge = input<boolean>()
+}
+",
+  "astro/IAvatarBase.astro": "---
+export interface AvatarBaseProps {
+  /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+  src?: string;
+  /**
+   * Alternative text for the image. Empty by default (decorative — the common case when a visible
+   * username sits beside the avatar); set it when the avatar is the only representation of the user.
+   */
+  alt?: string;
+  /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+  label?: string;
+  /** Renders the \`badge\` slot as a status overlay. */
+  showBadge?: boolean;
+}
+type Props = AvatarBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { src, alt, label, showBadge, ...__attrs } = props;
+---
+<div {...__attrs} class={["avatar", __attrs.class].filter(Boolean).join(" ")}>{!!src ? (<img src={src} alt={alt ?? ""} />) : (<slot>
+{label}
+</slot>)}{!!showBadge ? (<slot name="badge" />) : null}</div>
+",
+  "qwik/IAvatarBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface AvatarBaseProps {
+  /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+  src?: string;
+  /**
+   * Alternative text for the image. Empty by default (decorative — the common case when a visible
+   * username sits beside the avatar); set it when the avatar is the only representation of the user.
+   */
+  alt?: string;
+  /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+  label?: string;
+  /** Renders the \`badge\` slot as a status overlay. */
+  showBadge?: boolean;
+}
+export const IAvatarBase = component$((props: AvatarBaseProps & Record<string, any>) =>
+{
+const { children, badge, src, alt, label, showBadge, ...__attrs } = props
+return (
+<div {...__attrs} class={["avatar", props.class].filter(Boolean).join(" ")}>
+  {!!props.src ? (<><img src={props.src} alt={props.alt ?? ""} /></>) : (<><Slot>{props.label}</Slot></>)}
+  {!!props.showBadge ? (<>{props.badge}</>) : null}
+</div>
+)
+});
+",
+  "react/IAvatarBase.tsx": "export interface AvatarBaseProps {
+  /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+  src?: string;
+  /**
+   * Alternative text for the image. Empty by default (decorative — the common case when a visible
+   * username sits beside the avatar); set it when the avatar is the only representation of the user.
+   */
+  alt?: string;
+  /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+  label?: string;
+  /** Renders the \`badge\` slot as a status overlay. */
+  showBadge?: boolean;
+}
+export function IAvatarBase(props: AvatarBaseProps & { children?: React.ReactNode; badge?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, badge, src, alt, label, showBadge, ...__attrs } = props
+return (
+<div {...__attrs} className={["avatar", props.className].filter(Boolean).join(" ")}>
+  {!!props.src ? <img src={props.src} alt={props.alt ?? ""} /> : props.children ?? props.label}
+  {!!props.showBadge ? props.badge : null}
+</div>
+)
+}
+",
+  "solid/IAvatarBase.tsx": "import { splitProps, Show } from "solid-js";
+import type { JSX } from "solid-js";
+export interface AvatarBaseProps {
+  /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+  src?: string;
+  /**
+   * Alternative text for the image. Empty by default (decorative — the common case when a visible
+   * username sits beside the avatar); set it when the avatar is the only representation of the user.
+   */
+  alt?: string;
+  /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+  label?: string;
+  /** Renders the \`badge\` slot as a status overlay. */
+  showBadge?: boolean;
+}
+export default function IAvatarBase(props: AvatarBaseProps & { children?: any; badge?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children", "badge", "src", "alt", "label", "showBadge"])
+return (
+<div {...__attrs} class={["avatar", props.class].filter(Boolean).join(" ")}>
+  <Show when={!!props.src} fallback={<>{props.children ?? props.label}</>}>
+    <img src={props.src} alt={props.alt ?? ""} />
+  </Show>
+  <Show when={!!props.showBadge}>
+    {props.badge}
+  </Show>
+</div>
+)
+}
+",
+  "svelte/IAvatarBase.svelte": "<script lang="ts">
+  export interface AvatarBaseProps {
+    /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+    src?: string;
+    /**
+     * Alternative text for the image. Empty by default (decorative — the common case when a visible
+     * username sits beside the avatar); set it when the avatar is the only representation of the user.
+     */
+    alt?: string;
+    /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+    label?: string;
+    /** Renders the \`badge\` slot as a status overlay. */
+    showBadge?: boolean;
+  }
+  import type { Snippet } from "svelte";
+  let { src, alt, label, showBadge, children, badge: badgeSnippet, ...__attrs }: AvatarBaseProps & { children?: Snippet; badge?: Snippet } & Record<string, any> = $props()
+</script>
+<div {...__attrs} class={["avatar", __attrs.class].filter(Boolean).join(" ")}>{#if !!src}<img src={src} alt={alt ?? ""} />{:else}{#if children}{@render children()}{:else}{label}{/if}{/if}{#if !!showBadge}{@render badgeSnippet?.()}{/if}</div>
+",
+  "vue/IAvatarBase.vue": "<script setup lang="ts">
+  export interface AvatarBaseProps {
+    /** Image URL. When absent, the \`label\` / default-slot fallback shows instead. */
+    src?: string;
+    /**
+     * Alternative text for the image. Empty by default (decorative — the common case when a visible
+     * username sits beside the avatar); set it when the avatar is the only representation of the user.
+     */
+    alt?: string;
+    /** Fallback text, typically initials, shown when there is no image. Overridden by the default slot. */
+    label?: string;
+    /** Renders the \`badge\` slot as a status overlay. */
+    showBadge?: boolean;
+  }
+  const props = defineProps<AvatarBaseProps>()
+</script>
+<template>
+<div class="avatar">
+  <img v-if="!!src" :src="src" :alt='alt ?? ""' />
+  <slot v-else>
+    {{ label }}
+  </slot>
+  <slot v-if="!!showBadge" name="badge" />
+</div>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/avatar/stories/AvatarBadges.ink.tsx
+++ b/ui/components/src/components/avatar/stories/AvatarBadges.ink.tsx
@@ -1,0 +1,13 @@
+import { defineComponent } from "@inkline/core";
+import IAvatar from "../styled/IAvatar.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatar label="ON" badge={true} badgeColor="success" badgePosition="bottom-right" />
+      <IAvatar label="AW" badge={true} badgeColor="warning" badgePosition="top-right" />
+      <IAvatar label="BZ" badge={true} badgeColor="error" badgePosition="top-left" />
+      <IAvatar label="OF" badge={true} badgeColor="neutral" badgePosition="bottom-left" />
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar/stories/AvatarColors.ink.tsx
+++ b/ui/components/src/components/avatar/stories/AvatarColors.ink.tsx
@@ -1,0 +1,13 @@
+import { defineComponent } from "@inkline/core";
+import IAvatar from "../styled/IAvatar.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatar color="primary" label="PR" />
+      <IAvatar color="light" label="LI" />
+      <IAvatar color="dark" label="DA" />
+      <IAvatar color="neutral" label="NE" />
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar/stories/AvatarImage.ink.tsx
+++ b/ui/components/src/components/avatar/stories/AvatarImage.ink.tsx
@@ -1,0 +1,26 @@
+import { defineComponent } from "@inkline/core";
+import IAvatar from "../styled/IAvatar.ink.tsx";
+
+// Inline SVG data URIs (no network) so the story renders identically across every target.
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatar
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48'%3E%3Crect width='48' height='48' fill='%236366f1'/%3E%3Ccircle cx='24' cy='19' r='9' fill='white'/%3E%3Cpath d='M8 42c0-9 7-14 16-14s16 5 16 14z' fill='white'/%3E%3C/svg%3E"
+        alt="Ada Lovelace"
+      />
+      <IAvatar
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48'%3E%3Crect width='48' height='48' fill='%2310b981'/%3E%3Ccircle cx='24' cy='19' r='9' fill='white'/%3E%3Cpath d='M8 42c0-9 7-14 16-14s16 5 16 14z' fill='white'/%3E%3C/svg%3E"
+        alt="Grace Hopper"
+        shape="square"
+      />
+      <IAvatar
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48'%3E%3Crect width='48' height='48' fill='%23f59e0b'/%3E%3Ccircle cx='24' cy='19' r='9' fill='white'/%3E%3Cpath d='M8 42c0-9 7-14 16-14s16 5 16 14z' fill='white'/%3E%3C/svg%3E"
+        alt="Alan Turing"
+        size="lg"
+        badge={true}
+        badgeColor="success"
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar/stories/AvatarShapes.ink.tsx
+++ b/ui/components/src/components/avatar/stories/AvatarShapes.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+import IAvatar from "../styled/IAvatar.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatar shape="circle" label="CI" />
+      <IAvatar shape="square" label="SQ" />
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar/stories/AvatarSizes.ink.tsx
+++ b/ui/components/src/components/avatar/stories/AvatarSizes.ink.tsx
@@ -1,0 +1,14 @@
+import { defineComponent } from "@inkline/core";
+import IAvatar from "../styled/IAvatar.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatar size="xs" label="XS" />
+      <IAvatar size="sm" label="SM" />
+      <IAvatar size="md" label="MD" />
+      <IAvatar size="lg" label="LG" />
+      <IAvatar size="xl" label="XL" />
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar/stories/AvatarVariants.ink.tsx
+++ b/ui/components/src/components/avatar/stories/AvatarVariants.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+import IAvatar from "../styled/IAvatar.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IAvatar variant="solid" color="primary" label="SO" />
+      <IAvatar variant="soft" color="primary" label="SF" />
+    </div>
+  );
+});

--- a/ui/components/src/components/avatar/stories/IAvatar.ink.stories.ts
+++ b/ui/components/src/components/avatar/stories/IAvatar.ink.stories.ts
@@ -1,0 +1,60 @@
+import { defineStories } from "@inkline/storybook";
+import type { AvatarProps } from "../styled/IAvatar.ink.tsx";
+
+const meta = defineStories<AvatarProps>({
+  component: "IAvatar",
+  title: "Components/Data Display/Avatar",
+  args: {
+    label: "JD",
+  },
+  argTypes: {
+    src: { control: "text", description: "Image URL; falls back to the label when absent" },
+    alt: { control: "text", description: "Alternative text for the image" },
+    label: { control: "text", description: "Fallback text, typically initials" },
+    color: {
+      control: "select",
+      options: ["primary", "light", "dark", "neutral"],
+      description: "Color variant",
+    },
+    variant: { control: "select", options: ["solid", "soft"], description: "Style variant" },
+    shape: { control: "select", options: ["circle", "square"], description: "Shape variant" },
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "Size variant",
+    },
+    badge: { control: "boolean", description: "Show a status-indicator dot" },
+    badgeColor: {
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "error",
+        "light",
+        "dark",
+        "neutral",
+      ],
+      description: "Color of the status badge",
+    },
+    badgePosition: {
+      control: "select",
+      options: ["top-left", "top-right", "bottom-left", "bottom-right"],
+      description: "Corner the status badge sits in",
+    },
+  },
+});
+
+export default meta;
+
+export const Default = {};
+export const WithBadge = { args: { badge: true, badgeColor: "success" } };
+export const Square = { args: { shape: "square" } };
+export const Colors = { render: "./AvatarColors.ink.tsx" };
+export const Variants = { render: "./AvatarVariants.ink.tsx" };
+export const Shapes = { render: "./AvatarShapes.ink.tsx" };
+export const Sizes = { render: "./AvatarSizes.ink.tsx" };
+export const Image = { render: "./AvatarImage.ink.tsx" };
+export const Badges = { render: "./AvatarBadges.ink.tsx" };

--- a/ui/components/src/components/avatar/styled/IAvatar.ink.test.ts
+++ b/ui/components/src/components/avatar/styled/IAvatar.ink.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectNoDiagnostics,
+  expectOutputContains,
+  expectImports,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+  type ComponentTestResult,
+  type TargetName,
+} from "@inkline/test-utils";
+import { mountStyledOnAngular } from "../../angular-ssr-helper.ts";
+
+const IAVATAR = resolveComponent(import.meta.url, "./IAvatar.ink.tsx");
+
+const out = (result: ComponentTestResult, target: TargetName) => result.files[target] ?? [];
+
+// A deterministic inline portrait (no network) for the image branch.
+const PORTRAIT =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='40' height='40' fill='%236366f1'/%3E%3C/svg%3E";
+
+describe("IAvatar (styled)", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(IAVATAR);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("produces zero diagnostics (no two-way, no hasSlot gating)", async () => {
+    expectNoDiagnostics(await compileComponent(IAVATAR));
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(IAVATAR));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(IAVATAR));
+  });
+
+  it("composes the base and the status-badge part", async () => {
+    const result = await compileComponent(IAVATAR);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      expectOutputContains(out(result, target), "IAvatarBase");
+      expectOutputContains(out(result, target), "IAvatarBadgeBase");
+    }
+  });
+
+  it("pulls both avatar recipes from virtual:styleframe", async () => {
+    const result = await compileComponent(IAVATAR);
+    for (const target of ["react", "vue", "solid"] as const) {
+      expectImports(out(result, target), "virtual:styleframe", [
+        "avatarRecipe",
+        "avatarBadgeRecipe",
+      ]);
+    }
+  });
+
+  it("gates the badge via showBadge, filling the badge slot with a plain element", async () => {
+    const result = await compileComponent(IAVATAR);
+    // React/Solid/Qwik: showBadge prop forwarded; the badge is a plain node-prop fill (no conditional
+    // in attribute position — that would miscompile on React/Qwik).
+    expectOutputContains(out(result, "react"), "showBadge={props.badge}");
+    expectOutputContains(out(result, "solid"), "showBadge={props.badge}");
+    expectOutputContains(out(result, "qwik"), "showBadge={props.badge}");
+    // Vue: bound showBadge + a named `#badge` slot fill.
+    expectOutputContains(out(result, "vue"), ":showBadge");
+    expectOutputContains(out(result, "vue"), "#badge");
+    // Angular: showBadge input + projected [slot=badge] content.
+    expectOutputContains(out(result, "angular"), '[showBadge]="badge()"');
+    expectOutputContains(out(result, "angular"), 'slot="badge"');
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(IAVATAR))).toMatchSnapshot();
+  });
+});
+
+// Real-DOM verification on the Angular target (SSR via @angular/platform-server). These mounts also
+// drive the .ink.tsx coverage remap (React) for IAvatar + its headless parts.
+describe("IAvatar (styled) on Angular SSR", () => {
+  const HEADLESS = ["../headless/IAvatarBase.ink.tsx", "../headless/IAvatarBadgeBase.ink.tsx"];
+
+  const mount = (props?: Record<string, unknown>) =>
+    mountStyledOnAngular(import.meta.url, "./IAvatar.ink.tsx", HEADLESS, props);
+
+  it("renders the initials fallback with the recipe classes when there is no image", async () => {
+    const { html } = await mount({
+      label: "JD",
+      color: "primary",
+      variant: "soft",
+      shape: "circle",
+      size: "md",
+    });
+
+    expect(html).toMatch(/<div[^>]*class="avatar[^"]*"/);
+    expect(html).toContain("avatar--color-primary");
+    expect(html).toContain("avatar--variant-soft");
+    expect(html).toContain("avatar--shape-circle");
+    expect(html).toContain("avatar--size-md");
+    expect(html).toContain("JD");
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("avatar-badge");
+  });
+
+  it("renders the image (with alt) instead of the initials when a src is set", async () => {
+    const { html } = await mount({ src: PORTRAIT, alt: "Ada Lovelace", label: "AL" });
+
+    expect(html).toMatch(/<img[^>]*src="data:image\/svg/);
+    expect(html).toMatch(/<img[^>]*alt="Ada Lovelace"/);
+    expect(html).not.toContain("AL");
+  });
+
+  it("renders an empty alt when the image has no alt (Solid-safe coalesce)", async () => {
+    const { html } = await mount({ src: PORTRAIT });
+
+    expect(html).toMatch(/<img[^>]*alt=""/);
+  });
+
+  it("renders the status-badge dot with its recipe classes when badge is set", async () => {
+    const { html } = await mount({
+      label: "ON",
+      badge: true,
+      badgeColor: "success",
+      badgePosition: "top-right",
+      size: "lg",
+    });
+
+    expect(html).toMatch(/<span[^>]*class="avatar-badge[^"]*"/);
+    expect(html).toContain("avatar-badge--color-success");
+    expect(html).toContain("avatar-badge--position-top-right");
+    expect(html).toContain("avatar-badge--size-lg");
+    // aria-hidden falls through to the badge part's host (the element-selector wrapper), not the
+    // inner <span> — assert its presence without pinning it to a specific element.
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("projects custom fallback content in place of the label", async () => {
+    const { html } = await mount({ label: "JD", __slots: { default: "<em>ZZ</em>" } });
+
+    expect(html).toContain("<em>ZZ</em>");
+    expect(html).not.toContain("JD");
+  });
+
+  // The collapsed host variant inlines the composite onto the real <div>: zero display:contents
+  // wrapper elements, both ink-* attributes present, recipe classes merged directly.
+  it("host variant renders a zero-wrapper avatar shell", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./IAvatar.ink.tsx",
+      HEADLESS,
+      { label: "JD", color: "primary", size: "md" },
+      "IAvatarHostComponent",
+    );
+
+    expect(html).toMatch(/<div[^>]*ink-avatar[^>]*class="avatar[^"]*avatar--color-primary/);
+    expect(html).toContain("ink-avatar-base");
+    expect(html).toContain("JD");
+    expect(html).not.toContain("<ink-avatar"); // no display:contents wrapper elements anywhere
+  });
+});

--- a/ui/components/src/components/avatar/styled/IAvatar.ink.tsx
+++ b/ui/components/src/components/avatar/styled/IAvatar.ink.tsx
@@ -1,0 +1,67 @@
+import { defineComponent, Slot, createMemo } from "@inkline/core";
+import IAvatarBase, { type AvatarBaseProps } from "../headless/IAvatarBase.ink.tsx";
+import IAvatarBadgeBase from "../headless/IAvatarBadgeBase.ink.tsx";
+import {
+  avatarRecipe,
+  avatarBadgeRecipe,
+  type AvatarRecipeProps as AvatarStylingProps,
+  type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+} from "virtual:styleframe";
+
+export interface AvatarProps extends AvatarBaseProps {
+  /** Color variant. */
+  color?: AvatarStylingProps["color"];
+  /** Style variant. */
+  variant?: AvatarStylingProps["variant"];
+  /** Shape variant. */
+  shape?: AvatarStylingProps["shape"];
+  /** Size variant; also sizes the status badge. */
+  size?: AvatarStylingProps["size"];
+  /** Shows a status-indicator dot overlaid on the avatar. */
+  badge?: boolean;
+  /** Color of the status badge. */
+  badgeColor?: AvatarBadgeStylingProps["color"];
+  /** Corner the status badge sits in. */
+  badgePosition?: AvatarBadgeStylingProps["position"];
+}
+
+/**
+ * The styled Avatar: an image with an automatic text (initials) fallback and an optional status-dot
+ * overlay. The badge is gated by the `badge` prop (a real conditional on every target — no runtime
+ * slot presence needed), so an avatar without a badge renders no overlay element at all.
+ */
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: AvatarProps) => {
+    const className = createMemo(() =>
+      avatarRecipe({
+        color: props.color,
+        variant: props.variant,
+        shape: props.shape,
+        size: props.size,
+      }),
+    );
+
+    const badgeClassName = createMemo(() =>
+      avatarBadgeRecipe({
+        color: props.badgeColor,
+        position: props.badgePosition,
+        size: props.size,
+      }),
+    );
+
+    // The badge is a plain node-prop fill (never a conditional in attribute position — that miscompiles
+    // on React/Qwik); IAvatarBase gates whether it renders via `showBadge`, in child position.
+    return (
+      <IAvatarBase
+        class={className()}
+        src={props.src}
+        alt={props.alt}
+        showBadge={props.badge}
+        badge={<IAvatarBadgeBase class={badgeClassName()} aria-hidden="true" />}
+      >
+        <Slot>{props.label}</Slot>
+      </IAvatarBase>
+    );
+  },
+);

--- a/ui/components/src/components/avatar/styled/IAvatar.styleframe.ts
+++ b/ui/components/src/components/avatar/styled/IAvatar.styleframe.ts
@@ -1,0 +1,11 @@
+import { styleframe } from "virtual:styleframe";
+import { useAvatarRecipe, useAvatarBadgeRecipe } from "@styleframe/theme";
+
+const s = styleframe();
+
+// Both Avatar-family recipes are registered here (the single styled IAvatar consumes both), so
+// `virtual:styleframe` exports each recipe and emits its `.avatar` / `.avatar-badge` rules. The theme
+// already ships the `.avatar > img` cover rules and the badge's absolute positioning — no local CSS,
+// and no `:empty` collapse (the badge is prop-gated, so an empty wrapper is never rendered).
+export const avatarRecipe = useAvatarRecipe(s);
+export const avatarBadgeRecipe = useAvatarBadgeRecipe(s);

--- a/ui/components/src/components/avatar/styled/__snapshots__/IAvatar.ink.test.ts.snap
+++ b/ui/components/src/components/avatar/styled/__snapshots__/IAvatar.ink.test.ts.snap
@@ -1,0 +1,320 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IAvatar (styled) > output matches snapshots 1`] = `
+{
+  "angular/IAvatar.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+import { IAvatarBaseComponent as IAvatarBase } from "../headless/IAvatarBase.component";
+import { type AvatarBaseProps } from "../headless/IAvatarBase.component";
+import { IAvatarBadgeBaseComponent as IAvatarBadgeBase } from "../headless/IAvatarBadgeBase.component";
+import { IAvatarBadgeBaseHostComponent } from "../headless/IAvatarBadgeBase.component";
+import {
+  avatarRecipe,
+  avatarBadgeRecipe,
+  type AvatarRecipeProps as AvatarStylingProps,
+  type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+} from "virtual:styleframe";
+export interface AvatarProps extends AvatarBaseProps {
+  /** Color variant. */
+  color?: AvatarStylingProps["color"];
+  /** Style variant. */
+  variant?: AvatarStylingProps["variant"];
+  /** Shape variant. */
+  shape?: AvatarStylingProps["shape"];
+  /** Size variant; also sizes the status badge. */
+  size?: AvatarStylingProps["size"];
+  /** Shows a status-indicator dot overlaid on the avatar. */
+  badge?: boolean;
+  /** Color of the status badge. */
+  badgeColor?: AvatarBadgeStylingProps["color"];
+  /** Corner the status badge sits in. */
+  badgePosition?: AvatarBadgeStylingProps["position"];
+}
+@Component({ standalone: true, selector: 'ink-avatar', host: { style: 'display: contents' }, imports: [IAvatarBase, IAvatarBadgeBase], template: \`<ink-avatar-base [klass]="(className()) + (klass() ? ' ' + klass() : '')" [src]="src()" [alt]="alt()" [showBadge]="badge()">
+<ng-content>{{ label() }}</ng-content>
+<ng-container slot="badge">
+<ink-avatar-badge-base [klass]="(badgeClassName())" aria-hidden="true"></ink-avatar-badge-base>
+</ng-container>
+</ink-avatar-base>\` })
+export class IAvatarComponent
+{
+avatarRecipe = avatarRecipe
+avatarBadgeRecipe = avatarBadgeRecipe
+klass = input<string>()
+className = computed(() => avatarRecipe({ color: this.color(), variant: this.variant(), shape: this.shape(), size: this.size() }))
+badgeClassName = computed(() => avatarBadgeRecipe({ color: this.badgeColor(), position: this.badgePosition(), size: this.size() }))
+color = input<AvatarStylingProps["color"]>()
+variant = input<AvatarStylingProps["variant"]>()
+shape = input<AvatarStylingProps["shape"]>()
+size = input<AvatarStylingProps["size"]>()
+badge = input<boolean>()
+badgeColor = input<AvatarBadgeStylingProps["color"]>()
+badgePosition = input<AvatarBadgeStylingProps["position"]>()
+src = input<string>()
+alt = input<string>()
+label = input<string>()
+showBadge = input<boolean>()
+}
+@Component({ standalone: true, selector: 'div[ink-avatar]', host: { '[class]': "'avatar' + ((className()) ? ' ' + (className()) : '') + (klass() ? ' ' + klass() : '')", 'ink-avatar-base': '' }, imports: [IAvatarBadgeBaseHostComponent], template: \`@if (!!src()) {
+<img [attr.src]="(src()) ?? null" [attr.alt]="(alt() ?? '') ?? null" />
+} @else {
+<ng-content>{{ label() }}</ng-content>
+}
+@if (!!showBadge()) {
+<span ink-avatar-badge-base [klass]="(badgeClassName())" aria-hidden="true"></span>
+}\` })
+export class IAvatarHostComponent
+{
+avatarRecipe = avatarRecipe
+avatarBadgeRecipe = avatarBadgeRecipe
+klass = input<string>()
+className = computed(() => avatarRecipe({ color: this.color(), variant: this.variant(), shape: this.shape(), size: this.size() }))
+badgeClassName = computed(() => avatarBadgeRecipe({ color: this.badgeColor(), position: this.badgePosition(), size: this.size() }))
+color = input<AvatarStylingProps["color"]>()
+variant = input<AvatarStylingProps["variant"]>()
+shape = input<AvatarStylingProps["shape"]>()
+size = input<AvatarStylingProps["size"]>()
+badge = input<boolean>()
+badgeColor = input<AvatarBadgeStylingProps["color"]>()
+badgePosition = input<AvatarBadgeStylingProps["position"]>()
+src = input<string>()
+alt = input<string>()
+label = input<string>()
+showBadge = input<boolean>()
+}
+",
+  "astro/IAvatar.astro": "---
+import IAvatarBase, { type AvatarBaseProps } from "../headless/IAvatarBase.astro";
+import IAvatarBadgeBase from "../headless/IAvatarBadgeBase.astro";
+import {
+  avatarRecipe,
+  avatarBadgeRecipe,
+  type AvatarRecipeProps as AvatarStylingProps,
+  type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+} from "virtual:styleframe";
+export interface AvatarProps extends AvatarBaseProps {
+  /** Color variant. */
+  color?: AvatarStylingProps["color"];
+  /** Style variant. */
+  variant?: AvatarStylingProps["variant"];
+  /** Shape variant. */
+  shape?: AvatarStylingProps["shape"];
+  /** Size variant; also sizes the status badge. */
+  size?: AvatarStylingProps["size"];
+  /** Shows a status-indicator dot overlaid on the avatar. */
+  badge?: boolean;
+  /** Color of the status badge. */
+  badgeColor?: AvatarBadgeStylingProps["color"];
+  /** Corner the status badge sits in. */
+  badgePosition?: AvatarBadgeStylingProps["position"];
+}
+type Props = AvatarProps & Record<string, any>
+const props = Astro.props as Props;
+const { color, variant, shape, size, badge, badgeColor, badgePosition, src, alt, label, showBadge, ...__attrs } = props;
+const className = avatarRecipe({ color: color, variant: variant, shape: shape, size: size })
+const badgeClassName = avatarBadgeRecipe({ color: badgeColor, position: badgePosition, size: size })
+---
+<IAvatarBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")} src={src} alt={alt} showBadge={badge}>
+<slot>
+{label}
+</slot>
+<Fragment slot="badge">
+<IAvatarBadgeBase class={badgeClassName} aria-hidden="true" />
+</Fragment>
+</IAvatarBase>
+",
+  "qwik/IAvatar.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+import { IAvatarBase } from "../headless/IAvatarBase";
+import { type AvatarBaseProps } from "../headless/IAvatarBase";
+import { IAvatarBadgeBase } from "../headless/IAvatarBadgeBase";
+import {
+  avatarRecipe,
+  avatarBadgeRecipe,
+  type AvatarRecipeProps as AvatarStylingProps,
+  type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+} from "virtual:styleframe";
+export interface AvatarProps extends AvatarBaseProps {
+  /** Color variant. */
+  color?: AvatarStylingProps["color"];
+  /** Style variant. */
+  variant?: AvatarStylingProps["variant"];
+  /** Shape variant. */
+  shape?: AvatarStylingProps["shape"];
+  /** Size variant; also sizes the status badge. */
+  size?: AvatarStylingProps["size"];
+  /** Shows a status-indicator dot overlaid on the avatar. */
+  badge?: boolean;
+  /** Color of the status badge. */
+  badgeColor?: AvatarBadgeStylingProps["color"];
+  /** Corner the status badge sits in. */
+  badgePosition?: AvatarBadgeStylingProps["position"];
+}
+export const IAvatar = component$((props: AvatarProps & Record<string, any>) =>
+{
+const className = useComputed$(() => avatarRecipe({ color: props.color, variant: props.variant, shape: props.shape, size: props.size }))
+const badgeClassName = useComputed$(() => avatarBadgeRecipe({ color: props.badgeColor, position: props.badgePosition, size: props.size }))
+const { children, color, variant, shape, size, badge, badgeColor, badgePosition, src, alt, label, showBadge, ...__attrs } = props
+return (
+<IAvatarBase {...__attrs} class={[className.value, props.class].filter(Boolean).join(" ")} src={props.src} alt={props.alt} showBadge={props.badge} badge={<IAvatarBadgeBase class={badgeClassName.value} aria-hidden="true" />}>
+  <Slot>
+    {props.label}
+  </Slot>
+</IAvatarBase>
+)
+});
+",
+  "react/IAvatar.tsx": "import { useMemo } from "react";
+import { IAvatarBase } from "../headless/IAvatarBase";
+import { type AvatarBaseProps } from "../headless/IAvatarBase";
+import { IAvatarBadgeBase } from "../headless/IAvatarBadgeBase";
+import {
+  avatarRecipe,
+  avatarBadgeRecipe,
+  type AvatarRecipeProps as AvatarStylingProps,
+  type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+} from "virtual:styleframe";
+export interface AvatarProps extends AvatarBaseProps {
+  /** Color variant. */
+  color?: AvatarStylingProps["color"];
+  /** Style variant. */
+  variant?: AvatarStylingProps["variant"];
+  /** Shape variant. */
+  shape?: AvatarStylingProps["shape"];
+  /** Size variant; also sizes the status badge. */
+  size?: AvatarStylingProps["size"];
+  /** Shows a status-indicator dot overlaid on the avatar. */
+  badge?: boolean;
+  /** Color of the status badge. */
+  badgeColor?: AvatarBadgeStylingProps["color"];
+  /** Corner the status badge sits in. */
+  badgePosition?: AvatarBadgeStylingProps["position"];
+}
+export function IAvatar(props: AvatarProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const className = useMemo(() => avatarRecipe({ color: props.color, variant: props.variant, shape: props.shape, size: props.size }), [props.color, props.variant, props.shape, props.size])
+const badgeClassName = useMemo(() => avatarBadgeRecipe({ color: props.badgeColor, position: props.badgePosition, size: props.size }), [props.badgeColor, props.badgePosition, props.size])
+const { children, color, variant, shape, size, badge, badgeColor, badgePosition, src, alt, label, showBadge, ...__attrs } = props
+return (
+<IAvatarBase {...__attrs} className={[className, props.className].filter(Boolean).join(" ")} src={props.src} alt={props.alt} showBadge={props.badge} badge={<IAvatarBadgeBase className={badgeClassName} aria-hidden="true" />}>
+  {props.children ?? props.label}
+</IAvatarBase>
+)
+}
+",
+  "solid/IAvatar.tsx": "import { createMemo, splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+import IAvatarBase, { type AvatarBaseProps } from "../headless/IAvatarBase";
+import IAvatarBadgeBase from "../headless/IAvatarBadgeBase";
+import {
+  avatarRecipe,
+  avatarBadgeRecipe,
+  type AvatarRecipeProps as AvatarStylingProps,
+  type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+} from "virtual:styleframe";
+export interface AvatarProps extends AvatarBaseProps {
+  /** Color variant. */
+  color?: AvatarStylingProps["color"];
+  /** Style variant. */
+  variant?: AvatarStylingProps["variant"];
+  /** Shape variant. */
+  shape?: AvatarStylingProps["shape"];
+  /** Size variant; also sizes the status badge. */
+  size?: AvatarStylingProps["size"];
+  /** Shows a status-indicator dot overlaid on the avatar. */
+  badge?: boolean;
+  /** Color of the status badge. */
+  badgeColor?: AvatarBadgeStylingProps["color"];
+  /** Corner the status badge sits in. */
+  badgePosition?: AvatarBadgeStylingProps["position"];
+}
+export default function IAvatar(props: AvatarProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const className = createMemo(() => avatarRecipe({ color: props.color, variant: props.variant, shape: props.shape, size: props.size }))
+const badgeClassName = createMemo(() => avatarBadgeRecipe({ color: props.badgeColor, position: props.badgePosition, size: props.size }))
+const [, __attrs] = splitProps(props, ["children", "color", "variant", "shape", "size", "badge", "badgeColor", "badgePosition", "src", "alt", "label", "showBadge"])
+return (
+<IAvatarBase {...__attrs} class={[className(), props.class].filter(Boolean).join(" ")} src={props.src} alt={props.alt} showBadge={props.badge} badge={<IAvatarBadgeBase class={badgeClassName()} aria-hidden="true" />}>
+  {props.children ?? props.label}
+</IAvatarBase>
+)
+}
+",
+  "svelte/IAvatar.svelte": "<script lang="ts">
+  import IAvatarBase, { type AvatarBaseProps } from "../headless/IAvatarBase.svelte";
+  import IAvatarBadgeBase from "../headless/IAvatarBadgeBase.svelte";
+  import {
+    avatarRecipe,
+    avatarBadgeRecipe,
+    type AvatarRecipeProps as AvatarStylingProps,
+    type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+  } from "virtual:styleframe";
+  export interface AvatarProps extends AvatarBaseProps {
+    /** Color variant. */
+    color?: AvatarStylingProps["color"];
+    /** Style variant. */
+    variant?: AvatarStylingProps["variant"];
+    /** Shape variant. */
+    shape?: AvatarStylingProps["shape"];
+    /** Size variant; also sizes the status badge. */
+    size?: AvatarStylingProps["size"];
+    /** Shows a status-indicator dot overlaid on the avatar. */
+    badge?: boolean;
+    /** Color of the status badge. */
+    badgeColor?: AvatarBadgeStylingProps["color"];
+    /** Corner the status badge sits in. */
+    badgePosition?: AvatarBadgeStylingProps["position"];
+  }
+  import type { Snippet } from "svelte";
+  let { color, variant, shape, size, badge, badgeColor, badgePosition, src, alt, label, showBadge, children, ...__attrs }: AvatarProps & { children?: Snippet } & Record<string, any> = $props()
+  let className = $derived(avatarRecipe({ color: color, variant: variant, shape: shape, size: size }))
+  let badgeClassName = $derived(avatarBadgeRecipe({ color: badgeColor, position: badgePosition, size: size }))
+</script>
+<IAvatarBase {...__attrs} class={[className, __attrs.class].filter(Boolean).join(" ")} src={src} alt={alt} showBadge={badge}>
+  {#if children}{@render children()}{:else}{label}{/if}
+  {#snippet badge()}
+  <IAvatarBadgeBase class={badgeClassName} aria-hidden="true" />
+  {/snippet}
+</IAvatarBase>
+",
+  "vue/IAvatar.vue": "<script setup lang="ts">
+  import { computed } from "vue";
+  import IAvatarBase, { type AvatarBaseProps } from "../headless/IAvatarBase.vue";
+  import IAvatarBadgeBase from "../headless/IAvatarBadgeBase.vue";
+  import {
+    avatarRecipe,
+    avatarBadgeRecipe,
+    type AvatarRecipeProps as AvatarStylingProps,
+    type AvatarBadgeRecipeProps as AvatarBadgeStylingProps,
+  } from "virtual:styleframe";
+  export interface AvatarProps extends AvatarBaseProps {
+    /** Color variant. */
+    color?: AvatarStylingProps["color"];
+    /** Style variant. */
+    variant?: AvatarStylingProps["variant"];
+    /** Shape variant. */
+    shape?: AvatarStylingProps["shape"];
+    /** Size variant; also sizes the status badge. */
+    size?: AvatarStylingProps["size"];
+    /** Shows a status-indicator dot overlaid on the avatar. */
+    badge?: boolean;
+    /** Color of the status badge. */
+    badgeColor?: AvatarBadgeStylingProps["color"];
+    /** Corner the status badge sits in. */
+    badgePosition?: AvatarBadgeStylingProps["position"];
+  }
+  const props = defineProps<AvatarProps>()
+  const className = computed(() => avatarRecipe({ color: props.color, variant: props.variant, shape: props.shape, size: props.size }))
+  const badgeClassName = computed(() => avatarBadgeRecipe({ color: props.badgeColor, position: props.badgePosition, size: props.size }))
+</script>
+<template>
+<IAvatarBase :class="className" :src="src" :alt="alt" :showBadge="badge">
+  <slot>
+    {{ label }}
+  </slot>
+  <template #badge>
+  <IAvatarBadgeBase :class="badgeClassName" aria-hidden="true" />
+  </template>
+</IAvatarBase>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/index.ts
+++ b/ui/components/src/components/index.ts
@@ -1,3 +1,13 @@
+// Avatar ships as a single styled component (IAvatar) composing the base and its status-badge part.
+// IAvatarGroup is its own family (a stacked-avatars container). Headless parts stay individually
+// exported for advanced/custom composition.
+export { default as IAvatar } from "./avatar/styled/IAvatar.ink.tsx";
+export { default as IAvatarBase } from "./avatar/headless/IAvatarBase.ink.tsx";
+export { default as IAvatarBadgeBase } from "./avatar/headless/IAvatarBadgeBase.ink.tsx";
+
+export { default as IAvatarGroup } from "./avatar-group/styled/IAvatarGroup.ink.tsx";
+export { default as IAvatarGroupBase } from "./avatar-group/headless/IAvatarGroupBase.ink.tsx";
+
 export { default as IBadge } from "./badge/styled/IBadge.ink.tsx";
 export { default as IBadgeBase } from "./badge/headless/IBadgeBase.ink.tsx";
 


### PR DESCRIPTION
## Summary

Adds `IAvatar` and `IAvatarGroup` write-once components with headless and styled variants, Storybook stories, and cross-target snapshot tests. Includes badge support via `IAvatarBadge` and size/shape/color/variant story coverage.

## Related issues

- Closes #

## Type of change

- [x] `feat` — new user-facing capability or public API

## Test plan

- [ ] `vp run ready` passes locally
- [ ] Snapshot tests pass for `IAvatarBase`, `IAvatarBadgeBase`, `IAvatarGroup` (headless + styled)
- [ ] Storybook stories render correctly across frameworks

## Checklist

- [ ] Added a changeset (`pnpm changeset`) for any change to a published package's behavior, API, or types. See [docs/release-process.md](../docs/release-process.md).
- [ ] If this PR changes public API, build flow, conventions, or repo structure, the relevant `AGENTS.md` or `docs/*.md` files have been updated. See [docs/maintenance.md](../docs/maintenance.md) → "Cross-references".
- [x] Commit messages follow the conventional format (`feat(scope): …`, `fix(scope): …`). See [docs/conventions.md](../docs/conventions.md) → "Commit messages".