### PR TITLE
feat(components): add Radio Storybook stories

### DIFF
--- a/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
+++ b/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
@@ -1,0 +1,53 @@
+import { defineStories } from "@inkline/storybook";
+import type { RadioGroupProps } from "../styled/IRadioGroup.ink.tsx";
+
+const meta = defineStories<RadioGroupProps>({
+  component: "IRadioGroup",
+  title: "Components/Forms/Radio",
+  args: {
+    options: [
+      { value: "apple", label: "Apple" },
+      { value: "banana", label: "Banana" },
+      { value: "cherry", label: "Cherry" },
+    ],
+    name: "fruit",
+    disabled: false,
+  },
+  argTypes: {
+    options: {
+      control: "object",
+      description: "The choices, each `{ value, label?, disabled? }`",
+    },
+    name: { control: "text", description: "Shared native control name (mutual exclusivity)" },
+    color: {
+      control: "select",
+      options: ["light", "dark", "neutral"],
+      description: "Color variant",
+    },
+    size: { control: "select", options: ["sm", "md", "lg"], description: "Size variant" },
+    orientation: {
+      control: "select",
+      options: ["vertical", "horizontal"],
+      description: "Layout orientation",
+    },
+    disabled: { control: "boolean", description: "Disables every option in the group" },
+  },
+});
+
+export default meta;
+
+export const Default = {};
+export const Horizontal = { args: { orientation: "horizontal" } };
+export const Disabled = { args: { disabled: true } };
+export const WithDisabledOption = {
+  args: {
+    options: [
+      { value: "apple", label: "Apple" },
+      { value: "banana", label: "Banana", disabled: true },
+      { value: "cherry", label: "Cherry" },
+    ],
+  },
+};
+export const Sizes = { render: "./RadioSizes.ink.tsx" };
+export const Colors = { render: "./RadioColors.ink.tsx" };
+export const Orientations = { render: "./RadioOrientations.ink.tsx" };

--- a/ui/components/src/components/radio/stories/RadioColors.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioColors.ink.tsx
@@ -1,0 +1,39 @@
+import { defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IRadioGroup
+        color="light"
+        name="color-light"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+      <IRadioGroup
+        color="dark"
+        name="color-dark"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+      <IRadioGroup
+        color="neutral"
+        name="color-neutral"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/radio/stories/RadioOrientations.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioOrientations.ink.tsx
@@ -1,0 +1,29 @@
+import { defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IRadioGroup
+        orientation="vertical"
+        name="orientation-vertical"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+      <IRadioGroup
+        orientation="horizontal"
+        name="orientation-horizontal"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/radio/stories/RadioSizes.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioSizes.ink.tsx
@@ -1,0 +1,39 @@
+import { defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+export default defineComponent(() => {
+  return (
+    <div id="story">
+      <IRadioGroup
+        size="sm"
+        name="size-sm"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+      <IRadioGroup
+        size="md"
+        name="size-md"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+      <IRadioGroup
+        size="lg"
+        name="size-lg"
+        value="apple"
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary
Single-source Storybook stories for `IRadioGroup` (INK-25), stacked on the radio component source (#498). One `.ink.tsx` definition renders across all seven Storybooks.

## Changes
- `ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts` — `defineStories<RadioGroupProps>` meta (`Components/Forms/Radio`) with typed `argTypes` for `options`, `name`, `color`, `size`, `orientation`, `disabled`, and inline state variants: `Default`, `Horizontal`, `Disabled`, `WithDisabledOption`.
- Render-helper showcases (one axis each): `RadioSizes` (sm/md/lg), `RadioColors` (light/dark/neutral), `RadioOrientations` (vertical/horizontal).
- Two-way `value` is intentionally not an arg — it is a `defineModel`, not a `RadioGroupProps` member (same as Input); it is bound directly in the render helpers.
- No changeset: `@inkline/components` is private/ignore-listed and stories compile to gitignored `.inkline/` output — nothing published.

## Verification
```
$ pnpm --filter @inkline/components run build
Generated 42 story file(s) for 6 component(s).
# radio emits only the 2 expected INK0045 notices (group value model + field change event); no new errors.

$ vp check
pass: Found no warnings, lint errors, or type errors in 561 files
```
CSF3 generated for all 7 frameworks; story ids: `Colors`, `Default`, `Disabled`, `Horizontal`, `Orientations`, `Sizes`, `WithDisabledOption`. Verified the `options` array literal inlines correctly in the generated React/Vue/Svelte render helpers.

## Notes
Render helpers inline the `options` literal per usage rather than hoisting a module-scope const — the compiler only emits bindings declared inside `defineComponent`, so a hoisted const is silently dropped from the generated output. Base branch is `agent/palette/radio`; retarget to `main` once #498 lands.
