### PR TITLE
feat(storybook-app): configurable production ref domains (INK-19)

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,18 +1,45 @@
 // @ts-nocheck
 const DEV = process.env.NODE_ENV !== "production";
-const ref = (port: number, path: string) => (DEV ? `http://localhost:${port}` : path);
+
+// The seven composed framework Storybooks. `port` is the dev-server port each
+// framework listens on; `path` is the default production location (a relative
+// path the deploy hosts under, preserving today's behavior).
+const frameworks = [
+  { key: "react", title: "React", port: 6006, path: "./react" },
+  { key: "vue", title: "Vue", port: 6007, path: "./vue" },
+  { key: "svelte", title: "Svelte", port: 6008, path: "./svelte" },
+  { key: "solid", title: "Solid", port: 6009, path: "./solid" },
+  { key: "angular", title: "Angular", port: 6010, path: "./angular" },
+  { key: "qwik", title: "Qwik", port: 6011, path: "./qwik" },
+  { key: "astro", title: "Astro", port: 6012, path: "./astro" },
+];
+
+// Production ref URL resolution, in precedence order:
+//   1. STORYBOOK_REF_<KEY> — a full per-framework override (e.g. STORYBOOK_REF_VUE).
+//   2. STORYBOOK_REF_BASE_URL — a template with a `{framework}` placeholder
+//      (e.g. "https://{framework}.storybook.inkline.io").
+//   3. The framework's default relative `path` (today's behavior).
+const template = process.env.STORYBOOK_REF_BASE_URL;
+const prodUrl = ({ key, path }) => {
+  const override = process.env[`STORYBOOK_REF_${key.toUpperCase()}`];
+  if (override) return override;
+  if (template) return template.replace(/\{framework\}/g, key);
+  return path;
+};
+
+const refs = Object.fromEntries(
+  frameworks.map((framework) => [
+    framework.key,
+    {
+      title: framework.title,
+      url: DEV ? `http://localhost:${framework.port}` : prodUrl(framework),
+    },
+  ]),
+);
 
 export default {
   framework: "@storybook/react-vite",
   stories: ["../stories/**/*.stories.ts"],
   addons: ["@storybook/addon-a11y", "@storybook/addon-docs"],
-  refs: {
-    react: { title: "React", url: ref(6006, "./react") },
-    vue: { title: "Vue", url: ref(6007, "./vue") },
-    svelte: { title: "Svelte", url: ref(6008, "./svelte") },
-    solid: { title: "Solid", url: ref(6009, "./solid") },
-    angular: { title: "Angular", url: ref(6010, "./angular") },
-    qwik: { title: "Qwik", url: ref(6011, "./qwik") },
-    astro: { title: "Astro", url: ref(6012, "./astro") },
-  },
+  refs,
 };

--- a/apps/storybook/AGENTS.md
+++ b/apps/storybook/AGENTS.md
@@ -29,7 +29,27 @@ refs: {
 ```
 
 - **In dev** (`pnpm storybook` here, or `pnpm run storybook` from the repo root), each `url` points to the corresponding framework's live Storybook on `localhost:<port>`.
-- **In production** (built by `pnpm storybook:build`), each `url` is a relative path — the deployment is expected to host each framework's built `storybook-static` under that path. CI uploads them as separate artifacts; the deploy step (out of scope here) stitches them together.
+- **In production** (built by `pnpm storybook:build`), each `url` resolves through the config surface below. By default it is a relative path — the deployment is expected to host each framework's built `storybook-static` under that path. CI uploads them as separate artifacts; the deploy step (out of scope here) stitches them together.
+
+## Configuring production ref domains
+
+The seven production ref URLs are configurable via environment variables read at **build time** (`pnpm storybook:build`). Resolution is per-framework, in precedence order:
+
+1. `STORYBOOK_REF_<FRAMEWORK>` — a full per-framework override URL. `<FRAMEWORK>` is the upper-cased key: `STORYBOOK_REF_REACT`, `STORYBOOK_REF_VUE`, `STORYBOOK_REF_SVELTE`, `STORYBOOK_REF_SOLID`, `STORYBOOK_REF_ANGULAR`, `STORYBOOK_REF_QWIK`, `STORYBOOK_REF_ASTRO`.
+2. `STORYBOOK_REF_BASE_URL` — a template with a `{framework}` placeholder applied to every framework at once.
+3. **Default** — the framework's relative path (`./react`, `./vue`, …). This is today's behavior, unchanged when no env var is set.
+
+```bash
+# Point every framework at its own subdomain in one shot:
+STORYBOOK_REF_BASE_URL="https://{framework}.storybook.inkline.io" pnpm storybook:build
+#   → react → https://react.storybook.inkline.io, vue → https://vue.storybook.inkline.io, …
+
+# Override a single framework (takes precedence over the template):
+STORYBOOK_REF_BASE_URL="https://{framework}.storybook.inkline.io" \
+STORYBOOK_REF_QWIK="https://qwik-canary.storybook.inkline.io" pnpm storybook:build
+```
+
+Dev URLs (`localhost:<port>`) are unaffected by these variables.
 
 ## Running
 
@@ -56,7 +76,7 @@ Cross-framework visual-parity tests (Playwright) live in their own package, [`te
 ## When you change something here
 
 - New welcome / landing story → add it under `stories/`. The aggregator only globs `stories/**/*.stories.ts`.
-- New framework target → add a `refs` entry in [`.storybook/main.ts`](./.storybook/main.ts), pick a fresh port, and wire it into:
+- New framework target → add an entry to the `frameworks` table in [`.storybook/main.ts`](./.storybook/main.ts) (key, title, a fresh port, and default relative `path`), and wire it into:
   - The root `package.json` `storybook:frameworks` and `storybook:app` scripts (in the `wait-on tcp:` list).
   - [`docs/contributing.md`](../../docs/contributing.md) → "Dev loops".
   - [`ui/<new-framework>/AGENTS.md`](../../ui/) (port assignment).


### PR DESCRIPTION
## Goal

Let deploy point each composed framework Storybook at its own domain (`vue.storybook.inkline.io`, `react.storybook.inkline.io`, …) instead of the hardcoded relative paths in `apps/storybook/.storybook/main.ts`.

## What changed

`main.ts` now resolves each framework's **production** ref URL through env vars, read at build time (`pnpm storybook:build`), per-framework precedence:

1. `STORYBOOK_REF_<FRAMEWORK>` — full per-framework override (e.g. `STORYBOOK_REF_VUE`)
2. `STORYBOOK_REF_BASE_URL` — a `{framework}` template applied to all
3. **default** — today's relative path (`./react`, `./vue`, …), unchanged

Dev URLs (`localhost:<port>`) are untouched. Refactored the seven hardcoded `refs` entries into a single `frameworks` table (key / title / port / default path). AGENTS.md documents the config surface.

## Acceptance criteria

- [x] No env set → prod refs are the original relative paths (`./react` … `./astro`)
- [x] `STORYBOOK_REF_BASE_URL="https://{framework}.storybook.inkline.io"` → every ref becomes its subdomain
- [x] `STORYBOOK_REF_<FRAMEWORK>` overrides a single target and wins over the template
- [x] Dev mode still points at `localhost:6006–6012`
- [x] AGENTS.md documents the three resolution modes

## Verify

Resolution logic (all three modes) — extracted from `main.ts`, run under `NODE_ENV=production`:

```
# default (no env)
{ react: './react', vue: './vue', svelte: './svelte', solid: './solid',
  angular: './angular', qwik: './qwik', astro: './astro' }

# STORYBOOK_REF_BASE_URL='https://{framework}.storybook.inkline.io'
{ react: 'https://react.storybook.inkline.io', vue: 'https://vue.storybook.inkline.io', … }

# + STORYBOOK_REF_QWIK='https://qwik-canary.inkline.io'
{ …, qwik: 'https://qwik-canary.inkline.io', … }   # per-framework override wins
```

Build command deploy would run:

```bash
STORYBOOK_REF_BASE_URL="https://{framework}.storybook.inkline.io" pnpm --filter @inkline/storybook-app storybook:build
```

`node --input-type=module --check` passes on `main.ts`.

## Out of scope

- The deploy/CI wiring that sets these env vars and hosts each artifact under its domain.
- Dev-mode URLs and ports.
- The Qwik upstream render gap (tracked separately).