### PR TITLE
fix(compiler): unwrap Angular element refs to .nativeElement

### DIFF
--- a/.changeset/angular-element-ref-native-element-unwrap.md
+++ b/.changeset/angular-element-ref-native-element-unwrap.md
@@ -1,0 +1,16 @@
+---
+"@inkline/compiler": patch
+"@inkline/angular": patch
+---
+
+fix(compiler): unwrap Angular element refs to `.nativeElement`
+
+On the Angular target a class-body read of an element ref (`ref.current` in an
+effect or event handler) resolved to the `viewChild<ElementRef>` wrapper, so
+imperative DOM writes and reads landed on the wrapper instead of the node — a
+silent no-op (`el.indeterminate = …`, `el.focus()`, layout measurement). Element
+refs now unwrap to `this.ref()?.nativeElement`; component-instance refs
+(`<Child ref={x}>`) keep the raw `this.childRef()` signal read, so `ComponentRef`
+output is byte-identical. The element-vs-component signal is derived from the
+render tree (refs on `Element` nodes) rather than the ref declaration category.
+The other six targets already return the raw element and are untouched.

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -30,7 +30,11 @@ export type SetterStyleKind =
 
 export type RefAccessKind =
   | { readonly kind: "field"; readonly field: string }
-  | { readonly kind: "bare" };
+  // `bare` reads the ref variable directly. `unwrap`, when set, appends `?.<unwrap>` to a class-body
+  // (`selfPrefix`) read of an *element* ref — Angular's `viewChild<ElementRef>` signal returns the
+  // ElementRef wrapper, so `ref.current` must unwrap to `this.ref()?.nativeElement` to reach the DOM
+  // node. Gated by {@link RewriteRules.elementRefs} so component refs keep the raw wrapper.
+  | { readonly kind: "bare"; readonly unwrap?: string };
 
 export interface MemberRewriteRules {
   /**
@@ -79,6 +83,13 @@ export interface RewriteRules {
    * {@link setters} gates the write side.
    */
   readonly reactiveReads?: ReadonlySet<string>;
+  /**
+   * Names of refs bound to a DOM element (`<input ref={x}>`). A class-body read of one of these
+   * (`ref.current`) is unwrapped per {@link RefAccessKind} `unwrap` (Angular:
+   * `this.ref()?.nativeElement`); a ref on a component instance (absent here) keeps the raw signal
+   * read. Angular-only.
+   */
+  readonly elementRefs?: ReadonlySet<string>;
   /**
    * Prop names that are destructured into a local with a default applied (e.g. React's
    * `const { color = "blue", ...__attrs } = props`). A read `props.color` is rewritten to the

--- a/core/compiler/src/codegen/shared/expr-rewrite.ts
+++ b/core/compiler/src/codegen/shared/expr-rewrite.ts
@@ -249,10 +249,18 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
     if (expr.name.text === "current") {
       const base = walk(expr.expression, rules);
       switch (rules.refAccess.kind) {
-        case "bare":
-          // In a class body (Angular), a ref is a `viewChild` signal member, so `inputRef.current`
-          // becomes `this.inputRef()`; in the template it stays the bare template-ref variable.
-          return rules.selfPrefix ? `this.${base}()` : base;
+        case "bare": {
+          // In the template a ref stays the bare template-ref variable (already the DOM node).
+          if (!rules.selfPrefix) return base;
+          // In a class body (Angular) a ref is a `viewChild` signal member, so `inputRef.current`
+          // becomes `this.inputRef()`. For an *element* ref that call returns an `ElementRef`
+          // wrapper, so unwrap to `this.inputRef()?.nativeElement` to reach the real DOM node;
+          // component refs (not in `elementRefs`) keep the raw signal read.
+          const read = `this.${base}()`;
+          return rules.refAccess.unwrap && rules.elementRefs?.has(base)
+            ? `${read}?.${rules.refAccess.unwrap}`
+            : read;
+        }
         case "field":
           return `${base}${expr.questionDotToken ? "?." : "."}${rules.refAccess.field}`;
       }

--- a/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -177,7 +177,7 @@ exports[`angular full output snapshots > ElementRef 1`] = `
 export class ElementRefComponent
 {
 klass = input<string>()
-constructor() { afterNextRender(() => { this.inputRef()?.focus(); }) }
+constructor() { afterNextRender(() => { this.inputRef()?.nativeElement?.focus(); }) }
 inputRef = viewChild<ElementRef>('inputRef')
 }
 "
@@ -350,7 +350,7 @@ exports[`angular full output snapshots > MultiRefs 1`] = `
 export class MultiRefsComponent
 {
 klass = input<string>()
-constructor() { afterNextRender(() => { this.inputRef()?.focus(); }) }
+constructor() { afterNextRender(() => { this.inputRef()?.nativeElement?.focus(); }) }
 inputRef = viewChild<ElementRef>('inputRef')
 buttonRef = viewChild<ElementRef>('buttonRef')
 }

--- a/core/compiler/src/codegen/targets/angular/__tests__/refs.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/refs.test.ts
@@ -17,9 +17,11 @@ describe("ElementRef: single template ref bound + focused on mount", () => {
       'template: `<input placeholder="auto-focus" [class]="klass()" #inputRef />`',
     );
     // onMount is wired: Angular emits `afterNextRender` inside a single constructor, and the focus
-    // body reads the viewChild signal member as `this.inputRef()` (imports the lifecycle helper
-    // alongside viewChild/ElementRef).
-    expect(out).toContain("constructor() { afterNextRender(() => { this.inputRef()?.focus(); }) }");
+    // body reads the viewChild signal member unwrapped to its DOM node —
+    // `this.inputRef()?.nativeElement` (imports the lifecycle helper alongside viewChild/ElementRef).
+    expect(out).toContain(
+      "constructor() { afterNextRender(() => { this.inputRef()?.nativeElement?.focus(); }) }",
+    );
     expect(out).toContain("afterNextRender");
   });
 });
@@ -37,7 +39,10 @@ describe("MultiRefs: two independent refs on sibling elements", () => {
     expect(out).toContain('<input placeholder="focus me" #inputRef />');
     expect(out).toContain("<button #buttonRef>");
     // onMount is wired: the inputRef focus runs via afterNextRender in the constructor, reading the
-    // viewChild signal as `this.inputRef()`. buttonRef is declared but unread (as authored), fine.
-    expect(out).toContain("constructor() { afterNextRender(() => { this.inputRef()?.focus(); }) }");
+    // viewChild signal unwrapped as `this.inputRef()?.nativeElement`. buttonRef is declared but
+    // unread (as authored), fine.
+    expect(out).toContain(
+      "constructor() { afterNextRender(() => { this.inputRef()?.nativeElement?.focus(); }) }",
+    );
   });
 });

--- a/core/compiler/src/codegen/targets/angular/index.test.ts
+++ b/core/compiler/src/codegen/targets/angular/index.test.ts
@@ -207,6 +207,73 @@ describe("Angular codegen fixes", () => {
       expect(code).toContain("viewChild<ElementRef>('inputRef')");
       expect(code).toContain("viewChild");
     });
+
+    it("unwraps an element ref read in an effect to `.nativeElement` for imperative DOM writes", () => {
+      // The `viewChild<ElementRef>` signal returns the ElementRef wrapper; a `.current` read must
+      // unwrap to `this.inputRef()?.nativeElement` so `el.indeterminate = …` lands on the real node
+      // (the bug this change fixes — previously it mutated the wrapper, a silent no-op).
+      const render = createElement({
+        tag: "input",
+        refs: [
+          {
+            ref: createExpr({ expr: mockExpr("inputRef"), deps: DYNAMIC_DEPS }),
+            category: "element",
+            loc,
+          },
+        ],
+      });
+      const comp = makeComp("Form", render, {
+        refs: [
+          {
+            name: "inputRef",
+            symbolId: "t::ref::inputRef@0" as SymbolId,
+            category: "element",
+            elementType: "HTMLInputElement",
+            loc,
+          },
+        ],
+        effects: [
+          {
+            body: mockExpr(
+              "() => { const el = inputRef.current; if (el) { el.indeterminate = true; } }",
+            ),
+            deps: DYNAMIC_DEPS,
+            cleanup: "absent",
+            isDynamic: false,
+            loc,
+          },
+        ],
+      });
+      const code = emitCode(comp);
+      expect(code).toContain("const el = this.inputRef()?.nativeElement;");
+    });
+
+    it("does not unwrap a component ref (keeps the raw viewChild signal read)", () => {
+      // A component ref (`category: "component"`) is not an ElementRef-wrapped DOM node, so its
+      // `.current` read stays `this.childRef()` — no `.nativeElement` unwrap.
+      const comp = makeComp("Wrapper", createElement({ tag: "div" }), {
+        refs: [
+          {
+            name: "childRef",
+            symbolId: "t::ref::childRef@0" as SymbolId,
+            category: "component",
+            loc,
+          },
+        ],
+        effects: [
+          {
+            body: mockExpr("() => { console.log(childRef.current); }"),
+            deps: DYNAMIC_DEPS,
+            cleanup: "absent",
+            isDynamic: false,
+            loc,
+          },
+        ],
+      });
+      const code = emitCode(comp);
+      expect(code).toContain("console.log(this.childRef())");
+      expect(code).not.toContain("nativeElement");
+    });
   });
 
   describe("multiple refs", () => {

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -110,7 +110,9 @@ function analyzeProvide(
 const REWRITES: RewriteRules = {
   reactiveRead: { kind: "preserve-call" },
   setterStyle: { kind: "method-call", method: "set" },
-  refAccess: { kind: "bare" },
+  // A ref is a `viewChild<ElementRef>` signal; a class-body read of an element ref unwraps to
+  // `this.ref()?.nativeElement` (see `elementRefs` below) so imperative DOM writes land on the node.
+  refAccess: { kind: "bare", unwrap: "nativeElement" },
   jsxAttrCasing: "html",
   eventNameCase: "camel",
   members: { props: { strip: true } },
@@ -474,11 +476,25 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   const emitRule = component.emitName
     ? ({ local: component.emitName, style: "angular-output" } as const)
     : undefined;
+  // Refs bound to a DOM element (`<input ref={x}>`) must unwrap to `this.x()?.nativeElement` in
+  // class-body reads (see REWRITES.refAccess); a ref on a component instance keeps the raw `viewChild`
+  // signal read. The render tree is the authoritative element-vs-component signal here — the ref
+  // declaration's `category` is populated by an earlier pass that misses component-instance refs.
+  const elementRefNames = new Set<string>();
+  walkRenderTree(component.render, {
+    enter(node) {
+      if (node.kind === "Element") {
+        for (const r of node.refs) elementRefNames.add(r.ref.expr.getText());
+      }
+    },
+  });
+
   const baseRules: RewriteRules = {
     ...ctx.rewrites,
     setters,
     emit: emitRule,
     reactiveReads: reactiveReadNames(component),
+    elementRefs: elementRefNames,
   };
   const stateSignals = new Set(component.state.map((s) => s.name));
 


### PR DESCRIPTION
## Summary

Fixes INK-14. On the **Angular** target, a `createRef` + `createEffect`/handler that writes a DOM property imperatively was a silent no-op: the ref resolved to the `viewChild<ElementRef>` wrapper, and codegen never unwrapped it to `.nativeElement`, so assignments (`el.indeterminate = …`) and calls (`.focus()`, `.scrollIntoView()`) landed on the wrapper instead of the real node. Follow-up to INK-12. The other six targets already hand back the raw element and are unchanged.

## Before → after (Angular only)

```
this.inputRef()?.focus()   →   this.inputRef()?.nativeElement?.focus()
const el = inputRef.current →   const el = this.inputRef()?.nativeElement
```

## Change (surgical, ~40 lines)

- `context.ts` — `RefAccessKind.bare` gains optional `unwrap?: string`; `RewriteRules` gains `elementRefs?: ReadonlySet<string>`.
- `expr-rewrite.ts` — a `selfPrefix` bare `.current` read appends `?.<unwrap>` **only** when the ref name is in `elementRefs`.
- `angular/index.ts` — sets `unwrap: "nativeElement"` and derives `elementRefs` from the **render tree** (ref names on `Element` nodes via `walkRenderTree`).

## Invariant preserved

The `.current` rewrite keeps the zero-`@inkline/core` guarantee and only touches Angular's `bare + selfPrefix` path. Component-instance refs (`<Child ref={x}>`) deliberately keep the raw `this.childRef()` signal read — never unwrapped — so `ComponentRef` output is byte-identical.

## Why render-tree, not the ref `category`

Keying off `IRRefDeclaration.category === "element"` broke the `ComponentRef` snapshot — `childRef` came back `"element"`. Root cause is a **pre-existing latent bug** in the P3 lower pass `refs.ts`: it reclassifies component refs via `ref.ref.deps[0]?.symbolId`, but component-instance ref bindings carry `deps: []`, so `symbolId` is `undefined` and reclassification never fires. That miscategorization also feeds React's `hasComponentRefs`, so fixing it at source would ripple across targets — left as a follow-up. The render tree is the authoritative element-vs-component signal and keeps this fix Angular-scoped.

## Test plan

- [x] `vp test` — 3208 passed (216 files)
- [x] `vp check` — clean on changed source (fixture `@inkline/core`/JSX errors are pre-existing compiler-input noise)
- [x] `vp pack` — dist rebuilt for consumers
- [x] New unit tests in `angular/index.test.ts` (element ref unwraps in an effect; component ref does not)
- [x] Updated `ElementRef`/`MultiRefs` integration assertions + two output snapshots
