### PR TITLE
test(e2e): wait for Qwik resume before capturing in visual-parity

### DIFF
--- a/testing/e2e/storybook.ts
+++ b/testing/e2e/storybook.ts
@@ -115,6 +115,23 @@ async function waitForStoryReady(page: Page): Promise<void> {
   } catch {
     // Capture whatever rendered (e.g. an empty container) rather than hanging.
   }
+  // Qwik renders in two phases: the SSR container mounts "paused" (collapsed), then resumes and
+  // hydrates asynchronously. Storybook's render phase settles at mount — before resume — so a capture
+  // taken then intermittently catches the pre-resume container (a tiny placeholder) and reports a
+  // spurious dimension mismatch against the already-painted React reference. Wait for the container to
+  // reach `q:container="resumed"` when one is present; a no-op for every other framework. Bounded and
+  // non-fatal so a genuinely stuck resume still fails fast via screenshotRoot rather than hanging.
+  try {
+    await page.waitForFunction(
+      () => {
+        const container = document.querySelector("#storybook-root [q\\:container]");
+        return !container || container.getAttribute("q:container") === "resumed";
+      },
+      { timeout: 8_000 },
+    );
+  } catch {
+    // Resume never completed — capture whatever is there and let the diff surface it.
+  }
   await page.evaluate(() => document.fonts.ready).catch(() => undefined);
   await page.waitForTimeout(120);
 }


### PR DESCRIPTION
## Summary

The `visual-parity` suite intermittently failed on `qwik components-actions-button--block @initial` with a dimension mismatch (`reference 104x72 vs candidate 32x32`). Root cause: **a harness timing race, not a cross-framework render divergence.**

Qwik renders in two phases — the SSR container mounts `q:container="paused"` (collapsed placeholder), then resumes and hydrates asynchronously. `waitForStoryReady` settled on Storybook's render phase, which fires at *mount* (before resume), so a screenshot taken then occasionally caught the pre-resume placeholder while the React reference was already painted.

Evidence it's not a real divergence: with the container resumed, the Qwik `#storybook-root` box is `103.2×71.6` — **byte-for-byte the same** as React and Vue, and the full DOM matches. A sequential pass over all 30 stories shows identical dimensions React↔Qwik across the board.

## Fix

After the render phase settles, wait for `q:container="resumed"` when a Qwik container is present (a no-op for the other six frameworks). Bounded (8s) and non-fatal so a genuinely stuck resume still fails fast via `screenshotRoot` rather than hanging.

## Verification

- `pnpm --filter @inkline/e2e run test:e2e` — **PASS (6) FAIL (0)** on 3 consecutive full runs
- Both CI shards (`STORY_SHARD=1/2`, `2/2`) — **PASS (6) FAIL (0)**
- `npx vp fmt --check` · `npx vp lint` · `npx vp check` — all green

## Test plan

- [ ] `pnpm --filter @inkline/e2e run test:e2e` is green across all six compared frameworks vs the React reference
- [ ] No committed baselines changed; fix is confined to `testing/e2e/storybook.ts`
