### PR TITLE
fix(compiler): emit refs before memos/effects on React and Vue (INK-12)

### DIFF
--- a/.changeset/ref-before-effect-react-vue.md
+++ b/.changeset/ref-before-effect-react-vue.md
@@ -1,0 +1,20 @@
+---
+"@inkline/compiler": patch
+"@inkline/react": patch
+"@inkline/vue": patch
+---
+
+fix(compiler): emit refs before memos/effects on React and Vue (INK-12)
+
+The React and Vue emitters declared element refs after memos and effects. React
+dependency arrays (`[controlRef.current, …]`) evaluate synchronously at the
+`useMemo`/`useEffect` call site, and Vue's `watchEffect` runs its callback
+synchronously at setup — so a ref referenced before its `const` declaration was a
+temporal-dead-zone `ReferenceError` that crashed the component on mount (e.g. a
+`createRef` + `createEffect` pair setting a DOM IDL property like `indeterminate`).
+
+Refs are inert `null` declarations that depend on nothing, so the refs loop is now
+hoisted above the memos/effects loops in both emitters — behavior-preserving and
+matching source order. Solid/Svelte/Qwik defer effects, Angular initializes class
+fields before the constructor body, and Astro emits no effects, so those targets
+were already correct and emit byte-identical output.

--- a/core/compiler/src/codegen/targets/react/__snapshots__/index.test.ts.snap
+++ b/core/compiler/src/codegen/targets/react/__snapshots__/index.test.ts.snap
@@ -123,13 +123,13 @@ return (
 `;
 
 exports[`react emit + print > useRef with element type 1`] = `
-"import { useState, useMemo, useEffect, useRef } from "react";
+"import { useState, useRef, useMemo, useEffect } from "react";
 export function Form(props: Record<string, never>)
 {
 const [count, setCount] = useState(0)
+const inputRef = useRef<HTMLInputElement>(null)
 const doubled = useMemo(() => count * 2, [count])
 useEffect(() => { console.log("effect"); }, [])
-const inputRef = useRef<HTMLInputElement>(null)
 return (
 <div />
 )

--- a/core/compiler/src/codegen/targets/react/index.test.ts
+++ b/core/compiler/src/codegen/targets/react/index.test.ts
@@ -205,6 +205,24 @@ describe("react emit + print", () => {
     expect(emitCode(react, comp)).toMatchSnapshot();
   });
 
+  it("declares refs before the memos and effects that read them (INK-12 TDZ)", () => {
+    // richComp carries a `doubled` memo and a `console.log` effect; adding a ref must not leave the
+    // `const inputRef = useRef(...)` declaration below the `useMemo`/`useEffect` calls, or a deps
+    // array referencing `inputRef.current` would be a temporal-dead-zone ReferenceError.
+    const code = emitCode(
+      react,
+      richComp("Form", createElement({ tag: "div" }), { refs: elementRef() }),
+    );
+    const refIdx = code.indexOf("const inputRef = useRef");
+    const memoIdx = code.indexOf("useMemo(");
+    const effectIdx = code.indexOf("useEffect(");
+    expect(refIdx).toBeGreaterThanOrEqual(0);
+    expect(memoIdx).toBeGreaterThanOrEqual(0);
+    expect(effectIdx).toBeGreaterThanOrEqual(0);
+    expect(refIdx).toBeLessThan(memoIdx);
+    expect(refIdx).toBeLessThan(effectIdx);
+  });
+
   it("forwardRef: expose and props both present", () => {
     const comp = richComp("Modal", createElement({ tag: "div" }), {
       props: [{ name: "title", required: true, symbolId: "t::prop::title@0" as SymbolId, loc }],

--- a/core/compiler/src/codegen/targets/react/index.ts
+++ b/core/compiler/src/codegen/targets/react/index.ts
@@ -567,6 +567,19 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       }),
     );
   }
+  // Refs are inert `null` declarations that depend on nothing, so they must precede any memo or
+  // effect that reads them: React deps arrays (`[ref.current, …]`) are evaluated synchronously at
+  // the `useMemo`/`useEffect` call site, so a ref referenced before its `const` declaration is a
+  // temporal-dead-zone ReferenceError (INK-12).
+  for (const r of component.refs) {
+    reactImports.push("useRef");
+    body.push(
+      cStmt({
+        body: `const ${r.name} = useRef${r.elementType ? `<${r.elementType}>` : ""}(null)`,
+        span: r.loc,
+      }),
+    );
+  }
   for (const m of component.memos) {
     reactImports.push("useMemo");
     body.push(
@@ -623,15 +636,6 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       cStmt({
         body: `useEffect(() => { (${fetcher})().then(${dataSetter})${catchPart}${finallyPart}; }, [])`,
         span: res.loc,
-      }),
-    );
-  }
-  for (const r of component.refs) {
-    reactImports.push("useRef");
-    body.push(
-      cStmt({
-        body: `const ${r.name} = useRef${r.elementType ? `<${r.elementType}>` : ""}(null)`,
-        span: r.loc,
       }),
     );
   }

--- a/core/compiler/src/codegen/targets/vue/__snapshots__/index.test.ts.snap
+++ b/core/compiler/src/codegen/targets/vue/__snapshots__/index.test.ts.snap
@@ -56,9 +56,9 @@ exports[`vue emit + print > ref() for element ref 1`] = `
 "<script setup lang="ts">
   import { ref, computed, watchEffect } from "vue";
   const count = ref(0)
+  const inputRef = ref<HTMLInputElement | null>(null)
   const doubled = computed(() => count.value * 2)
   watchEffect(() => { console.log("effect"); })
-  const inputRef = ref<HTMLInputElement | null>(null)
 </script>
 <template>
 <div />

--- a/core/compiler/src/codegen/targets/vue/index.test.ts
+++ b/core/compiler/src/codegen/targets/vue/index.test.ts
@@ -53,6 +53,24 @@ describe("vue emit + print", () => {
     expect(emitCode(vue, comp)).toMatchSnapshot();
   });
 
+  it("declares refs before the computed and watchEffect that read them (INK-12 TDZ)", () => {
+    // richComp carries a `doubled` computed and a `watchEffect`; the ref declaration must sit above
+    // them, or `watchEffect` (which runs synchronously at setup) would read `inputRef.value` before
+    // its `const inputRef = ref(null)` declaration — a temporal-dead-zone error.
+    const code = emitCode(
+      vue,
+      richComp("Form", createElement({ tag: "div" }), { refs: elementRef() }),
+    );
+    const refIdx = code.indexOf("const inputRef = ref");
+    const computedIdx = code.indexOf("computed(");
+    const effectIdx = code.indexOf("watchEffect(");
+    expect(refIdx).toBeGreaterThanOrEqual(0);
+    expect(computedIdx).toBeGreaterThanOrEqual(0);
+    expect(effectIdx).toBeGreaterThanOrEqual(0);
+    expect(refIdx).toBeLessThan(computedIdx);
+    expect(refIdx).toBeLessThan(effectIdx);
+  });
+
   it("emits a scoped style block", () => {
     const comp = richComp(
       "Styled",

--- a/core/compiler/src/codegen/targets/vue/index.ts
+++ b/core/compiler/src/codegen/targets/vue/index.ts
@@ -324,6 +324,18 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       }),
     );
   }
+  // Refs are inert `null` declarations that depend on nothing, so they must precede any memo or
+  // effect that reads them: `watchEffect` runs its callback synchronously at setup, so a ref
+  // referenced before its `const ref(null)` declaration is a temporal-dead-zone error (INK-12).
+  for (const r of component.refs) {
+    vueImports.push("ref");
+    scriptBody.push(
+      cStmt({
+        body: `const ${r.name} = ref${r.elementType ? `<${r.elementType} | null>` : ""}(null)`,
+        span: r.loc,
+      }),
+    );
+  }
   for (const m of component.memos) {
     vueImports.push("computed");
     scriptBody.push(
@@ -356,15 +368,6 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       cStmt({
         body: `;(${fetcher})().then((d) => ${res.name}.value = d)${onError}${onFinally}`,
         span: res.loc,
-      }),
-    );
-  }
-  for (const r of component.refs) {
-    vueImports.push("ref");
-    scriptBody.push(
-      cStmt({
-        body: `const ${r.name} = ref${r.elementType ? `<${r.elementType} | null>` : ""}(null)`,
-        span: r.loc,
       }),
     );
   }


### PR DESCRIPTION
## Summary

Fixes INK-12: the React and Vue emitters declared element refs **after** memos and effects, producing a temporal-dead-zone `ReferenceError` at runtime.

- **React** — `useEffect(cb, [controlRef.current, …])` deps arrays evaluate synchronously at the call site; with `const controlRef = useRef(null)` emitted below, `controlRef` is read before its declaration → TDZ crash on mount.
- **Vue** — `watchEffect(...)` runs its callback synchronously at setup, above `const controlRef = ref(null)` → same TDZ crash.

## Fix

Refs are inert `null` declarations that depend on nothing, so the refs loop is hoisted above the memos and effects loops in both emitters. This is behavior-preserving and matches idiomatic source order.

The other five targets were already correct and are untouched:
- **Solid / Svelte / Qwik** defer effects (`createEffect` / `$effect` / `useVisibleTask$`), so there is no synchronous TDZ.
- **Angular** refs are class fields; per JS semantics all field initializers run before the constructor body (where `effect()` lives).
- **Astro** emits no runtime effects.

> Note: the Angular *host-collapse* ref-resolution issue mentioned in INK-12 is a separate, deeper problem (viewChild cannot resolve once the element becomes the component host) — not an ordering defect, and out of scope here.

## Test plan

- [x] Added per-target ordering tests (`react/index.test.ts`, `vue/index.test.ts`) pinning refs-before-memos/effects (INK-12 TDZ).
- [x] Updated the two affected snapshots (`useRef with element type`, `ref() for element ref`) to the corrected ordering.
- [x] Full compiler suite green: **3208 tests / 216 files**, including cross-target scenario tests — the 5 unaffected targets emit byte-identical output.
- [x] `vp check` clean on all changed files.

Once this lands, the Checkbox `indeterminate` control can switch from the attribute workaround back to the ref+effect path for full-target parity (@palette).

cc @warden for review.