### PR TITLE
feat(components): add Switch component

### DIFF
--- a/.changeset/add-switch.md
+++ b/.changeset/add-switch.md
@@ -1,0 +1,19 @@
+---
+"@inkline/react": minor
+"@inkline/vue": minor
+"@inkline/svelte": minor
+"@inkline/solid": minor
+"@inkline/angular": minor
+"@inkline/qwik": minor
+"@inkline/astro": minor
+---
+
+feat(components): add Switch component
+
+Add `ISwitch` (and its headless parts `ISwitchBase`, `ISwitchControlBase`, `ISwitchLabelBase`), an
+accessible on/off toggle styled with the Styleframe `switch` / `switch-field` recipes. It follows the
+WAI-ARIA **Switch** pattern on a native `<input type="checkbox">`: a two-way `checked` model drives
+`aria-checked`, Space toggles natively, and Enter synthesises the native click to complete the switch
+keyboard map. The default slot (or `label` prop) supplies the accessible name, and the `.switch-label`
+addon collapses when empty. Supports `color` (`light` / `dark` / `neutral`) and `size`
+(`sm` / `md` / `lg`).

--- a/ui/components/src/components/index.ts
+++ b/ui/components/src/components/index.ts
@@ -17,3 +17,10 @@ export { default as IInputBase } from "./input/headless/IInputBase.ink.tsx";
 export { default as IInputControlBase } from "./input/headless/IInputControlBase.ink.tsx";
 export { default as IInputPrefixBase } from "./input/headless/IInputPrefixBase.ink.tsx";
 export { default as IInputSuffixBase } from "./input/headless/IInputSuffixBase.ink.tsx";
+
+// Switch ships as a single styled component (ISwitch) that composes every headless part. The
+// headless parts remain individually exported for advanced/custom composition.
+export { default as ISwitch } from "./switch/styled/ISwitch.ink.tsx";
+export { default as ISwitchBase } from "./switch/headless/ISwitchBase.ink.tsx";
+export { default as ISwitchControlBase } from "./switch/headless/ISwitchControlBase.ink.tsx";
+export { default as ISwitchLabelBase } from "./switch/headless/ISwitchLabelBase.ink.tsx";

--- a/ui/components/src/components/switch/headless/ISwitchBase.ink.test.ts
+++ b/ui/components/src/components/switch/headless/ISwitchBase.ink.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const SWITCH_BASE = resolveComponent(import.meta.url, "./ISwitchBase.ink.tsx");
+
+describe("SwitchBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(SWITCH_BASE);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("is a plain slotted shell: no two-way notice (INK0045), no hasSlot notice (INK0068)", async () => {
+    // The shell holds no model and reads no runtime slot presence, so it lowers cleanly everywhere.
+    const result = await compileComponent(SWITCH_BASE);
+    expect(result.diagnostics.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(SWITCH_BASE));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(SWITCH_BASE));
+  });
+
+  it('renders a `<label class="switch">` shell across targets', async () => {
+    const result = await compileComponent(SWITCH_BASE);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      const files = result.files[target] ?? [];
+      expectOutputContains(files, "switch");
+    }
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(SWITCH_BASE))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/switch/headless/ISwitchBase.ink.tsx
+++ b/ui/components/src/components/switch/headless/ISwitchBase.ink.tsx
@@ -1,0 +1,18 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface SwitchBaseProps {}
+
+// The switch shell: a `<label>` that wraps the control and its text, so clicking anywhere on the
+// label toggles the field (implicit label association) and the label text supplies the accessible
+// name. Single static root, so it host-extracts to `label[ink-switch-base]` and the styled `class`
+// falls through to it.
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: SwitchBaseProps) => {
+    return (
+      <label class="switch">
+        <Slot />
+      </label>
+    );
+  },
+);

--- a/ui/components/src/components/switch/headless/ISwitchControlBase.ink.test.ts
+++ b/ui/components/src/components/switch/headless/ISwitchControlBase.ink.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+  type ComponentTestResult,
+  type TargetName,
+} from "@inkline/test-utils";
+
+const SWITCH_CONTROL = resolveComponent(import.meta.url, "./ISwitchControlBase.ink.tsx");
+
+const out = (result: ComponentTestResult, target: TargetName) => result.files[target] ?? [];
+
+describe("SwitchControlBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(SWITCH_CONTROL);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("emits only the expected Astro two-way notice (INK0045)", async () => {
+    // The `checked` model is two-way; on the static Astro target it lowers to a read-only value and
+    // emits an info notice (INK0045). No slots, so no INK0068. Every other target is clean.
+    const result = await compileComponent(SWITCH_CONTROL);
+    const unexpected = result.diagnostics.filter((d) => d.code !== "INK0045");
+    expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+    expect(result.diagnostics.filter((d) => d.code === "INK0068")).toHaveLength(0);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(SWITCH_CONTROL));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(SWITCH_CONTROL));
+  });
+
+  it("renders a native checkbox with the switch ARIA contract across targets", async () => {
+    const result = await compileComponent(SWITCH_CONTROL);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      const files = out(result, target);
+      expectOutputContains(files, "switch-field");
+      expectOutputContains(files, "checkbox");
+      expectOutputContains(files, "aria-checked");
+    }
+  });
+
+  it("keeps the Enter-toggle handler intact on every interactive target", async () => {
+    // Regression: authored as an `if` block, the Enter handler lowered to an empty `(keydown)=""` on
+    // Angular, whose event bindings carry only expression statements — the `if` was dropped. Authored
+    // as guarded `&&` expression statements that synthesise the native click, it survives on all six
+    // interactive targets: both actions are method calls, so there is no assignment left-hand side for
+    // the `&&` to bind too tightly (which would break Vue/Svelte, where a model set lowers to `= …`).
+    const result = await compileComponent(SWITCH_CONTROL);
+
+    // Angular: a non-empty keydown binding that fires the native click on Enter.
+    expectOutputContains(out(result, "angular"), "(keydown)=");
+    expectOutputContains(out(result, "angular"), "$event.currentTarget.click()");
+    expect(out(result, "angular").some((f) => f.contents.includes('(keydown)=""'))).toBe(false);
+
+    // Vue / Svelte / React / Solid / Qwik: guarded method-call statements, never an assignment LHS.
+    for (const target of ["vue", "svelte", "react", "solid", "qwik"] as const) {
+      expectOutputContains(out(result, target), "e.currentTarget.click()");
+    }
+  });
+
+  it("forwards the toggle to the two-way model on change per target", async () => {
+    const result = await compileComponent(SWITCH_CONTROL);
+    expectOutputContains(out(result, "angular"), "(change)=");
+    expectOutputContains(out(result, "vue"), "checked = e.currentTarget.checked");
+    expectOutputContains(out(result, "svelte"), "checked = e.currentTarget.checked");
+  });
+
+  it('coalesces the bound checked value so an unset model renders unchecked, not "undefined"', async () => {
+    const result = await compileComponent(SWITCH_CONTROL);
+    expectOutputContains(out(result, "solid"), "checked={props.checked ?? false}");
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(SWITCH_CONTROL))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/switch/headless/ISwitchControlBase.ink.tsx
+++ b/ui/components/src/components/switch/headless/ISwitchControlBase.ink.tsx
@@ -1,0 +1,41 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+export interface SwitchControlBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control (form submission). */
+  name?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+}
+
+// The native toggle: an `<input type="checkbox">` styled (via `.switch-field`) as a sliding switch.
+// A single static root, so it host-extracts to `input[ink-switch-control-base]`. `role="switch"` +
+// `aria-checked` announce it as a switch; the browser toggles on Space natively, and Enter is
+// handled explicitly to complete the APG switch keyboard map.
+export default defineComponent({ meta: { headless: true } }, (props: SwitchControlBaseProps) => {
+  // Two-way-bindable on/off state: a `checked` prop + an `update:checked` event, so a parent can
+  // `$bind:checked`.
+  const [checked, setChecked] = defineModel<boolean>("checked");
+
+  return (
+    <input
+      class="switch-field"
+      type="checkbox"
+      role="switch"
+      id={props.id}
+      name={props.name}
+      checked={checked() ?? false}
+      aria-checked={checked() ? "true" : "false"}
+      disabled={props.disabled}
+      onChange={(e: { currentTarget: HTMLInputElement }) => setChecked(e.currentTarget.checked)}
+      // Space toggles the checkbox natively; Enter does not, so complete the APG switch keyboard map
+      // by synthesising the native click on Enter (which flips the box and fires `onChange` →
+      // `setChecked`). A single guarded expression (arrow body, not a block statement) so it survives
+      // Angular's event bindings, which carry only a single expression.
+      onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) =>
+        e.key === "Enter" && e.currentTarget.click()
+      }
+    />
+  );
+});

--- a/ui/components/src/components/switch/headless/ISwitchLabelBase.ink.test.ts
+++ b/ui/components/src/components/switch/headless/ISwitchLabelBase.ink.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+} from "@inkline/test-utils";
+
+const SWITCH_LABEL = resolveComponent(import.meta.url, "./ISwitchLabelBase.ink.tsx");
+
+describe("SwitchLabelBase", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(SWITCH_LABEL);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("is a plain slotted span: no two-way notice (INK0045), no hasSlot notice (INK0068)", async () => {
+    const result = await compileComponent(SWITCH_LABEL);
+    expect(result.diagnostics.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(SWITCH_LABEL));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(SWITCH_LABEL));
+  });
+
+  it('renders a `<span class="switch-label">` across targets', async () => {
+    const result = await compileComponent(SWITCH_LABEL);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      expectOutputContains(result.files[target] ?? [], "switch-label");
+    }
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(SWITCH_LABEL))).toMatchSnapshot();
+  });
+});

--- a/ui/components/src/components/switch/headless/ISwitchLabelBase.ink.tsx
+++ b/ui/components/src/components/switch/headless/ISwitchLabelBase.ink.tsx
@@ -1,0 +1,18 @@
+import { defineComponent, Slot } from "@inkline/core";
+
+export interface SwitchLabelBaseProps {}
+
+// The switch's text container. Sits after the control inside the shell `<label>`; the `switch`
+// recipe owns the gap and typography. Rendered unconditionally by the styled component and collapsed
+// via a `.switch-label:empty` CSS rule when no label is supplied, so an unlabelled switch leaves no
+// trailing gap on every target (no `hasSlot` needed).
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (_props: SwitchLabelBaseProps) => {
+    return (
+      <span class="switch-label">
+        <Slot />
+      </span>
+    );
+  },
+);

--- a/ui/components/src/components/switch/headless/__snapshots__/ISwitchBase.ink.test.ts.snap
+++ b/ui/components/src/components/switch/headless/__snapshots__/ISwitchBase.ink.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SwitchBase > output matches snapshots 1`] = `
+{
+  "angular/ISwitchBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface SwitchBaseProps {}
+@Component({ standalone: true, selector: 'ink-switch-base', host: { style: 'display: contents' }, template: \`<label [class]="'switch' + (klass() ? ' ' + klass() : '')">
+<ng-content></ng-content>
+</label>\` })
+export class ISwitchBaseComponent
+{
+klass = input<string>()
+}
+@Component({ standalone: true, selector: 'label[ink-switch-base]', host: { '[class]': "'switch' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content></ng-content>\` })
+export class ISwitchBaseHostComponent
+{
+klass = input<string>()
+}
+",
+  "astro/ISwitchBase.astro": "---
+export interface SwitchBaseProps {}
+type Props = SwitchBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+---
+<label {...__attrs} class={["switch", __attrs.class].filter(Boolean).join(" ")}>
+<slot />
+</label>
+",
+  "qwik/ISwitchBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface SwitchBaseProps {}
+export const ISwitchBase = component$((props) =>
+{
+const { children, ...__attrs } = props
+return (
+<label {...__attrs} class={["switch", props.class].filter(Boolean).join(" ")}>
+  <Slot />
+</label>
+)
+});
+",
+  "react/ISwitchBase.tsx": "export interface SwitchBaseProps {}
+export function ISwitchBase(props: SwitchBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, ...__attrs } = props
+return (
+<label {...__attrs} className={["switch", props.className].filter(Boolean).join(" ")}>
+  {props.children}
+</label>
+)
+}
+",
+  "solid/ISwitchBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface SwitchBaseProps {}
+export default function ISwitchBase(props: SwitchBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children"])
+return (
+<label {...__attrs} class={["switch", props.class].filter(Boolean).join(" ")}>
+  {props.children}
+</label>
+)
+}
+",
+  "svelte/ISwitchBase.svelte": "<script lang="ts">
+  export interface SwitchBaseProps {}
+  import type { Snippet } from "svelte";
+  let { children, ...__attrs }: SwitchBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<label {...__attrs} class={["switch", __attrs.class].filter(Boolean).join(" ")}>
+  {@render children?.()}
+</label>
+",
+  "vue/ISwitchBase.vue": "<script setup lang="ts">
+  export interface SwitchBaseProps {}
+  const props = defineProps<SwitchBaseProps>()
+</script>
+<template>
+<label class="switch">
+  <slot />
+</label>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/switch/headless/__snapshots__/ISwitchControlBase.ink.test.ts.snap
+++ b/ui/components/src/components/switch/headless/__snapshots__/ISwitchControlBase.ink.test.ts.snap
@@ -1,0 +1,130 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SwitchControlBase > output matches snapshots 1`] = `
+{
+  "angular/ISwitchControlBase.component.ts": "import { Component, signal, computed, effect, input, model } from "@angular/core";
+export interface SwitchControlBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control (form submission). */
+  name?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+}
+@Component({ standalone: true, selector: 'ink-switch-control-base', host: { style: 'display: contents' }, template: \`<input [class]="'switch-field' + (klass() ? ' ' + klass() : '')" type="checkbox" role="switch" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [checked]="checked() ?? false" [attr.aria-checked]="(checked() ? 'true' : 'false') ?? null" [disabled]="disabled()" (change)="checked.set($event.currentTarget.checked)" (keydown)="$event.key === 'Enter' && $event.currentTarget.click()" />\` })
+export class ISwitchControlBaseComponent
+{
+klass = input<string>()
+id = input<string>()
+name = input<string>()
+disabled = input<boolean>()
+checked = model<boolean>()
+}
+@Component({ standalone: true, selector: 'input[ink-switch-control-base]', host: { '[class]': "'switch-field' + (klass() ? ' ' + klass() : '')", 'type': 'checkbox', 'role': 'switch', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[checked]': "checked() ?? false", '[attr.aria-checked]': "(checked() ? 'true' : 'false') ?? null", '[disabled]': "disabled()", '(change)': "checked.set($event.currentTarget.checked)", '(keydown)': "$event.key === 'Enter' && $event.currentTarget.click()" }, template: \`\` })
+export class ISwitchControlBaseHostComponent
+{
+klass = input<string>()
+id = input<string>()
+name = input<string>()
+disabled = input<boolean>()
+checked = model<boolean>()
+}
+",
+  "astro/ISwitchControlBase.astro": "---
+export interface SwitchControlBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control (form submission). */
+  name?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+}
+type Props = SwitchControlBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { id, name, disabled, ...__attrs } = props;
+let checked = props.checked
+---
+<input {...__attrs} class={["switch-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={id} name={name} checked={checked ?? false} aria-checked={checked ? "true" : "false"} disabled={disabled} onChange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+",
+  "qwik/ISwitchControlBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
+export interface SwitchControlBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control (form submission). */
+  name?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+}
+export const ISwitchControlBase = component$((props: SwitchControlBaseProps & { checked?: boolean; onUpdateChecked$?: QRL<(value: boolean) => void> } & Record<string, any>) =>
+{
+const { id, name, disabled, checked, onUpdateChecked$, ...__attrs } = props
+return (
+<input {...__attrs} class={["switch-field", props.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} disabled={props.disabled} onChange={$((e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked$?.(e.currentTarget.checked))} onKeyDown={$((e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click())} />
+)
+});
+",
+  "react/ISwitchControlBase.tsx": "export interface SwitchControlBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control (form submission). */
+  name?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+}
+export function ISwitchControlBase(props: SwitchControlBaseProps & { checked?: boolean; onUpdateChecked?: (value: boolean) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const { id, name, disabled, checked, onUpdateChecked, ...__attrs } = props
+return (
+<input {...__attrs} className={["switch-field", props.className].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} disabled={props.disabled} onChange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+)
+}
+",
+  "solid/ISwitchControlBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface SwitchControlBaseProps {
+  /** Id of the native control. */
+  id?: string;
+  /** Name of the native control (form submission). */
+  name?: string;
+  /** Disables the control. */
+  disabled?: boolean;
+}
+export default function ISwitchControlBase(props: SwitchControlBaseProps & { checked?: boolean; onUpdateChecked?: (value: boolean) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["id", "name", "disabled", "checked", "onUpdateChecked"])
+return (
+<input {...__attrs} class={["switch-field", props.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} disabled={props.disabled} onchange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} onkeydown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+)
+}
+",
+  "svelte/ISwitchControlBase.svelte": "<script lang="ts">
+  export interface SwitchControlBaseProps {
+    /** Id of the native control. */
+    id?: string;
+    /** Name of the native control (form submission). */
+    name?: string;
+    /** Disables the control. */
+    disabled?: boolean;
+  }
+  let { id, name, disabled, checked = $bindable(), ...__attrs }: SwitchControlBaseProps & { checked?: boolean } & Record<string, any> = $props()
+</script>
+<input {...__attrs} class={["switch-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={id} name={name} checked={checked ?? false} aria-checked={checked ? "true" : "false"} disabled={disabled} onchange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} onkeydown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+",
+  "vue/ISwitchControlBase.vue": "<script setup lang="ts">
+  export interface SwitchControlBaseProps {
+    /** Id of the native control. */
+    id?: string;
+    /** Name of the native control (form submission). */
+    name?: string;
+    /** Disables the control. */
+    disabled?: boolean;
+  }
+  const props = defineProps<SwitchControlBaseProps>()
+  const checked = defineModel<boolean>("checked")
+</script>
+<template>
+<input class="switch-field" type="checkbox" role="switch" :id="id" :name="name" :checked="checked ?? false" :aria-checked='checked ? "true" : "false"' :disabled="disabled" @change="(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked" @keydown='(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()' />
+</template>
+",
+}
+`;

--- a/ui/components/src/components/switch/headless/__snapshots__/ISwitchLabelBase.ink.test.ts.snap
+++ b/ui/components/src/components/switch/headless/__snapshots__/ISwitchLabelBase.ink.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SwitchLabelBase > output matches snapshots 1`] = `
+{
+  "angular/ISwitchLabelBase.component.ts": "import { Component, signal, computed, effect, input } from "@angular/core";
+export interface SwitchLabelBaseProps {}
+@Component({ standalone: true, selector: 'ink-switch-label-base', host: { style: 'display: contents' }, template: \`<span [class]="'switch-label' + (klass() ? ' ' + klass() : '')">
+<ng-content></ng-content>
+</span>\` })
+export class ISwitchLabelBaseComponent
+{
+klass = input<string>()
+}
+@Component({ standalone: true, selector: 'span[ink-switch-label-base]', host: { '[class]': "'switch-label' + (klass() ? ' ' + klass() : '')" }, template: \`<ng-content></ng-content>\` })
+export class ISwitchLabelBaseHostComponent
+{
+klass = input<string>()
+}
+",
+  "astro/ISwitchLabelBase.astro": "---
+export interface SwitchLabelBaseProps {}
+type Props = SwitchLabelBaseProps & Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+---
+<span {...__attrs} class={["switch-label", __attrs.class].filter(Boolean).join(" ")}>
+<slot />
+</span>
+",
+  "qwik/ISwitchLabelBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
+export interface SwitchLabelBaseProps {}
+export const ISwitchLabelBase = component$((props) =>
+{
+const { children, ...__attrs } = props
+return (
+<span {...__attrs} class={["switch-label", props.class].filter(Boolean).join(" ")}>
+  <Slot />
+</span>
+)
+});
+",
+  "react/ISwitchLabelBase.tsx": "export interface SwitchLabelBaseProps {}
+export function ISwitchLabelBase(props: SwitchLabelBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
+{
+const { children, ...__attrs } = props
+return (
+<span {...__attrs} className={["switch-label", props.className].filter(Boolean).join(" ")}>
+  {props.children}
+</span>
+)
+}
+",
+  "solid/ISwitchLabelBase.tsx": "import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export interface SwitchLabelBaseProps {}
+export default function ISwitchLabelBase(props: SwitchLabelBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["children"])
+return (
+<span {...__attrs} class={["switch-label", props.class].filter(Boolean).join(" ")}>
+  {props.children}
+</span>
+)
+}
+",
+  "svelte/ISwitchLabelBase.svelte": "<script lang="ts">
+  export interface SwitchLabelBaseProps {}
+  import type { Snippet } from "svelte";
+  let { children, ...__attrs }: SwitchLabelBaseProps & { children?: Snippet } & Record<string, any> = $props()
+</script>
+<span {...__attrs} class={["switch-label", __attrs.class].filter(Boolean).join(" ")}>
+  {@render children?.()}
+</span>
+",
+  "vue/ISwitchLabelBase.vue": "<script setup lang="ts">
+  export interface SwitchLabelBaseProps {}
+  const props = defineProps<SwitchLabelBaseProps>()
+</script>
+<template>
+<span class="switch-label">
+  <slot />
+</span>
+</template>
+",
+}
+`;

--- a/ui/components/src/components/switch/styled/ISwitch.ink.test.ts
+++ b/ui/components/src/components/switch/styled/ISwitch.ink.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileComponent,
+  expectCompilationSuccess,
+  expectCorrectFileExtensions,
+  expectOutputContains,
+  expectImports,
+  assertConformance,
+  snapshotOutput,
+  resolveComponent,
+  type ComponentTestResult,
+  type TargetName,
+} from "@inkline/test-utils";
+import { mountStyledOnAngular } from "../../angular-ssr-helper.ts";
+
+const ISWITCH = resolveComponent(import.meta.url, "./ISwitch.ink.tsx");
+
+const out = (result: ComponentTestResult, target: TargetName) => result.files[target] ?? [];
+
+describe("ISwitch (styled)", () => {
+  it("compiles to all 7 targets without errors", async () => {
+    const result = await compileComponent(ISWITCH);
+    expectCompilationSuccess(result);
+    expect(Object.keys(result.files)).toHaveLength(7);
+  });
+
+  it("emits only the expected Astro two-way notice (INK0045); no hasSlot INK0068", async () => {
+    const result = await compileComponent(ISWITCH);
+    const unexpected = result.diagnostics.filter((d) => d.code !== "INK0045");
+    expect(unexpected.map((d) => `${d.code}: ${d.title}`)).toEqual([]);
+    expect(result.diagnostics.filter((d) => d.code === "INK0068")).toHaveLength(0);
+  });
+
+  it("produces correct file extensions per target", async () => {
+    expectCorrectFileExtensions(await compileComponent(ISWITCH));
+  });
+
+  it("passes conformance invariants for all targets", async () => {
+    assertConformance(await compileComponent(ISWITCH));
+  });
+
+  it("composes every headless part (shell, control, label)", async () => {
+    const result = await compileComponent(ISWITCH);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      const files = out(result, target);
+      expectOutputContains(files, "ISwitchBase");
+      expectOutputContains(files, "ISwitchControlBase");
+      expectOutputContains(files, "ISwitchLabelBase");
+    }
+  });
+
+  it("pulls both Switch recipes from virtual:styleframe", async () => {
+    const result = await compileComponent(ISWITCH);
+    for (const target of ["react", "vue", "solid"] as const) {
+      expectImports(out(result, target), "virtual:styleframe", [
+        "switchRecipe",
+        "switchFieldRecipe",
+      ]);
+    }
+  });
+
+  it("forwards a two-way `checked` to the control per target", async () => {
+    const result = await compileComponent(ISWITCH);
+    expectOutputContains(out(result, "react"), "onUpdateChecked");
+    expectOutputContains(out(result, "vue"), 'v-model:checked="checked"');
+    expectOutputContains(out(result, "svelte"), "bind:checked={checked}");
+    expectOutputContains(out(result, "angular"), "(checkedChange)=");
+  });
+
+  it("output matches snapshots", async () => {
+    expect(snapshotOutput(await compileComponent(ISWITCH))).toMatchSnapshot();
+  });
+});
+
+// Real-DOM verification on the Angular target (SSR via @angular/platform-server): the recipe classes
+// land on the right elements (shell `<label>`, native `<input>`), the switch ARIA contract is
+// present, the label text projects, and the disabled/checked states reflect onto the control.
+describe("ISwitch (styled) on Angular SSR", () => {
+  const HEADLESS = [
+    "../headless/ISwitchBase.ink.tsx",
+    "../headless/ISwitchControlBase.ink.tsx",
+    "../headless/ISwitchLabelBase.ink.tsx",
+  ];
+
+  const mount = (props?: Record<string, unknown>) =>
+    mountStyledOnAngular(import.meta.url, "./ISwitch.ink.tsx", HEADLESS, props);
+
+  it("renders the composed toggle: shell label with recipe classes wrapping the native switch", async () => {
+    const { html } = await mount({
+      label: "Airplane mode",
+      name: "airplane",
+      size: "md",
+      color: "light",
+    });
+
+    expect(html).toMatch(/<label[^>]*class="switch switch--size-md"/);
+    expect(html).toMatch(
+      /<input[^>]*class="switch-field switch-field--color-light switch-field--size-md"/,
+    );
+    expect(html).toMatch(/<input[^>]*type="checkbox"/);
+    expect(html).toMatch(/<input[^>]*role="switch"/);
+    expect(html).toMatch(/<input[^>]*name="airplane"/);
+  });
+
+  it("announces the toggle state via aria-checked and projects the label text", async () => {
+    const { html } = await mount({ label: "Airplane mode", checked: true });
+
+    expect(html).toMatch(/<input[^>]*aria-checked="true"/);
+    expect(html).toMatch(/<input[^>]*checked/);
+    expect(html).toMatch(/<span[^>]*class="switch-label">Airplane mode<\/span>/);
+  });
+
+  it("renders aria-checked=false and an unchecked control when the model is unset", async () => {
+    const { html } = await mount({ label: "Off" });
+
+    expect(html).toMatch(/<input[^>]*aria-checked="false"/);
+    expect(html).not.toMatch(/<input[^>]*aria-checked="true"/);
+  });
+
+  it("keeps the label span empty when no label is provided (the CSS :empty contract)", async () => {
+    const { html } = await mount({ name: "bare" });
+
+    expect(html).toMatch(/<span[^>]*class="switch-label"><\/span>/);
+  });
+
+  it("reflects the disabled state onto the native control", async () => {
+    const { html } = await mount({ label: "Off", disabled: true });
+
+    expect(html).toMatch(/<input[^>]*disabled/);
+  });
+
+  it("forwards id to the control only, not the shell label", async () => {
+    const { html } = await mount({ id: "wifi", label: "Wi-Fi" });
+
+    expect(html).toMatch(/<input[^>]*id="wifi"/);
+    expect(html).not.toMatch(/<label[^>]*id="wifi"/);
+  });
+
+  // The collapsed host variant inlines the composite onto native elements: the shell is the <label>
+  // host, the control is a bare native <input ink-switch-control-base>, the label a <span> — zero
+  // display:contents wrapper elements anywhere.
+  it("host variant renders a zero-wrapper toggle (label > input / span)", async () => {
+    const { html } = await mountStyledOnAngular(
+      import.meta.url,
+      "./ISwitch.ink.tsx",
+      HEADLESS,
+      { label: "Dark mode", checked: true, color: "dark", size: "lg" },
+      "ISwitchHostComponent",
+    );
+
+    expect(html).toMatch(/<label[^>]*ink-switch[^>]*class="switch switch--size-lg"/);
+    expect(html).toMatch(/<input[^>]*ink-switch-control-base[^>]*class="switch-field/);
+    expect(html).toMatch(/<span ink-switch-label-base[^>]*>Dark mode<\/span>/);
+    expect(html).not.toContain("<ink-switch"); // no display:contents wrapper elements
+  });
+});

--- a/ui/components/src/components/switch/styled/ISwitch.ink.tsx
+++ b/ui/components/src/components/switch/styled/ISwitch.ink.tsx
@@ -1,0 +1,57 @@
+import { defineComponent, Slot, defineModel, createMemo } from "@inkline/core";
+import ISwitchBase from "../headless/ISwitchBase.ink.tsx";
+import ISwitchControlBase, {
+  type SwitchControlBaseProps,
+} from "../headless/ISwitchControlBase.ink.tsx";
+import ISwitchLabelBase from "../headless/ISwitchLabelBase.ink.tsx";
+import {
+  switchRecipe,
+  switchFieldRecipe,
+  type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+} from "virtual:styleframe";
+
+// The axes reference the recipe's own prop types so they stay a single source of truth (and the
+// compiler only enumerates members of this directly-named interface). `color`/`size` come from the
+// visual `switch-field` recipe; the shell `switch` recipe shares the same `size` scale.
+export interface SwitchProps extends SwitchControlBaseProps {
+  /** Off-state track colour. */
+  color?: SwitchFieldStylingProps["color"];
+  /** Size variant. */
+  size?: SwitchFieldStylingProps["size"];
+  /** Label text; overridden by the default slot. */
+  label?: string;
+}
+
+/**
+ * The styled Switch: an accessible on/off toggle that composes the shell `<label>`, the native
+ * `<input type="checkbox" role="switch">` control, and its text label — styled together with the
+ * Styleframe `switch` / `switch-field` recipes. The two-way `checked` model is forwarded to the
+ * control via `$bind:checked`; the label text (default slot or `label` prop) supplies the accessible
+ * name. Space toggles natively and Enter is handled explicitly.
+ */
+export default defineComponent(
+  { meta: { headless: true }, slots: { default: {} } },
+  (props: SwitchProps) => {
+    const [checked, _setChecked] = defineModel<boolean>("checked");
+
+    const shellClassName = createMemo(() => switchRecipe({ size: props.size }));
+    const fieldClassName = createMemo(() =>
+      switchFieldRecipe({ color: props.color, size: props.size }),
+    );
+
+    return (
+      <ISwitchBase class={shellClassName()}>
+        <ISwitchControlBase
+          class={fieldClassName()}
+          id={props.id}
+          name={props.name}
+          $bind:checked={checked}
+          disabled={props.disabled}
+        />
+        <ISwitchLabelBase>
+          <Slot>{props.label}</Slot>
+        </ISwitchLabelBase>
+      </ISwitchBase>
+    );
+  },
+);

--- a/ui/components/src/components/switch/styled/ISwitch.styleframe.ts
+++ b/ui/components/src/components/switch/styled/ISwitch.styleframe.ts
@@ -1,0 +1,18 @@
+import { styleframe } from "virtual:styleframe";
+import { useSwitchRecipe, useSwitchFieldRecipe } from "@styleframe/theme";
+
+const s = styleframe();
+
+// Both Switch-family recipes are registered here (the single styled ISwitch is the only consumer),
+// so `virtual:styleframe` exports each recipe and emits its `.switch` / `.switch-field` rules.
+export const switchRecipe = useSwitchRecipe(s);
+export const switchFieldRecipe = useSwitchFieldRecipe(s);
+
+// ISwitch always renders its text-label wrapper (no `hasSlot` gate), so an unlabelled switch would
+// otherwise show a trailing gap from the shell's flex layout. Collapsing the empty wrapper removes
+// the label — and its gap — entirely, on every target.
+const { selector } = s;
+
+selector(".switch-label:empty", {
+  display: "none",
+});

--- a/ui/components/src/components/switch/styled/__snapshots__/ISwitch.ink.test.ts.snap
+++ b/ui/components/src/components/switch/styled/__snapshots__/ISwitch.ink.test.ts.snap
@@ -1,0 +1,270 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ISwitch (styled) > output matches snapshots 1`] = `
+{
+  "angular/ISwitch.component.ts": "import { Component, signal, computed, effect, input, model } from "@angular/core";
+import { ISwitchBaseComponent as ISwitchBase } from "../headless/ISwitchBase.component";
+import { ISwitchControlBaseComponent as ISwitchControlBase } from "../headless/ISwitchControlBase.component";
+import { type SwitchControlBaseProps } from "../headless/ISwitchControlBase.component";
+import { ISwitchLabelBaseComponent as ISwitchLabelBase } from "../headless/ISwitchLabelBase.component";
+import { ISwitchControlBaseHostComponent } from "../headless/ISwitchControlBase.component";
+import { ISwitchLabelBaseHostComponent } from "../headless/ISwitchLabelBase.component";
+import {
+  switchRecipe,
+  switchFieldRecipe,
+  type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+} from "virtual:styleframe";
+export interface SwitchProps extends SwitchControlBaseProps {
+  /** Off-state track colour. */
+  color?: SwitchFieldStylingProps["color"];
+  /** Size variant. */
+  size?: SwitchFieldStylingProps["size"];
+  /** Label text; overridden by the default slot. */
+  label?: string;
+}
+@Component({ standalone: true, selector: 'ink-switch', host: { style: 'display: contents' }, imports: [ISwitchBase, ISwitchControlBase, ISwitchLabelBase], template: \`<ink-switch-base [klass]="(shellClassName()) + (klass() ? ' ' + klass() : '')">
+<ink-switch-control-base [klass]="(fieldClassName())" [id]="id()" [name]="name()" [checked]="checked()" [disabled]="disabled()" (checkedChange)="checked.set($event)"></ink-switch-control-base>
+<ink-switch-label-base>
+<ng-content>{{ label() }}</ng-content>
+</ink-switch-label-base>
+</ink-switch-base>\` })
+export class ISwitchComponent
+{
+switchRecipe = switchRecipe
+switchFieldRecipe = switchFieldRecipe
+klass = input<string>()
+shellClassName = computed(() => switchRecipe({ size: this.size() }))
+fieldClassName = computed(() => switchFieldRecipe({ color: this.color(), size: this.size() }))
+color = input<SwitchFieldStylingProps["color"]>()
+size = input<SwitchFieldStylingProps["size"]>()
+label = input<string>()
+id = input<string>()
+name = input<string>()
+disabled = input<boolean>()
+checked = model<boolean>()
+}
+@Component({ standalone: true, selector: 'label[ink-switch]', host: { '[class]': "'switch' + ((shellClassName()) ? ' ' + (shellClassName()) : '') + (klass() ? ' ' + klass() : '')", 'ink-switch-base': '' }, imports: [ISwitchControlBaseHostComponent, ISwitchLabelBaseHostComponent], template: \`<input ink-switch-control-base [klass]="(fieldClassName())" [id]="id()" [name]="name()" [checked]="checked()" [disabled]="disabled()" (checkedChange)="checked.set($event)" />
+<span ink-switch-label-base>
+<ng-content>{{ label() }}</ng-content>
+</span>\` })
+export class ISwitchHostComponent
+{
+switchRecipe = switchRecipe
+switchFieldRecipe = switchFieldRecipe
+klass = input<string>()
+shellClassName = computed(() => switchRecipe({ size: this.size() }))
+fieldClassName = computed(() => switchFieldRecipe({ color: this.color(), size: this.size() }))
+color = input<SwitchFieldStylingProps["color"]>()
+size = input<SwitchFieldStylingProps["size"]>()
+label = input<string>()
+id = input<string>()
+name = input<string>()
+disabled = input<boolean>()
+checked = model<boolean>()
+}
+",
+  "astro/ISwitch.astro": "---
+import ISwitchBase from "../headless/ISwitchBase.astro";
+import ISwitchControlBase, { type SwitchControlBaseProps } from "../headless/ISwitchControlBase.astro";
+import ISwitchLabelBase from "../headless/ISwitchLabelBase.astro";
+import {
+  switchRecipe,
+  switchFieldRecipe,
+  type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+} from "virtual:styleframe";
+export interface SwitchProps extends SwitchControlBaseProps {
+  /** Off-state track colour. */
+  color?: SwitchFieldStylingProps["color"];
+  /** Size variant. */
+  size?: SwitchFieldStylingProps["size"];
+  /** Label text; overridden by the default slot. */
+  label?: string;
+}
+type Props = SwitchProps & Record<string, any>
+const props = Astro.props as Props;
+const { color, size, label, id, name, disabled, ...__attrs } = props;
+let checked = props.checked
+const shellClassName = switchRecipe({ size: size })
+const fieldClassName = switchFieldRecipe({ color: color, size: size })
+---
+<ISwitchBase {...__attrs} class={[shellClassName, __attrs.class].filter(Boolean).join(" ")}>
+<ISwitchControlBase class={fieldClassName} id={id} name={name} checked={checked} disabled={disabled} />
+<ISwitchLabelBase>
+<slot>
+{label}
+</slot>
+</ISwitchLabelBase>
+</ISwitchBase>
+",
+  "qwik/ISwitch.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL, Slot } from "@qwik.dev/core";
+import { ISwitchBase } from "../headless/ISwitchBase";
+import { ISwitchControlBase } from "../headless/ISwitchControlBase";
+import { type SwitchControlBaseProps } from "../headless/ISwitchControlBase";
+import { ISwitchLabelBase } from "../headless/ISwitchLabelBase";
+import {
+  switchRecipe,
+  switchFieldRecipe,
+  type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+} from "virtual:styleframe";
+export interface SwitchProps extends SwitchControlBaseProps {
+  /** Off-state track colour. */
+  color?: SwitchFieldStylingProps["color"];
+  /** Size variant. */
+  size?: SwitchFieldStylingProps["size"];
+  /** Label text; overridden by the default slot. */
+  label?: string;
+}
+export const ISwitch = component$((props: SwitchProps & { checked?: boolean; onUpdateChecked$?: QRL<(value: boolean) => void> } & Record<string, any>) =>
+{
+const shellClassName = useComputed$(() => switchRecipe({ size: props.size }))
+const fieldClassName = useComputed$(() => switchFieldRecipe({ color: props.color, size: props.size }))
+const { children, color, size, label, id, name, disabled, checked, onUpdateChecked$, ...__attrs } = props
+return (
+<ISwitchBase {...__attrs} class={[shellClassName.value, props.class].filter(Boolean).join(" ")}>
+  <>
+    <ISwitchControlBase class={fieldClassName.value} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} onUpdateChecked$={$(v => props.onUpdateChecked$?.(v))} />
+    <ISwitchLabelBase>
+      <Slot>
+        {props.label}
+      </Slot>
+    </ISwitchLabelBase>
+  </>
+</ISwitchBase>
+)
+});
+",
+  "react/ISwitch.tsx": "import { useMemo } from "react";
+import { ISwitchBase } from "../headless/ISwitchBase";
+import { ISwitchControlBase } from "../headless/ISwitchControlBase";
+import { type SwitchControlBaseProps } from "../headless/ISwitchControlBase";
+import { ISwitchLabelBase } from "../headless/ISwitchLabelBase";
+import {
+  switchRecipe,
+  switchFieldRecipe,
+  type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+} from "virtual:styleframe";
+export interface SwitchProps extends SwitchControlBaseProps {
+  /** Off-state track colour. */
+  color?: SwitchFieldStylingProps["color"];
+  /** Size variant. */
+  size?: SwitchFieldStylingProps["size"];
+  /** Label text; overridden by the default slot. */
+  label?: string;
+}
+export function ISwitch(props: SwitchProps & { children?: React.ReactNode } & { checked?: boolean; onUpdateChecked?: (value: boolean) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const shellClassName = useMemo(() => switchRecipe({ size: props.size }), [props.size])
+const fieldClassName = useMemo(() => switchFieldRecipe({ color: props.color, size: props.size }), [props.color, props.size])
+const { children, color, size, label, id, name, disabled, checked, onUpdateChecked, ...__attrs } = props
+return (
+<ISwitchBase {...__attrs} className={[shellClassName, props.className].filter(Boolean).join(" ")}>
+  <>
+    <ISwitchControlBase className={fieldClassName} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} onUpdateChecked={v => props.onUpdateChecked?.(v)} />
+    <ISwitchLabelBase>
+      {props.children ?? props.label}
+    </ISwitchLabelBase>
+  </>
+</ISwitchBase>
+)
+}
+",
+  "solid/ISwitch.tsx": "import { createMemo, splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+import ISwitchBase from "../headless/ISwitchBase";
+import ISwitchControlBase, { type SwitchControlBaseProps } from "../headless/ISwitchControlBase";
+import ISwitchLabelBase from "../headless/ISwitchLabelBase";
+import {
+  switchRecipe,
+  switchFieldRecipe,
+  type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+} from "virtual:styleframe";
+export interface SwitchProps extends SwitchControlBaseProps {
+  /** Off-state track colour. */
+  color?: SwitchFieldStylingProps["color"];
+  /** Size variant. */
+  size?: SwitchFieldStylingProps["size"];
+  /** Label text; overridden by the default slot. */
+  label?: string;
+}
+export default function ISwitch(props: SwitchProps & { children?: any } & { checked?: boolean; onUpdateChecked?: (value: boolean) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const shellClassName = createMemo(() => switchRecipe({ size: props.size }))
+const fieldClassName = createMemo(() => switchFieldRecipe({ color: props.color, size: props.size }))
+const [, __attrs] = splitProps(props, ["children", "color", "size", "label", "id", "name", "disabled", "checked", "onUpdateChecked"])
+return (
+<ISwitchBase {...__attrs} class={[shellClassName(), props.class].filter(Boolean).join(" ")}>
+  <>
+    <ISwitchControlBase class={fieldClassName()} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} onUpdateChecked={v => props.onUpdateChecked?.(v)} />
+    <ISwitchLabelBase>
+      {props.children ?? props.label}
+    </ISwitchLabelBase>
+  </>
+</ISwitchBase>
+)
+}
+",
+  "svelte/ISwitch.svelte": "<script lang="ts">
+  import ISwitchBase from "../headless/ISwitchBase.svelte";
+  import ISwitchControlBase, { type SwitchControlBaseProps } from "../headless/ISwitchControlBase.svelte";
+  import ISwitchLabelBase from "../headless/ISwitchLabelBase.svelte";
+  import {
+    switchRecipe,
+    switchFieldRecipe,
+    type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+  } from "virtual:styleframe";
+  export interface SwitchProps extends SwitchControlBaseProps {
+    /** Off-state track colour. */
+    color?: SwitchFieldStylingProps["color"];
+    /** Size variant. */
+    size?: SwitchFieldStylingProps["size"];
+    /** Label text; overridden by the default slot. */
+    label?: string;
+  }
+  import type { Snippet } from "svelte";
+  let { color, size, label, id, name, disabled, checked = $bindable(), children, ...__attrs }: SwitchProps & { checked?: boolean; children?: Snippet } & Record<string, any> = $props()
+  let shellClassName = $derived(switchRecipe({ size: size }))
+  let fieldClassName = $derived(switchFieldRecipe({ color: color, size: size }))
+</script>
+<ISwitchBase {...__attrs} class={[shellClassName, __attrs.class].filter(Boolean).join(" ")}>
+  <ISwitchControlBase bind:checked={checked} class={fieldClassName} id={id} name={name} disabled={disabled} />
+  <ISwitchLabelBase>
+    {#if children}{@render children()}{:else}{label}{/if}
+  </ISwitchLabelBase>
+</ISwitchBase>
+",
+  "vue/ISwitch.vue": "<script setup lang="ts">
+  import { computed } from "vue";
+  import ISwitchBase from "../headless/ISwitchBase.vue";
+  import ISwitchControlBase, { type SwitchControlBaseProps } from "../headless/ISwitchControlBase.vue";
+  import ISwitchLabelBase from "../headless/ISwitchLabelBase.vue";
+  import {
+    switchRecipe,
+    switchFieldRecipe,
+    type SwitchFieldRecipeProps as SwitchFieldStylingProps,
+  } from "virtual:styleframe";
+  export interface SwitchProps extends SwitchControlBaseProps {
+    /** Off-state track colour. */
+    color?: SwitchFieldStylingProps["color"];
+    /** Size variant. */
+    size?: SwitchFieldStylingProps["size"];
+    /** Label text; overridden by the default slot. */
+    label?: string;
+  }
+  const props = defineProps<SwitchProps>()
+  const checked = defineModel<boolean>("checked")
+  const shellClassName = computed(() => switchRecipe({ size: props.size }))
+  const fieldClassName = computed(() => switchFieldRecipe({ color: props.color, size: props.size }))
+</script>
+<template>
+<ISwitchBase :class="shellClassName">
+  <ISwitchControlBase v-model:checked="checked" :class="fieldClassName" :id="id" :name="name" :disabled="disabled" />
+  <ISwitchLabelBase>
+    <slot>
+      {{ label }}
+    </slot>
+  </ISwitchLabelBase>
+</ISwitchBase>
+</template>
+",
+}
+`;


### PR DESCRIPTION
## Summary

Adds the accessible **Switch** (on/off toggle) family to `ui/components` — the next component in catalog wave 1 (INK-8, parent INK-5).

- **Headless parts** (`switch/headless/`): `ISwitchBase` (the `<label>` shell), `ISwitchControlBase` (native `<input type="checkbox" role="switch">` with the two-way `checked` model), and `ISwitchLabelBase` (the text label).
- **Styled** (`switch/styled/ISwitch`): composes the three parts and applies the Styleframe `switch` / `switch-field` recipes; `.switch-label:empty` collapse rule ships with it.
- **Axes**: `color` (`light` / `dark` / `neutral`) and `size` (`sm` / `md` / `lg`), typed from the recipes' own `RecipeProps`.
- **Accessibility** (WAI-ARIA Switch): `role="switch"` + `aria-checked` on a native checkbox, Space toggles natively, Enter synthesises the native click, `disabled` reflected, label supplies the accessible name.

### Cross-target note — the Enter handler

The Enter key is authored as a single-expression arrow body — `e.key === "Enter" && e.currentTarget.click()` — deliberately, not an `if` block. Angular's event bindings carry only a single expression (a block's `if`/`return` are dropped, which silently produced an empty `(keydown)=""`), and both the linter and Vue/Svelte's assignment-lowered model setter reject guarded statement forms. Synthesising the native click keeps one source of truth (click → `onChange` → `setChecked`) and survives all six interactive targets. A regression test locks this in.

## Verification

- `cd ui/components && pnpm build` — clean to all 7 targets; only the expected `INK0045` (Astro two-way) notices on the switch, no `INK0068`, no errors.
- `vp test --coverage` — 36 switch tests pass (compile, diagnostics, conformance, ARIA contract, cross-target bindings, snapshots, and real-DOM Angular SSR mounts); branch coverage 100%, line coverage on par with the shipped baselines.
- `vp check` — 0 warnings, 0 errors.
- Changeset: `minor` bump for each `@inkline/<framework>` package.

## Test plan

- [x] `pnpm build` clean to 7 targets (expected notices only)
- [x] `vp test --coverage` green (36/36)
- [x] `vp check` clean
- [x] Changeset added
