### PR TITLE
docs(storybook): thin README pointer to canonical AGENTS.md (INK-10)

### DIFF
--- a/tooling/storybook/README.md
+++ b/tooling/storybook/README.md
@@ -1,64 +1,17 @@
 # @inkline/storybook
 
 Single-source story definitions and shared Storybook configuration for
-Inkline's per-framework component packages.
+Inkline's per-framework component packages. A story is authored once and
+rendered across every framework target.
 
-A component is authored once as `.ink.tsx` and compiled to seven framework
-targets. Stories follow the same model: write one framework-agnostic
-definition, generate per-framework CSF.
+This is a private, monorepo-internal package — not published to npm.
 
-## Authoring a story
+## Authoritative reference
 
-Add a definition under `ui/components/stories/`, next to the single source:
+Setup, commands, the story flow, and the source map live in a single canonical
+doc so they can't drift:
 
-```ts
-import { defineStories } from "@inkline/storybook";
-import type { ButtonProps } from "../src/IButton.ink.tsx";
+**→ [`AGENTS.md`](./AGENTS.md)**
 
-export default defineStories<ButtonProps>({
-  component: "IButton",
-  title: "Components/Button",
-  args: { label: "Click me", disabled: false },
-  argTypes: { label: { control: "text" } },
-  stories: {
-    Default: {},
-    Disabled: { args: { disabled: true } },
-  },
-});
-```
-
-`defineStories` is a typed identity helper — `args` are checked against the
-component's prop type.
-
-## Generating
-
-```bash
-inkline-storybook generate            # one-shot
-inkline-storybook generate --watch    # regenerate on change
-```
-
-Emits `ui/<target>/stories/<Component>.stories.ts` for every active framework
-(React, Vue, Svelte, Solid, Angular, Qwik; Astro is deferred). Generated files
-are gitignored. The generator asserts the derived story IDs are identical
-across frameworks — the invariant cross-framework screenshot diffing relies on.
-
-## Shared Storybook config
-
-Each framework's `.storybook/main.ts` stays declarative:
-
-```ts
-import { createStorybookConfig } from "@inkline/storybook/preset/main";
-
-export default createStorybookConfig({
-  framework: "@storybook/react-vite",
-  componentPackage: "@inkline/react",
-  sourceEntry: new URL("../generated/index.ts", import.meta.url).pathname,
-  vitePlugins: [
-    /* framework vite plugin */
-  ],
-});
-```
-
-`./preset/parameters` exports the shared, renderer-agnostic Storybook
-`parameters`. Decorators are intentionally not shared — they are
-renderer-specific and stay local to each framework's `preview.ts`.
+See also [docs/authoring-components.md](../../docs/authoring-components.md) →
+"Stories" for author-facing instructions.


### PR DESCRIPTION
## Summary
- `tooling/storybook/README.md` was a heavily-drifted duplicate of the canonical `tooling/storybook/AGENTS.md` (wrong command `inkline-storybook generate`, wrong story path, "Astro is deferred", `generated/` instead of `.inkline/`).
- Per Maestro's decision on INK-10: **delete-and-point, not rewrite**. Reduced the README to a short human-facing intro + one-line "how to run" pointer to `AGENTS.md`, so there's a single source and no re-drift.
- `AGENTS.md` unchanged (already corrected in PR #495).

## Acceptance
- No command / story-path / target-list content duplicating `AGENTS.md` remains. Grep for `generated/`, `inkline-storybook generate`, `Astro is deferred` → no matches.
- README now points to `tooling/storybook/AGENTS.md` as authoritative.

## Verify
- `vp test` in `tooling/agents-check` — link integrity green (2/2 passed).
- `grep` of the drifted claims — no matches.

Refs INK-10.

Review: @warden