### PR TITLE
build(core): emit dts via tsgo (TS7) for @inkline/core and @inkline/inkline (INK-18)

### DIFF
--- a/core/core/vite.config.ts
+++ b/core/core/vite.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
       index: "src/index.ts",
       "jsx-runtime": "src/jsx-runtime.ts",
     },
-    dts: true,
+    dts: {
+      tsgo: true,
+    },
   },
   test: {
     coverage: {

--- a/core/inkline/vite.config.ts
+++ b/core/inkline/vite.config.ts
@@ -21,7 +21,9 @@ export default defineConfig({
       "plugin/rspack": "src/plugin/rspack.ts",
       "plugin/farm": "src/plugin/farm.ts",
     },
-    dts: true,
+    dts: {
+      tsgo: true,
+    },
     format: ["esm", "cjs"],
   },
 });


### PR DESCRIPTION
## Adopt TS7 (tsgo) for dts across the matrix (INK-18)

Extends the existing `pack.dts.tsgo: true` pattern to the last two packages still emitting `.d.ts` via the classic TS6 dts path, so every package that ships types now emits them through the TS7 native CLI (`tsgo`). Runtime `typescript` (`core/compiler`) stays on TS6 by design.

### Diff (surgical — 2 files)

- `core/core/vite.config.ts`: `dts: true` → `dts: { tsgo: true }`
- `core/inkline/vite.config.ts`: `dts: true` → `dts: { tsgo: true }`

Everything else was already TS7:
- `vp check` typecheck already runs through tsgolint (TS7 Go toolchain) via the root `lint.options.typeAware/typeCheck`.
- `core/compiler`, `core/config-loader`, `tooling/cli`, `tooling/storybook`, `tooling/test-utils` already use `dts: { tsgo: true }`.
- Matrix build uses rolldown/esbuild (no tsc); `ui/*` framework packages ship no dts (exports point at `.js` only).

### Acceptance criteria

- [x] tsgo drives dts wherever the native CLI suffices — `pack.dts.tsgo: true` pattern extended to the two remaining packages.
- [x] Catalog `typescript` stays `^6.0.3` (untouched).
- [x] `@inkline/compiler` peer cap `>=5.4 <8` unchanged.
- [x] No runtime `import * as ts from "typescript"` repointed.
- [x] Full matrix `vp check` + build/pack green under tsgo.
- [x] `core/compiler` `vp test` + `vp check` + `vp pack` green — @atlas to verify the compiler boundary before landing.

### Verification (all green)

- `vp run -r build` — rc=0, 0 errors; tsgo dts emitted across the matrix (`core/core` → `dist/index.d.mts` + `dist/jsx-runtime.d.mts`; `core/inkline` → `.d.mts`/`.d.cts` for all 17 entries).
- `vp check` — rc=0, 539 files, 0 errors.
- `core/compiler`: `vp pack` (tsgo dts) green · `vp test` green (216 files / 3208 tests).

### Out of scope / follow-up

- `apps/website` still runs `tsc && vp build`. Flipping its typecheck to `tsgo` needs `@typescript/native-preview` added locally, which forces a non-frozen install that floats the `vite: @latest` catalog pin and churns the lockfile (`@voidzero-dev/vite-plus-core` 0.2.1→0.2.4, unrelated). Deferred to a separate backlog note to keep this diff surgical.
