### PR TITLE
feat(components): Switch Storybook stories

### DIFF
--- a/ui/components/src/components/switch/stories/ISwitch.ink.stories.ts
+++ b/ui/components/src/components/switch/stories/ISwitch.ink.stories.ts
@@ -1,0 +1,37 @@
+import { defineStories } from "@inkline/storybook";
+import type { SwitchProps } from "../styled/ISwitch.ink.tsx";
+
+const meta = defineStories<SwitchProps>({
+  component: "ISwitch",
+  title: "Components/Forms/Switch",
+  args: {
+    label: "Airplane mode",
+    disabled: false,
+  },
+  argTypes: {
+    label: { control: "text", description: "Label text; overridden by the default slot" },
+    color: {
+      control: "select",
+      options: ["light", "dark", "neutral"],
+      description: "Off-state track color",
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+      description: "Size variant",
+    },
+    name: { control: "text", description: "Native control name (form submission)" },
+    disabled: { control: "boolean", description: "Disabled state" },
+  },
+});
+
+export default meta;
+
+export const Default = {};
+export const Disabled = { args: { disabled: true } };
+export const Checked = { render: "./SwitchChecked.ink.tsx" };
+export const Colors = { render: "./SwitchColors.ink.tsx" };
+export const Sizes = { render: "./SwitchSizes.ink.tsx" };
+export const States = { render: "./SwitchStates.ink.tsx" };
+export const LabelSlot = { render: "./SwitchLabelSlot.ink.tsx" };
+export const TwoWay = { render: "./SwitchTwoWay.ink.tsx" };

--- a/ui/components/src/components/switch/stories/SwitchChecked.ink.tsx
+++ b/ui/components/src/components/switch/stories/SwitchChecked.ink.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from "@inkline/core";
+import ISwitch from "../styled/ISwitch.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ISwitch label="Off" checked={false} />
+      <ISwitch label="On" checked={true} />
+    </div>
+  );
+});

--- a/ui/components/src/components/switch/stories/SwitchColors.ink.tsx
+++ b/ui/components/src/components/switch/stories/SwitchColors.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent } from "@inkline/core";
+import ISwitch from "../styled/ISwitch.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ISwitch color="light" label="Light" />
+      <ISwitch color="dark" label="Dark" />
+      <ISwitch color="neutral" label="Neutral" />
+    </div>
+  );
+});

--- a/ui/components/src/components/switch/stories/SwitchLabelSlot.ink.tsx
+++ b/ui/components/src/components/switch/stories/SwitchLabelSlot.ink.tsx
@@ -1,0 +1,13 @@
+import { defineComponent } from "@inkline/core";
+import ISwitch from "../styled/ISwitch.ink.tsx";
+
+// Parity: the `label` prop and the default slot resolve to the same accessible name; the slot wins
+// when both are present.
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ISwitch label="Label via prop" />
+      <ISwitch>Label via slot</ISwitch>
+    </div>
+  );
+});

--- a/ui/components/src/components/switch/stories/SwitchSizes.ink.tsx
+++ b/ui/components/src/components/switch/stories/SwitchSizes.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent } from "@inkline/core";
+import ISwitch from "../styled/ISwitch.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ISwitch size="sm" label="Small" />
+      <ISwitch size="md" label="Medium" />
+      <ISwitch size="lg" label="Large" />
+    </div>
+  );
+});

--- a/ui/components/src/components/switch/stories/SwitchStates.ink.tsx
+++ b/ui/components/src/components/switch/stories/SwitchStates.ink.tsx
@@ -1,0 +1,13 @@
+import { defineComponent } from "@inkline/core";
+import ISwitch from "../styled/ISwitch.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <ISwitch label="Off" checked={false} />
+      <ISwitch label="On" checked={true} />
+      <ISwitch label="Disabled off" disabled={true} checked={false} />
+      <ISwitch label="Disabled on" disabled={true} checked={true} />
+    </div>
+  );
+});

--- a/ui/components/src/components/switch/stories/SwitchTwoWay.ink.tsx
+++ b/ui/components/src/components/switch/stories/SwitchTwoWay.ink.tsx
@@ -1,0 +1,13 @@
+import { createSignal, defineComponent } from "@inkline/core";
+import ISwitch from "../styled/ISwitch.ink.tsx";
+
+// Two-way binding: toggling the switch updates `on`, reflected live below.
+export default defineComponent(() => {
+  const [on, _setOn] = createSignal(false);
+  return (
+    <div id="story">
+      <ISwitch label="Airplane mode" name="airplane" $bind:checked={on} />
+      <p>Airplane mode is {on() ? "on" : "off"}.</p>
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary

Single-source Storybook stories for the **Switch** component (INK-13), stacked on the component PR #500 (`agent/palette/switch`). Authored once as `.ink.tsx`; the CLI generates CSF3 for all seven frameworks.

- `ISwitch.ink.stories.ts` — `defineStories<SwitchProps>` meta with typed `argTypes` for every meaningful prop (`label`, `color`, `size`, `name`, `disabled`), sensible default args, and inline state variants (`Default`, `Disabled`).
- Render-helper showcases: `Checked`, `Colors` (light/dark/neutral), `Sizes` (sm/md/lg), `States` (on/off × enabled/disabled), `LabelSlot` (label-prop vs default-slot parity), `TwoWay` (`$bind:checked` reflected live).

`checked` is a two-way model (not a member of `SwitchProps`), so checked-state coverage lives in render helpers rather than args — matching the Input stories pattern.

## Verification

- `pnpm build` (root, recursive) — clean compile; CSF3 regenerated for all 7 frameworks (`ui/<fw>/.inkline/components/switch/stories/`).
- Two-way binding lowers correctly per target — React `onUpdateChecked`, Vue `v-model:checked`.
- Only the expected `INK0045` Astro two-way notices on `ISwitch`/`ISwitchControlBase`; no errors, no new diagnostics from the story helpers.
- Story ids: `Default`, `Disabled`, `Checked`, `Colors`, `Sizes`, `States`, `LabelSlot`, `TwoWay` — these are the e2e contract (@gauntlet wires visual-parity once landed).

## Notes

- Base is `agent/palette/switch` so the diff is stories-only (7 files, +111); retarget to `main` after #500 merges.
- Storybook boot (`pnpm run storybook`) across the 7 ports not run here — long-lived dev servers aren't appropriate in this run; the deterministic CSF generation is verified above.