### PR TITLE
ci(codecov): ignore compiled .ink.tsx compile-source from the coverage gate (INK-17)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+# Codecov configuration.
+#
+# `.ink.tsx` files are compile-only authoring source — they never run as a
+# module. Coverage is attributed to them *indirectly*: `coverInkViaReact`
+# renders each component through the React target, V8 instruments the generated
+# `.mjs`, and inline source maps remap that coverage back onto the authored
+# `.ink.tsx` (see ui/components/vite.config.ts). Nested-component JSX elements
+# compile to child-factory closures the remap can't pin to a single executed
+# line, so those lines read as uncovered even when the component demonstrably
+# renders (asserted by the colocated SSR mount tests). That makes line-level
+# coverage on `.ink.tsx` a source-map remap artifact, not a measure of test
+# quality — the executable surface is validated by the test suites themselves.
+#
+# Exclude compiled authoring source from coverage attribution so the gate stops
+# failing on unreachable compile-source lines. The real coverage threshold still
+# applies to normal `.ts`/`.tsx` source and to the local `vp test --coverage`
+# run.
+ignore:
+  - "**/*.ink.tsx"


### PR DESCRIPTION
## Summary
- Adds a repo-root `codecov.yml` ignoring `**/*.ink.tsx` so the coverage gate stops failing on unreachable compile-source lines.
- Config-only: no `.ink.tsx` / component source or tests touched.

## Why
`.ink.tsx` is **compile-only authoring source** — it never runs as a module. Coverage is attributed *indirectly*: `coverInkViaReact` renders the component through the React target, V8 instruments the generated `.mjs`, and inline source maps remap that coverage back onto the authored `.ink.tsx` (`ui/components/vite.config.ts:15-20`). Nested-component JSX elements compile to child-factory closures the remap can't pin to a single executed line, so those lines read as **uncovered even though the component demonstrably renders** (asserted by the colocated SSR mount tests).

This is a **repo-wide source-map artifact**, not a per-component test gap. Already-merged baselines carry it at *lower* coverage than switch:
- `IInput.ink.tsx` → 66.66%
- `IHamburgerMenu.ink.tsx` → 50%
- `ISwitch.ink.tsx` → 75% (branches 100%, executable surface ~100%, 36 tests)

It surfaced on PR #500: patch coverage 91.66% tips under the codecov target (94.62%) purely on `ISwitch.ink.tsx:44`.

## Approach
Chose the recommended repo-wide `ignore` over a component threshold / flag carryforward: line-level coverage on `.ink.tsx` is a **remap artifact that can't faithfully represent compile-only source**, so codecov's line gate can't meaningfully measure these files regardless of the component. The real coverage threshold still applies to normal `.ts`/`.tsx` source and to the local `vp test --coverage` run (parent INK-8's per-file gate is unaffected).

Validated against Codecov's `/validate` endpoint (`Valid!`; ignore glob compiles to `(?s:.*/[^\/]*\.ink\.tsx)\Z`).

## Verify
- [ ] codecov/patch and codecov/project on #500 go green (or non-blocking) once this config is on the default branch.
- [x] Diff is config-only; no `.ink.tsx` / component source touched.

Gate owner sign-off requested below.

Closes INK-17.

