### PR TITLE
docs: reconcile AGENTS/README drift with source (.inkline, real CLI, 7 targets)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Per package — descend to the `AGENTS.md` nearest the file you're editing (LLM 
 | [`core/plugin/AGENTS.md`](./core/plugin/AGENTS.md)                                                             | Bundler integration (Vite, webpack, Rollup, esbuild, Rspack, Farm)       |
 | [`core/config-loader/AGENTS.md`](./core/config-loader/AGENTS.md)                                               | `inkline.config.ts` loading                                              |
 | [`core/inkline/AGENTS.md`](./core/inkline/AGENTS.md)                                                           | The public `inkline` barrel package                                      |
-| [`tooling/cli/AGENTS.md`](./tooling/cli/AGENTS.md)                                                             | `inkline build`, `inkline compile`, `inkline diagnose`                   |
+| [`tooling/cli/AGENTS.md`](./tooling/cli/AGENTS.md)                                                             | `inkline compile`, `inkline check`, `inkline init`, `inkline add`        |
 | [`tooling/storybook/AGENTS.md`](./tooling/storybook/AGENTS.md)                                                 | Story authoring + per-target story generation                            |
 | [`tooling/test-utils/AGENTS.md`](./tooling/test-utils/AGENTS.md)                                               | Cross-target test harnesses                                              |
 | [`ui/components/AGENTS.md`](./ui/components/AGENTS.md)                                                         | **Where you author components** — the single source for all 7 frameworks |
@@ -72,7 +72,7 @@ These apply everywhere. Package-level `AGENTS.md` files repeat them only when co
 - **Tests**: colocated as `<file>.test.ts`. Vitest. Never in a separate `tests/` folder.
 - **Commits**: conventional commits with package scope — `feat(compiler): …`, `fix(ci): …`. See [docs/conventions.md](./docs/conventions.md) → "Commit messages".
 - **Changesets**: every change to a published package needs one (`pnpm changeset`). See [docs/release-process.md](./docs/release-process.md).
-- **Generated directories — never hand-edit**: `ui/<framework>/generated/`, `ui/<framework>/.styleframe/`, all `dist/`, `coverage/`, `storybook-static/`.
+- **Generated directories — never hand-edit**: `ui/<framework>/.inkline/`, `ui/<framework>/.styleframe/`, all `dist/`, `coverage/`, `storybook-static/`.
 - **Archived directory — never touch**: `.old/` is the v0 codebase, kept for reference only.
 - **Doc freshness**: if your change touches public API, build flow, conventions, or the directory shape, update the relevant `AGENTS.md` / `docs/*.md`. See [docs/maintenance.md](./docs/maintenance.md).
 

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -1,12 +1,15 @@
 # @inkline/compiler
 
-A write-once, compile-everywhere component compiler. Author UI components in `.ink.tsx` using a signal-based reactivity model, and compile them to native **React**, **Vue 3**, **Svelte 5**, and **Solid** components.
+A write-once, compile-everywhere component compiler. Author UI components in `.ink.tsx` using a signal-based reactivity model, and compile them to native **React**, **Vue 3**, **Svelte 5**, **Solid**, **Angular**, **Qwik**, and **Astro** components.
 
 ```
-Counter.ink.tsx  ──>  React/Counter.tsx
-                 ──>  Vue/Counter.vue
-                 ──>  Svelte/Counter.svelte
-                 ──>  Solid/Counter.tsx
+Counter.ink.tsx  ──>  react/Counter.tsx
+                 ──>  vue/Counter.vue
+                 ──>  svelte/Counter.svelte
+                 ──>  solid/Counter.tsx
+                 ──>  angular/Counter.component.ts
+                 ──>  qwik/Counter.tsx
+                 ──>  astro/Counter.astro
 ```
 
 ## Installation
@@ -48,17 +51,20 @@ export default defineComponent(() => {
 ### 2. Compile
 
 ```bash
-npx inkline build src/components/Counter.ink.tsx --target react,vue,svelte,solid --out-dir dist
+npx inkline compile src/components/Counter.ink.tsx --target react,vue,svelte,solid --out-dir dist
 ```
 
 ### 3. Use the Output
 
 ```
 dist/
-  react/Counter.tsx       # React component using useState, useMemo, useEffect
-  vue/Counter.vue         # Vue 3 SFC with <script setup>, ref(), computed()
-  svelte/Counter.svelte   # Svelte 5 component with $state, $derived, $effect
-  solid/Counter.tsx       # Solid component with createSignal, createMemo
+  react/Counter.tsx           # React component using useState, useMemo, useEffect
+  vue/Counter.vue             # Vue 3 SFC with <script setup>, ref(), computed()
+  svelte/Counter.svelte       # Svelte 5 component with $state, $derived, $effect
+  solid/Counter.tsx           # Solid component with createSignal, createMemo
+  angular/Counter.component.ts # Angular standalone component with signals
+  qwik/Counter.tsx            # Qwik component with useSignal / useComputed$
+  astro/Counter.astro         # Astro component (static render)
 ```
 
 Each output is a standalone, idiomatic component for its target framework. No runtime dependency on `@inkline/core`.
@@ -384,52 +390,78 @@ export default defineConfig({
 
 ### Available Targets
 
-| Name     | Output    | Framework                                         |
-| -------- | --------- | ------------------------------------------------- |
-| `react`  | `.tsx`    | React 19 (hooks API)                              |
-| `solid`  | `.tsx`    | Solid.js 1.8+                                     |
-| `vue`    | `.vue`    | Vue 3 (Composition API, `<script setup>`)         |
-| `svelte` | `.svelte` | Svelte 5 (runes: `$state`, `$derived`, `$effect`) |
+| Name      | Output          | Framework                                         |
+| --------- | --------------- | ------------------------------------------------- |
+| `react`   | `.tsx`          | React 19 (hooks API)                              |
+| `solid`   | `.tsx`          | Solid.js 1.8+                                     |
+| `vue`     | `.vue`          | Vue 3 (Composition API, `<script setup>`)         |
+| `svelte`  | `.svelte`       | Svelte 5 (runes: `$state`, `$derived`, `$effect`) |
+| `angular` | `.component.ts` | Angular standalone components (signals)           |
+| `qwik`    | `.tsx`          | Qwik (resumable, `useSignal` / `useComputed$`)    |
+| `astro`   | `.astro`        | Astro (static render)                             |
+
+All seven are registered in the built-in registry ([`src/codegen/registry.ts`](./src/codegen/registry.ts)).
 
 ---
 
 ## CLI
 
+The `inkline` CLI ships in [`@inkline/cli`](../../tooling/cli/). It exposes four commands:
+
 ```
 inkline <command> [options]
 
 Commands:
-  build <glob>     Compile .ink.tsx files to target frameworks.
-  diagnose <file>  Check a file for diagnostics without writing output.
-  version          Print version.
-  help [command]   Show help.
+  compile <glob>   Compile .ink.tsx files and generate stories.
+  check <file>     Run diagnostics on a file without writing output.
+  init             Initialize an Inkline project.
+  add <component>  Add a component to your project.
 ```
 
-### Build
+### Compile
 
 ```bash
 # Single target
-inkline build src/IButton.ink.tsx --target react
+inkline compile src/IButton.ink.tsx --target react
 
 # Multiple targets
-inkline build src/**/*.ink.tsx --target react,vue,svelte,solid --out-dir dist
+inkline compile "src/**/*.ink.tsx" --target react,vue,svelte,solid,angular,qwik,astro --out-dir dist
 
-# With config file
-inkline build src/**/*.ink.tsx --config inkline.config.ts
+# With config file (targets come from inkline.config.ts)
+inkline compile "src/**/*.ink.tsx" --config inkline.config.ts
 
 # Source maps
-inkline build src/**/*.ink.tsx --target react --source-map inline
+inkline compile src/IButton.ink.tsx --target react --source-map inline
+
+# Watch and recompile on change
+inkline compile "src/**/*.ink.tsx" --config inkline.config.ts --watch
 ```
 
-CLI flags override config file values.
+Flags: `--target`, `--src-dir`, `--out-dir` (default `dist`), `--source-map` (`external` | `inline` | `none`, default `external`), `--config`, `--clean` (default `true`), `--watch`, `--verbose`. `--target` is required unless the config file sets `targets`. CLI flags override config file values.
 
-### Diagnose
+### Check
 
-Check for diagnostic issues without producing output:
+Report diagnostics without producing output:
 
 ```bash
-inkline diagnose src/Counter.ink.tsx --target react
+inkline check src/Counter.ink.tsx --target react
 ```
+
+### Init
+
+Scaffold Inkline into the current project. Pass `--compiler` to also generate `inkline.config.ts`, an example component, and build scripts:
+
+```bash
+inkline init --framework react --compiler
+```
+
+### Add
+
+```bash
+inkline add IButton
+```
+
+`add` is registered but not yet implemented — it currently prints a notice.
 
 ---
 
@@ -629,8 +661,8 @@ export default defineConfig({
 ```json
 {
   "scripts": {
-    "build": "inkline build src/**/*.ink.tsx",
-    "check": "inkline diagnose src/**/*.ink.tsx"
+    "build": "inkline compile \"src/**/*.ink.tsx\"",
+    "check": "inkline check \"src/**/*.ink.tsx\""
   }
 }
 ```
@@ -758,7 +790,7 @@ The compiler produces diagnostics at each pipeline stage. Errors prevent output;
 | INK0090 | error    | A plugin threw an exception.                                                                                                            |
 | INK0100 | error    | Component failed during emit. Other components continue.                                                                                |
 
-Run `inkline diagnose <file>` to check without producing output.
+Run `inkline check <file>` to check without producing output.
 
 ---
 
@@ -801,8 +833,7 @@ The following features are deferred to v1:
 - **Scoped CSS / `<style>` blocks**
 - **Server/client component boundaries**
 - **Async components / Suspense / `createResource`**
-- **HMR / `--watch` mode** (use a Vite plugin wrapper)
-- **Angular, Qwik, Astro targets** (reserved in the type system)
+- **HMR** (the CLI's `--watch` recompiles on change; in-place hot module replacement still needs a Vite plugin wrapper)
 - **Sub-expression source-map granularity** (maps at statement/element level)
 
 See `docs/scope.md` for the full v1 roadmap.

--- a/core/inkline/AGENTS.md
+++ b/core/inkline/AGENTS.md
@@ -21,7 +21,7 @@ The root entry (`src/index.ts`) is literally `export * from "@inkline/core";` �
 
 ## CLI binary
 
-`bin/inkline.mjs` is shipped via [`package.json`](./package.json) `bin`. It is a thin re-export of `@inkline/cli`'s binary so end users can run `npx inkline build …` directly. Keep this file behavior in sync with [`tooling/cli/bin/inkline.mjs`](../../tooling/cli/) — see [`tooling/cli/AGENTS.md`](../../tooling/cli/AGENTS.md).
+`bin/inkline.mjs` is shipped via [`package.json`](./package.json) `bin`. It is a thin re-export of `@inkline/cli`'s binary so end users can run `npx inkline compile …` directly. Keep this file behavior in sync with [`tooling/cli/bin/inkline.mjs`](../../tooling/cli/) — see [`tooling/cli/AGENTS.md`](../../tooling/cli/AGENTS.md).
 
 ## Build
 

--- a/docs/adding-a-target.md
+++ b/docs/adding-a-target.md
@@ -122,7 +122,7 @@ Three layers required:
 When the new target is built-in, add the consumer-facing UI package:
 
 1. Create `ui/<new-target>/` matching the shape of [`ui/react/`](../ui/react/) (with the framework-specific tweaks documented in that package's [`AGENTS.md`](../ui/react/AGENTS.md)).
-2. Update [`ui/components/inkline.config.ts`](../ui/components/inkline.config.ts) `targetOutDir` so the cross-framework compile writes into `ui/<new-target>/generated/`.
+2. Update [`ui/components/inkline.config.ts`](../ui/components/inkline.config.ts) `targetOutDir` so the cross-framework compile writes into `ui/<new-target>/.inkline/`.
 3. Update the root [`package.json`](../package.json) `storybook:frameworks` script and the `wait-on` list in `storybook:app` with the new port.
 4. Add the new subpath to [`core/inkline/package.json`](../core/inkline/package.json) `exports` (`./<new-target>`) and to its [`AGENTS.md`](../core/inkline/AGENTS.md).
 5. Touch [docs/contributing.md](./contributing.md) → "Dev loops" and [scope.md](./scope.md) → "Compilation targets".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,7 +132,7 @@ The build is driven by Vite+ (see the per-package `vite.config.ts`). Type defini
        └────────────────────────────────────────────────┘
 ```
 
-The framework output packages (`@inkline/react` etc.) hold **generated code** in `ui/<framework>/generated/`. Source-of-truth changes happen in `ui/components/` and propagate to all targets on rebuild.
+The framework output packages (`@inkline/react` etc.) hold **generated code** in `ui/<framework>/.inkline/`. Source-of-truth changes happen in `ui/components/` and propagate to all targets on rebuild.
 
 ## Testing
 

--- a/docs/authoring-components.md
+++ b/docs/authoring-components.md
@@ -33,48 +33,59 @@ Consumers of `@inkline/{react,vue,…}` import the styled variant by default. Th
 From [`ui/components/src/components/badge/headless/IBadgeBase.ink.tsx`](../ui/components/src/components/badge/headless/IBadgeBase.ink.tsx):
 
 ```tsx
-import { defineComponent } from "@inkline/core";
+import { defineComponent, Slot } from "@inkline/core";
 
 export interface BadgeBaseProps {
   label?: string;
-  disabled?: boolean;
 }
 
 export default defineComponent(
   {
+    meta: { headless: true },
     slots: { default: {} },
   },
   (props: BadgeBaseProps) => {
     return (
-      <div class="badge" disabled={props.disabled}>
-        <slot>{props.label}</slot>
+      <div class="badge">
+        <Slot>{props.label}</Slot>
       </div>
     );
   },
 );
 ```
 
-Three things to notice:
+Four things to notice:
 
-1. **`defineComponent` is the sole entry point.** It accepts either `(setup)` or `(options, setup)`. Use the options form when you need to declare slots, events, or prop metadata.
+1. **`defineComponent` is the sole entry point.** It accepts either `(setup)` or `(options, setup)`. Use the options form when you need to declare slots, events, or metadata.
 2. **Props are typed as a TypeScript parameter type** (`props: BadgeBaseProps`). The compiler reads the type to generate per-framework prop declarations.
-3. **`<slot>` (lowercase) is the JSX intrinsic** the parser recognizes as the default slot. For typed / named / scoped slots, use the `<Slot>` JSX component from `@inkline/core` together with `defineSlot` — see [`core/compiler/README.md`](../core/compiler/README.md) and the compiler's slot fixtures.
+3. **`<Slot>` (imported from `@inkline/core`) renders a declared slot.** An unnamed `<Slot>` renders the default slot (the lowercase `<slot>` JSX intrinsic works too); `<Slot name="prefix" />` renders a named one. Declare each slot in the options object first. See [`core/compiler/README.md`](../core/compiler/README.md) → "Slots".
+4. **`meta: { headless: true }` marks a behavior-only component.** Its single static-element root becomes the Angular host (attribute-selector emission); it must have exactly one host-element root — a fragment or conditional root emits `INK0120`.
 
 The styled variant ([`IBadge.ink.tsx`](../ui/components/src/components/badge/styled/IBadge.ink.tsx)) composes the headless one:
 
 ```tsx
-import { defineComponent } from "@inkline/core";
+import { defineComponent, Slot, createMemo } from "@inkline/core";
 import IBadgeBase, { type BadgeBaseProps } from "../headless/IBadgeBase.ink.tsx";
-import { badge, type BadgeProps as BadgeStylingProps } from "virtual:styleframe";
+import { badgeRecipe, type BadgeRecipeProps as BadgeStylingProps } from "virtual:styleframe";
 
 export interface BadgeProps extends BadgeBaseProps, BadgeStylingProps {}
 
-export default defineComponent((props: BadgeProps) => {
-  return <IBadgeBase class={badge(props as BadgeStylingProps)}>{props.label}</IBadgeBase>;
-});
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: BadgeProps) => {
+    const className = createMemo(() =>
+      badgeRecipe({ color: props.color, variant: props.variant, size: props.size }),
+    );
+    return (
+      <IBadgeBase class={className()}>
+        <Slot>{props.label}</Slot>
+      </IBadgeBase>
+    );
+  },
+);
 ```
 
-`virtual:styleframe` is provided by the `styleframe` integration; the resolved classnames live in each framework's `.styleframe/` directory (auto-generated — never hand-edit).
+`badgeRecipe` is imported from `virtual:styleframe`; it maps the styling props (`color`, `variant`, `size`) to a class name. The recipe is registered in [`IBadge.styleframe.ts`](../ui/components/src/components/badge/styled/IBadge.styleframe.ts). `virtual:styleframe` is provided by the `styleframe` integration; the resolved classnames live in each framework's `.styleframe/` directory (auto-generated — never hand-edit).
 
 ### Attribute fallthrough
 
@@ -123,7 +134,7 @@ All primitives are authoring-time — the compiler removes them from emitted out
 
 ## Stories
 
-Stories are also authored in `.ink.tsx` and compiled per-framework into [`ui/<framework>/generated/stories/`](../ui/) by the CLI's story generator. Use the `defineStories` helper from [`@inkline/storybook`](../tooling/storybook/) to keep types tight.
+Stories are also authored in `.ink.tsx` and compiled per-framework into [`ui/<framework>/.inkline/`](../ui/) by the CLI's story generator. Use the `defineStories` helper from [`@inkline/storybook`](../tooling/storybook/) to keep types tight.
 
 Set `title` to `Components/<Category>/<Component>` — the `title` is the Storybook sidebar path, and the category segment groups the component in the sidebar. Current buckets: `Actions`, `Feedback`, `Forms` (add a new one when no existing category fits). Don't fall back to a flat `Components/<Component>`, or the component lands ungrouped.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -40,7 +40,7 @@ See [`pnpm-workspace.yaml`](../pnpm-workspace.yaml) for the authoritative glob l
 | `*.spec.ts`      | `testing/e2e/`                    | Playwright e2e specs (cross-framework visual parity). Not Vitest; run via `test:e2e`.                               |
 | `__fixtures__/`  | `core/compiler/src/__fixtures__/` | Compiler fixtures (`.ink.tsx`) used by scenario tests. Excluded from lint by [`vite.config.ts`](../vite.config.ts). |
 | `__snapshots__/` | colocated                         | Vitest snapshot files.                                                                                              |
-| `generated/`     | `ui/<framework>/generated/`       | **Auto-generated** by the compiler. Never hand-edit.                                                                |
+| `.inkline/`      | `ui/<framework>/.inkline/`        | **Auto-generated** by the compiler. Never hand-edit.                                                                |
 | `.styleframe/`   | `ui/<framework>/.styleframe/`     | **Auto-generated** style artifacts. Never hand-edit.                                                                |
 | `dist/`          | per-package                       | Build output. Never hand-edit.                                                                                      |
 

--- a/tooling/storybook/AGENTS.md
+++ b/tooling/storybook/AGENTS.md
@@ -14,7 +14,7 @@ Declared in [`package.json`](./package.json) `exports`:
 | `./preset/main`        | [`src/preset/main.ts`](./src/preset/main.ts)             | Storybook `main.ts` preset — shared addons, story globs, framework-agnostic settings. Re-used by each `ui/<framework>/.storybook/`.                                            |
 | `./preset/parameters`  | [`src/preset/parameters.ts`](./src/preset/parameters.ts) | Storybook `preview.ts` parameters (theming, controls, viewports).                                                                                                              |
 | `./preset/preview.css` | [`src/preset/preview.css`](./src/preset/preview.css)     | Storybook `preview.ts` styles — copied as-is to `dist` and imported (side-effect) by each `ui/<framework>/.storybook/preview.ts`.                                              |
-| `./generator`          | [`src/generator/index.ts`](./src/generator/index.ts)     | Compiler-adjacent: takes `defineStories` exports + the corresponding compiled component and emits per-framework CSF (`*.stories.ts`) into `ui/<framework>/generated/stories/`. |
+| `./generator`          | [`src/generator/index.ts`](./src/generator/index.ts)     | Compiler-adjacent: takes `defineStories` exports + the corresponding compiled component and emits per-framework CSF (`*.stories.ts`) co-located in `ui/<framework>/.inkline/`. |
 
 The generator is invoked by [`inkline compile stories`](../cli/AGENTS.md) — keep both packages in sync when the story format changes.
 
@@ -23,7 +23,7 @@ The generator is invoked by [`inkline compile stories`](../cli/AGENTS.md) — ke
 ```
 ui/components/src/components/<name>/stories/<variant>.ink.tsx
   ↓ inkline compile stories  (CLI → @inkline/storybook/generator)
-ui/<framework>/generated/stories/<name>/<variant>.stories.ts
+ui/<framework>/.inkline/<name>/<variant>.stories.ts
   ↓ Storybook reads it via the framework-specific .storybook/main.ts
 Storybook UI on port 6006..6012
 ```

--- a/ui/angular/AGENTS.md
+++ b/ui/angular/AGENTS.md
@@ -2,12 +2,12 @@
 
 The Angular output of Inkline's component compilation (standalone components).
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled Angular standalone components (`@Component` + template + style files) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — re-exports `generated/index.ts`.
+- `.inkline/` — compiled Angular standalone components (`@Component` + template + style files) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — re-exports `.inkline/index.ts`.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface

--- a/ui/astro/AGENTS.md
+++ b/ui/astro/AGENTS.md
@@ -2,12 +2,12 @@
 
 The Astro output of Inkline's component compilation.
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled `.astro` components written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — re-exports `generated/index.ts`.
+- `.inkline/` — compiled `.astro` components written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — re-exports `.inkline/index.ts`.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface

--- a/ui/components/AGENTS.md
+++ b/ui/components/AGENTS.md
@@ -23,18 +23,18 @@ ui/components/
 └── dist/                  # styleframe runtime output (NOT the compiled components)
 ```
 
-The compiled components do **not** land in `dist/` here. They land in `ui/<framework>/generated/` per the `targetOutDir` mapping in [`inkline.config.ts`](./inkline.config.ts). The `srcDir` option controls how much of the source path is preserved in the output — with `srcDir: "src"`, a source file at `src/components/badge/headless/IBadgeBase.ink.tsx` produces output at `generated/components/badge/headless/IBadgeBase.vue`:
+The compiled components do **not** land in `dist/` here. They land in `ui/<framework>/.inkline/` per the `targetOutDir` mapping in [`inkline.config.ts`](./inkline.config.ts). The `srcDir` option controls how much of the source path is preserved in the output — with `srcDir: "src"`, a source file at `src/components/badge/headless/IBadgeBase.ink.tsx` produces output at `.inkline/components/badge/headless/IBadgeBase.vue`:
 
 ```ts
 srcDir: "src",
 targetOutDir: {
-  react:   "../react/generated",
-  vue:     "../vue/generated",
-  svelte:  "../svelte/generated",
-  solid:   "../solid/generated",
-  angular: "../angular/generated",
-  qwik:    "../qwik/generated",
-  astro:   "../astro/generated",
+  react:   "../react/.inkline",
+  vue:     "../vue/.inkline",
+  svelte:  "../svelte/.inkline",
+  solid:   "../solid/.inkline",
+  angular: "../angular/.inkline",
+  qwik:    "../qwik/.inkline",
+  astro:   "../astro/.inkline",
 }
 ```
 
@@ -45,7 +45,7 @@ pnpm build   # vp build && inkline compile components 'src/**/*.ink.tsx' --confi
 pnpm dev     # inkline compile components 'src/**/*.ink.tsx' --watch
 ```
 
-`vp build` first compiles styleframe artifacts; `inkline compile components` then runs the [`@inkline/cli`](../../tooling/cli/) compile command for every target. The output is written directly into the framework packages' `generated/` directories, which their `src/index.ts` re-exports.
+`vp build` first compiles styleframe artifacts; `inkline compile components` then runs the [`@inkline/cli`](../../tooling/cli/) compile command for every target. The output is written directly into the framework packages' `.inkline/` directories, which their `src/index.ts` re-exports.
 
 ## Headless / styled split
 
@@ -54,7 +54,7 @@ Every component ships in two variants under its own directory:
 - **`headless/I<Name>Base.ink.tsx`** — structure, slots, props, events. No design tokens, no styleframe class names. Behavior + accessibility. One per part; this is what consumers swap in if they want to ship their own styling.
 - **`styled/I<Name>.ink.tsx`** — composes the headless part(s) and applies styleframe-generated classes via `virtual:styleframe`.
 
-Example: [`src/components/badge/`](./src/components/badge/) — the canonical single-part pattern to copy. The headless variant declares `slots: { default: {} }` so consumers can override content via slotting; the styled variant pulls `badge(props)` from `virtual:styleframe` to produce the class name.
+Example: [`src/components/badge/`](./src/components/badge/) — the canonical single-part pattern to copy. The headless variant declares `slots: { default: {} }` so consumers can override content via slotting; the styled variant pulls `badgeRecipe(props)` from `virtual:styleframe` to produce the class name.
 
 **A styled component may compose _all_ of a family's headless parts into one component** — there is one styled component per family, not one per part. [`src/components/input/`](./src/components/input/) is the model: the four `headless/IInput*Base` parts (shell, control, prefix, suffix) are composed by a single [`styled/IInput.ink.tsx`](./src/components/input/styled/IInput.ink.tsx). Optional addon slots are gated with `<Show when={hasSlot("prefix")}>` so an unused addon emits nothing; on Qwik/Angular (no runtime slot presence) `hasSlot` is `true` and the empty wrapper is collapsed by `:empty` rules in [`IInput.styleframe.ts`](./src/components/input/styled/IInput.styleframe.ts). All recipes for the family are registered in that one `.styleframe.ts`.
 
@@ -87,12 +87,12 @@ The config in [`vite.config.ts`](./vite.config.ts) deliberately leaves `coverage
 2. Author the headless variant first; verify it compiles to all seven targets.
 3. Author the styled variant; rebuild.
 4. Add stories per variant.
-5. Re-export from `src/components/index.ts` (when present) — the per-framework `generated/index.ts` is generated automatically.
+5. Re-export from `src/components/index.ts` (when present) — the per-framework `.inkline/index.ts` is generated automatically.
 6. Add a changeset for the seven framework packages (assuming a meaningful release).
 
 ## Pitfalls
 
-- **Do not edit anything under `ui/<framework>/generated/` or `ui/<framework>/.styleframe/`.** Both are rebuilt on every compile; your edits will be lost.
+- **Do not edit anything under `ui/<framework>/.inkline/` or `ui/<framework>/.styleframe/`.** Both are rebuilt on every compile; your edits will be lost.
 - **The `dist/` here is styleframe runtime output, not the component compile output.** Don't confuse the two.
 - **`virtual:styleframe` imports require the styleframe plugin in the consumer's Vite config.** The per-framework packages set this up. If a new build path skips it, styling will be missing at runtime.
 

--- a/ui/qwik/AGENTS.md
+++ b/ui/qwik/AGENTS.md
@@ -2,12 +2,12 @@
 
 The Qwik output of Inkline's component compilation.
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled Qwik components written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — re-exports `generated/index.ts`.
+- `.inkline/` — compiled Qwik components written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — re-exports `.inkline/index.ts`.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface

--- a/ui/react/AGENTS.md
+++ b/ui/react/AGENTS.md
@@ -2,23 +2,23 @@
 
 The React output of Inkline's component compilation.
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled React components written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — a single line: `export * from "../generated/index.ts";`. Re-exports the generated output. Do not extend it with hand-written code; if you need a manual override, route it through `ui/components/` so all seven frameworks stay in sync.
+- `.inkline/` — compiled React components written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — a single line: `export * from "../.inkline/index.ts";`. Re-exports the generated output. Do not extend it with hand-written code; if you need a manual override, route it through `ui/components/` so all seven frameworks stay in sync.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface
 
 From [`package.json`](./package.json) `exports`:
 
-| Subpath          | Contents                                                     |
-| ---------------- | ------------------------------------------------------------ |
-| `.`              | Re-export of `generated/index.ts` — all compiled components. |
-| `./css`          | Compiled CSS bundle.                                         |
-| `./package.json` | The manifest.                                                |
+| Subpath          | Contents                                                    |
+| ---------------- | ----------------------------------------------------------- |
+| `.`              | Re-export of `.inkline/index.ts` — all compiled components. |
+| `./css`          | Compiled CSS bundle.                                        |
+| `./package.json` | The manifest.                                               |
 
 Peer dep: `react >= 18`.
 

--- a/ui/solid/AGENTS.md
+++ b/ui/solid/AGENTS.md
@@ -2,12 +2,12 @@
 
 The Solid.js output of Inkline's component compilation.
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled Solid components (signals, fine-grained reactivity) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — re-exports `generated/index.ts`.
+- `.inkline/` — compiled Solid components (signals, fine-grained reactivity) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — re-exports `.inkline/index.ts`.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface

--- a/ui/svelte/AGENTS.md
+++ b/ui/svelte/AGENTS.md
@@ -2,12 +2,12 @@
 
 The Svelte 5 output of Inkline's component compilation.
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled `.svelte` components using runes (`$state`, `$derived`, `$effect`) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — re-exports `generated/index.ts`.
+- `.inkline/` — compiled `.svelte` components using runes (`$state`, `$derived`, `$effect`) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — re-exports `.inkline/index.ts`.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface

--- a/ui/vue/AGENTS.md
+++ b/ui/vue/AGENTS.md
@@ -2,12 +2,12 @@
 
 The Vue 3 output of Inkline's component compilation.
 
-## STOP — do not edit `src/` or `generated/` here
+## STOP — do not edit `src/` or `.inkline/` here
 
 This package is **auto-generated**. To change a component, edit the corresponding `.ink.tsx` file in [`ui/components/src/components/`](../components/) and rebuild. See [`ui/components/AGENTS.md`](../components/AGENTS.md).
 
-- `generated/` — compiled Vue SFCs (`<script setup>` + Composition API) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
-- `src/index.ts` — re-exports `generated/index.ts`. Do not extend with hand-written code.
+- `.inkline/` — compiled Vue SFCs (`<script setup>` + Composition API) written by [`inkline compile components`](../../tooling/cli/AGENTS.md). Never hand-edit.
+- `src/index.ts` — re-exports `.inkline/index.ts`. Do not extend with hand-written code.
 - `.styleframe/` — auto-generated styleframe artifacts. Never hand-edit.
 
 ## Public surface


### PR DESCRIPTION
## Summary

Truth reconciliation (INK-2): fix the known documentation drift so every AGENTS.md and the compiler README describe the system that ships today. All claims verified against source; `agents-check` link integrity green.

- **`generated/` → `.inkline/`** — the real `targetOutDir` per [`ui/components/inkline.config.ts`](../blob/agent/quill/489bde98/ui/components/inkline.config.ts). Fixed across the 7 framework `ui/<fw>/AGENTS.md`, `ui/components/AGENTS.md`, root `AGENTS.md`, `tooling/storybook/AGENTS.md`, and `docs/{conventions,architecture,adding-a-target}.md`.
- **Compiler README CLI section** rewritten for the real commands — `compile` / `check` / `init` / `add` (verified in [`tooling/cli/src/commands/`](../blob/agent/quill/489bde98/tooling/cli/src/commands)), not the stale `build` / `diagnose`. Every documented flag matches `compile.ts` / `init.ts` args.
- **4-target remnants → 7 targets** — intro, ASCII diagram, "Available Targets" table (now linked to [`registry.ts`](../blob/agent/quill/489bde98/core/compiler/src/codegen/registry.ts)), and the stale "Angular/Qwik/Astro reserved in the type system" v0 limitation removed.
- **`inkline build` → `inkline compile`** in root + `core/inkline/AGENTS.md`.
- **`badge(props)` → `badgeRecipe(props)`** in `ui/components/AGENTS.md`.
- **`docs/authoring-components.md` badge snippets** re-anchored **verbatim** on the live `IBadgeBase.ink.tsx` / `IBadge.ink.tsx` (Slot, `meta.headless`, `badgeRecipe`, `createMemo`) — the snippets are copies of compiling source, so they compile by construction.

## Out of scope (flagged, not touched)

`tooling/storybook/README.md` is a heavily-drifted **duplicate** of the canonical `tooling/storybook/AGENTS.md` (wrong command `inkline-storybook generate`, wrong story path, "Astro is deferred", `generated/`). Partially patching it would ship an inconsistent doc — this is a delete-and-point vs rewrite **restructure decision** for @maestro, tracked separately.

## Test plan

- [x] `vp test` in `tooling/agents-check` — link integrity green (2/2)
- [x] Every CLI claim verified against `tooling/cli/src/commands/{compile,check,init,add}.ts`
- [x] 7 targets verified against `core/compiler/src/codegen/registry.ts`
- [x] Badge snippets are verbatim from the live compiling source

Requesting @warden for review (substance + freshness gate). @atlas — the compiler README technical claims are yours to confirm.