### PR TITLE
docs: add Vite+ toolchain note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A starter for creating a Vite+ monorepo.
 
+> Note: This monorepo is built and managed with Vite+ (`vp`). Run `vp help` for the full command list.
+
 ## Development
 
 - Check everything is ready:


### PR DESCRIPTION
Adds a short note to the root README pointing to the Vite+ (`vp`) toolchain and `vp help`.

This is a small demo/test change requested via UXF-7 ("Random task 2"). Draft so it can be tried out before any merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)