### PR TITLE
ci: make visual-parity a blocking gate (INK-11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,10 +266,9 @@ jobs:
     name: Visual Parity (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: build
-    # Non-blocking on purpose: deliberately NOT listed in `ci-success.needs` below. The suite currently
-    # surfaces real cross-framework rendering differences that aren't all resolved yet (see
-    # testing/e2e/AGENTS.md), so this job reports them via its uploaded artifacts without gating the
-    # pipeline. To make it blocking, add `visual-parity` to `ci-success.needs`.
+    # Blocking: listed in `ci-success.needs` below. Parity is green and deterministic across all seven
+    # targets, so a diff here is a real regression and fails the pipeline. The uploaded Playwright report
+    # + diff images remain available as artifacts for triage.
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -323,7 +322,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [build, build-storybook, build-website, lint, typecheck, test]
+    needs: [build, build-storybook, build-website, lint, typecheck, test, visual-parity]
     if: always()
     steps:
       - name: Check job status

--- a/testing/e2e/AGENTS.md
+++ b/testing/e2e/AGENTS.md
@@ -65,19 +65,19 @@ of them. Example: `STORY_SHARD=1/2 pnpm --filter @inkline/e2e test:e2e`. CI runs
 exercised at a time. React references are captured once in `beforeAll` and reused across the
 per-framework tests.
 
-## Expect some red
+## Green means green
 
-The suite surfaces **real** cross-framework differences. As of this writing: the Input `two-way` width
-differs ~10px and a Button `sizes` story ~18px between some frameworks, plus a few ±2px rounding diffs;
-Solid matches React exactly; Qwik renders (the suite waits for its container to resume) and shows only
-small `fieldgroup` diffs. These are genuine findings, not test flakiness — the suite is wired
-**non-blocking** in CI (not part of `ci-success`) while they're triaged.
+The suite surfaces **real** cross-framework differences, and it is now green and deterministic across
+all seven targets — Solid, Qwik (the suite waits for its container to resume), and the rest all match
+the React reference. A diff here is a real regression, so the check is **blocking** in CI. Any new red
+is a genuine finding to fix, not test flakiness or an expected residual — read the uploaded Playwright
+report + diff images to triage it.
 
 ## CI
 
-A non-blocking `visual-parity` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+A blocking `visual-parity` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
 (`needs: build`) runs both shards and uploads the Playwright report + diff images as artifacts. It is
-deliberately not in `ci-success.needs`; add it there to make it blocking.
+listed in `ci-success.needs`, so a parity failure fails the pipeline.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Flip `visual-parity` from an informational job to a **blocking** CI gate. Parity is now green and deterministic across all seven targets (React reference + Vue/Svelte/Solid/Angular/Qwik/Astro), so a diff is a real regression and should red the pipeline.

Preconditions satisfied:
- **#496 merged** (2026-07-13) — fixes the last Qwik async-resume harness timing race.
- The stale `testing/e2e/AGENTS.md` "known diffs" (Input `two-way` ~10px, Button `sizes` ~18px) were **real Angular-only wrapper-width divergences resolved by #477** (merged 2026-06-22); the note simply predated the fix.

## Changes

- Add `visual-parity` to `ci-success.needs` so a parity failure fails the pipeline.
- Replace the "non-blocking on purpose" comment on the `visual-parity` job with a note that it now gates the pipeline. Report + diff images are still uploaded as artifacts for triage.
- Update `testing/e2e/AGENTS.md` in lockstep: the "Expect some red" section and the CI note no longer describe the suite as non-blocking, and the stale ~10px/~18px "known diffs" note (resolved by #477) is dropped.

## Verify

- `.github/workflows/ci.yml` diff shows `visual-parity` in `ci-success.needs` and no soft-fail / `continue-on-error` on that job.
- `testing/e2e/AGENTS.md` no longer tells readers to expect red or describes the check as non-blocking.
- `actionlint .github/workflows/ci.yml` passes clean.
- The green pipeline on this PR (with `ci-success` now gated on `visual-parity`) is the acceptance run.

## Out of scope

- No changes to the parity suite / stories (that's `@gauntlet`'s `testing/e2e`; #496 handled the flake).
- No threshold / budget tuning.