### PR TITLE
test(plugin): guard enforce:pre ordering and .ink.tsx transform filter

### DIFF
--- a/core/plugin/AGENTS.md
+++ b/core/plugin/AGENTS.md
@@ -45,7 +45,9 @@ Builds with [`unbuild`](https://github.com/unjs/unbuild), not `vp pack`. `pnpm d
 
 ## Tests
 
-None today. Coverage comes from the [`@inkline/compiler`](../compiler/) fixture suite (compile is the same code path) and from real consumers (the apps + ui/components build). Add direct tests here if the plugin gains non-trivial bundler-specific logic.
+Direct unit coverage lives in [`src/index.test.ts`](./src/index.test.ts) — `vp test` runs it, and [`vite.config.ts`](./vite.config.ts) enforces 100% line/branch/function/statement thresholds. The suite mocks `@inkline/compiler` and drives the factory directly: the transform handler (target resolution, source-map mode, main-file selection, diagnostic forwarding, incremental state threading), Vite `configResolved` target auto-detection and `handleHotUpdate`, the `enforce: "pre"` ordering guarantee, the `.ink.tsx`-only transform filter, and the six bundler adapter re-exports.
+
+Because the compiler is mocked, the plugin↔compiler seam (real `GeneratedFile` / `files[target]` shape) is covered instead by the [`@inkline/compiler`](../compiler/) fixture suite (compile is the same code path) and by real consumers (the apps + ui/components build). Keep the mock boundary; add cases here for any new bundler-specific logic.
 
 ## See also
 

--- a/core/plugin/src/index.test.ts
+++ b/core/plugin/src/index.test.ts
@@ -34,7 +34,10 @@ interface TransformContext {
   warn: (message: string) => void;
 }
 interface PluginShape {
+  name: string;
+  enforce?: string;
   transform: {
+    filter: { id: RegExp };
     handler: (
       this: TransformContext,
       code: string,
@@ -326,6 +329,22 @@ describe("vite.handleHotUpdate", () => {
 
     await plugin.transform.handler.call(makeCtx(), "SRC", ID);
     expect(compileIncrementalMock.mock.calls[1]![0]).toBe(afterHmr);
+  });
+});
+
+describe("plugin contract", () => {
+  it('enforces "pre" so .ink.tsx compiles before framework transforms', () => {
+    const plugin = build({ target: "react" });
+    expect(plugin.name).toBe("@inkline/plugin");
+    expect(plugin.enforce).toBe("pre");
+  });
+
+  it("filters transform to .ink.tsx files only", () => {
+    const { id } = build({ target: "react" }).transform.filter;
+    expect(id.test("/project/Button.ink.tsx")).toBe(true);
+    expect(id.test("/project/Button.tsx")).toBe(false);
+    expect(id.test("/project/app.ts")).toBe(false);
+    expect(id.test("/project/ink.tsx")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`@inkline/plugin` — flagged in INK-3 as the highest-risk untested surface — actually already gained comprehensive direct unit coverage in #465 (25 tests, 100% line/branch/function/statement thresholds enforced by `vite.config.ts`). This PR closes the two remaining unasserted contracts and corrects the stale docs.

- **`enforce: "pre"` + `name`** — the ordering guarantee that `.ink.tsx` compiles *before* framework transforms. A regression dropping `"pre"` would silently break every consumer; nothing caught it.
- **`transform.filter.id`** — the `.ink.tsx`-only file-selection contract. The suite calls the handler directly, bypassing the filter, so nothing verified the plugin matches `.ink.tsx` and rejects plain `.tsx`.
- **AGENTS.md** still claimed "Tests: None today" — refreshed to describe the real suite, the enforced thresholds, and the deliberate mock boundary at the compiler seam.

Scope note: the suite mocks `@inkline/compiler` by design, so the plugin↔compiler seam stays covered by the compiler fixture suite + real consumers. I did not couple the isolated unit suite to a built compiler dist.

## Verification

- `vp test` (core/plugin): **27 passed**, coverage **100%** (51/51 stmts · 33/33 branches · 10/10 funcs · 37/37 lines)
- `vp check` (core/plugin): pass — format + lint + types clean (compiler dist built via `vp pack` first)
- Matrix: adapter files untouched (trivial re-exports, already covered); factory-core behavior unchanged — this is test/docs only.

## Test plan

- [x] `vp test` green at 100% coverage
- [x] `vp check` green