### PR TITLE
feat(components): add readonly prop to Switch

### DIFF
--- a/.changeset/switch-readonly.md
+++ b/.changeset/switch-readonly.md
@@ -1,0 +1,19 @@
+---
+"@inkline/react": minor
+"@inkline/vue": minor
+"@inkline/svelte": minor
+"@inkline/solid": minor
+"@inkline/angular": minor
+"@inkline/qwik": minor
+"@inkline/astro": minor
+---
+
+feat(components): add `readonly` prop to Switch
+
+Add a `readonly` prop to `ISwitch` (and its headless `ISwitchControlBase`). Because a native
+checkbox ignores the HTML `readonly` attribute, read-only is enforced behaviourally: the control
+announces `aria-readonly="true"` and cancels the click's default action so the box can't flip. Mouse
+click, Space (which the browser dispatches as a click), and the Enter-synthesised click all funnel
+through one guard, so the two-way `checked` model can't change — while the switch stays focusable and
+form-submittable, unlike `disabled`. The `switch-field` recipe has no read-only visual state, so this
+is aria + behaviour only.

--- a/ui/components/src/components/switch/headless/ISwitchControlBase.ink.test.ts
+++ b/ui/components/src/components/switch/headless/ISwitchControlBase.ink.test.ts
@@ -80,6 +80,39 @@ describe("SwitchControlBase", () => {
     expectOutputContains(out(result, "solid"), "checked={props.checked ?? false}");
   });
 
+  it("announces read-only via a conditional aria-readonly across targets", async () => {
+    // `aria-readonly` is emitted for the switch role; it's gated on the `readonly` prop so it drops off
+    // entirely when unset (Angular via `?? null`, JSX targets via the `undefined` branch).
+    const result = await compileComponent(SWITCH_CONTROL);
+    for (const target of ["react", "vue", "solid", "svelte", "qwik", "angular"] as const) {
+      expectOutputContains(out(result, target), "aria-readonly");
+    }
+    expectOutputContains(out(result, "angular"), "[attr.aria-readonly]=");
+  });
+
+  it("enforces read-only by cancelling the click, never disabling or guarding the change handler", async () => {
+    // A native checkbox ignores HTML `readonly`, so the toggle is suppressed behaviourally: the click's
+    // default action is cancelled when `readonly` is set. Mouse click, Space (the browser fires a
+    // click), and Enter (synthesised as a click) all funnel through this one guard, so the bound model
+    // never changes — while the control stays focusable and form-submittable (never `disabled`). The
+    // change handler is deliberately left unguarded: an `&&` guard there would collide with the
+    // Vue/Svelte model-set lowering (`checked = …`).
+    const result = await compileComponent(SWITCH_CONTROL);
+
+    // Angular: a readonly-gated click binding that cancels the default action.
+    expectOutputContains(out(result, "angular"), "(click)=");
+    expectOutputContains(out(result, "angular"), "readonly() && $event.preventDefault()");
+
+    // Every other interactive target guards preventDefault on readonly.
+    for (const target of ["vue", "svelte", "react", "solid", "qwik"] as const) {
+      expectOutputContains(out(result, target), "e.preventDefault()");
+    }
+
+    // Regression: the change handler still forwards the toggle to the two-way model (not readonly-gated).
+    expectOutputContains(out(result, "vue"), "checked = e.currentTarget.checked");
+    expectOutputContains(out(result, "svelte"), "checked = e.currentTarget.checked");
+  });
+
   it("output matches snapshots", async () => {
     expect(snapshotOutput(await compileComponent(SWITCH_CONTROL))).toMatchSnapshot();
   });

--- a/ui/components/src/components/switch/headless/ISwitchControlBase.ink.tsx
+++ b/ui/components/src/components/switch/headless/ISwitchControlBase.ink.tsx
@@ -7,6 +7,12 @@ export interface SwitchControlBaseProps {
   name?: string;
   /** Disables the control. */
   disabled?: boolean;
+  /**
+   * Marks the control read-only: announces `aria-readonly` and suppresses the toggle while keeping
+   * the switch focusable and form-submittable (unlike `disabled`). A native checkbox ignores the
+   * HTML `readonly` attribute, so this is enforced behaviourally.
+   */
+  readonly?: boolean;
 }
 
 // The native toggle: an `<input type="checkbox">` styled (via `.switch-field`) as a sliding switch.
@@ -27,8 +33,17 @@ export default defineComponent({ meta: { headless: true } }, (props: SwitchContr
       name={props.name}
       checked={checked() ?? false}
       aria-checked={checked() ? "true" : "false"}
+      aria-readonly={props.readonly ? "true" : undefined}
       disabled={props.disabled}
       onChange={(e: { currentTarget: HTMLInputElement }) => setChecked(e.currentTarget.checked)}
+      // Read-only enforcement: cancel the click's default action so the box can't flip. Mouse click,
+      // Space (the browser fires a click), and Enter (synthesised as a click below) all funnel through
+      // here, so one guard covers the whole keyboard/pointer map — and because the toggle never
+      // happens, `onChange` never fires, leaving the two-way model untouched. `onChange` is left as-is
+      // on purpose: guarding it with `&&` would collide with the Vue/Svelte model-set lowering (`= …`).
+      // Focus and form submission are unaffected (unlike `disabled`). A single guarded expression so it
+      // survives Angular's event bindings, which carry only one expression.
+      onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()}
       // Space toggles the checkbox natively; Enter does not, so complete the APG switch keyboard map
       // by synthesising the native click on Enter (which flips the box and fires `onChange` →
       // `setChecked`). A single guarded expression (arrow body, not a block statement) so it survives

--- a/ui/components/src/components/switch/headless/__snapshots__/ISwitchControlBase.ink.test.ts.snap
+++ b/ui/components/src/components/switch/headless/__snapshots__/ISwitchControlBase.ink.test.ts.snap
@@ -10,23 +10,31 @@ export interface SwitchControlBaseProps {
   name?: string;
   /** Disables the control. */
   disabled?: boolean;
+  /**
+   * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+   * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+   * HTML \`readonly\` attribute, so this is enforced behaviourally.
+   */
+  readonly?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-switch-control-base', host: { style: 'display: contents' }, template: \`<input [class]="'switch-field' + (klass() ? ' ' + klass() : '')" type="checkbox" role="switch" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [checked]="checked() ?? false" [attr.aria-checked]="(checked() ? 'true' : 'false') ?? null" [disabled]="disabled()" (change)="checked.set($event.currentTarget.checked)" (keydown)="$event.key === 'Enter' && $event.currentTarget.click()" />\` })
+@Component({ standalone: true, selector: 'ink-switch-control-base', host: { style: 'display: contents' }, template: \`<input [class]="'switch-field' + (klass() ? ' ' + klass() : '')" type="checkbox" role="switch" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [checked]="checked() ?? false" [attr.aria-checked]="(checked() ? 'true' : 'false') ?? null" [attr.aria-readonly]="(readonly() ? 'true' : undefined) ?? null" [disabled]="disabled()" (change)="checked.set($event.currentTarget.checked)" (click)="readonly() && $event.preventDefault()" (keydown)="$event.key === 'Enter' && $event.currentTarget.click()" />\` })
 export class ISwitchControlBaseComponent
 {
 klass = input<string>()
 id = input<string>()
 name = input<string>()
 disabled = input<boolean>()
+readonly = input<boolean>()
 checked = model<boolean>()
 }
-@Component({ standalone: true, selector: 'input[ink-switch-control-base]', host: { '[class]': "'switch-field' + (klass() ? ' ' + klass() : '')", 'type': 'checkbox', 'role': 'switch', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[checked]': "checked() ?? false", '[attr.aria-checked]': "(checked() ? 'true' : 'false') ?? null", '[disabled]': "disabled()", '(change)': "checked.set($event.currentTarget.checked)", '(keydown)': "$event.key === 'Enter' && $event.currentTarget.click()" }, template: \`\` })
+@Component({ standalone: true, selector: 'input[ink-switch-control-base]', host: { '[class]': "'switch-field' + (klass() ? ' ' + klass() : '')", 'type': 'checkbox', 'role': 'switch', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[checked]': "checked() ?? false", '[attr.aria-checked]': "(checked() ? 'true' : 'false') ?? null", '[attr.aria-readonly]': "(readonly() ? 'true' : undefined) ?? null", '[disabled]': "disabled()", '(change)': "checked.set($event.currentTarget.checked)", '(click)': "readonly() && $event.preventDefault()", '(keydown)': "$event.key === 'Enter' && $event.currentTarget.click()" }, template: \`\` })
 export class ISwitchControlBaseHostComponent
 {
 klass = input<string>()
 id = input<string>()
 name = input<string>()
 disabled = input<boolean>()
+readonly = input<boolean>()
 checked = model<boolean>()
 }
 ",
@@ -38,13 +46,19 @@ export interface SwitchControlBaseProps {
   name?: string;
   /** Disables the control. */
   disabled?: boolean;
+  /**
+   * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+   * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+   * HTML \`readonly\` attribute, so this is enforced behaviourally.
+   */
+  readonly?: boolean;
 }
 type Props = SwitchControlBaseProps & Record<string, any>
 const props = Astro.props as Props;
-const { id, name, disabled, ...__attrs } = props;
+const { id, name, disabled, readonly, ...__attrs } = props;
 let checked = props.checked
 ---
-<input {...__attrs} class={["switch-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={id} name={name} checked={checked ?? false} aria-checked={checked ? "true" : "false"} disabled={disabled} onChange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+<input {...__attrs} class={["switch-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={id} name={name} checked={checked ?? false} aria-checked={checked ? "true" : "false"} aria-readonly={readonly ? "true" : undefined} disabled={disabled} onChange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} onClick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
 ",
   "qwik/ISwitchControlBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
 export interface SwitchControlBaseProps {
@@ -54,12 +68,18 @@ export interface SwitchControlBaseProps {
   name?: string;
   /** Disables the control. */
   disabled?: boolean;
+  /**
+   * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+   * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+   * HTML \`readonly\` attribute, so this is enforced behaviourally.
+   */
+  readonly?: boolean;
 }
 export const ISwitchControlBase = component$((props: SwitchControlBaseProps & { checked?: boolean; onUpdateChecked$?: QRL<(value: boolean) => void> } & Record<string, any>) =>
 {
-const { id, name, disabled, checked, onUpdateChecked$, ...__attrs } = props
+const { id, name, disabled, readonly, checked, onUpdateChecked$, ...__attrs } = props
 return (
-<input {...__attrs} class={["switch-field", props.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} disabled={props.disabled} onChange={$((e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked$?.(e.currentTarget.checked))} onKeyDown={$((e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click())} />
+<input {...__attrs} class={["switch-field", props.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} aria-readonly={props.readonly ? "true" : undefined} disabled={props.disabled} onChange={$((e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked$?.(e.currentTarget.checked))} onClick={$((e: { preventDefault: () => void }) => props.readonly && e.preventDefault())} onKeyDown={$((e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click())} />
 )
 });
 ",
@@ -70,12 +90,18 @@ return (
   name?: string;
   /** Disables the control. */
   disabled?: boolean;
+  /**
+   * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+   * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+   * HTML \`readonly\` attribute, so this is enforced behaviourally.
+   */
+  readonly?: boolean;
 }
 export function ISwitchControlBase(props: SwitchControlBaseProps & { checked?: boolean; onUpdateChecked?: (value: boolean) => void } & React.HTMLAttributes<HTMLElement>)
 {
-const { id, name, disabled, checked, onUpdateChecked, ...__attrs } = props
+const { id, name, disabled, readonly, checked, onUpdateChecked, ...__attrs } = props
 return (
-<input {...__attrs} className={["switch-field", props.className].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} disabled={props.disabled} onChange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+<input {...__attrs} className={["switch-field", props.className].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} aria-readonly={props.readonly ? "true" : undefined} disabled={props.disabled} onChange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onKeyDown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
 )
 }
 ",
@@ -88,12 +114,18 @@ export interface SwitchControlBaseProps {
   name?: string;
   /** Disables the control. */
   disabled?: boolean;
+  /**
+   * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+   * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+   * HTML \`readonly\` attribute, so this is enforced behaviourally.
+   */
+  readonly?: boolean;
 }
 export default function ISwitchControlBase(props: SwitchControlBaseProps & { checked?: boolean; onUpdateChecked?: (value: boolean) => void } & JSX.HTMLAttributes<HTMLElement>)
 {
-const [, __attrs] = splitProps(props, ["id", "name", "disabled", "checked", "onUpdateChecked"])
+const [, __attrs] = splitProps(props, ["id", "name", "disabled", "readonly", "checked", "onUpdateChecked"])
 return (
-<input {...__attrs} class={["switch-field", props.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} disabled={props.disabled} onchange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} onkeydown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+<input {...__attrs} class={["switch-field", props.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={props.id} name={props.name} checked={props.checked ?? false} aria-checked={props.checked ? "true" : "false"} aria-readonly={props.readonly ? "true" : undefined} disabled={props.disabled} onchange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} onclick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onkeydown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
 )
 }
 ",
@@ -105,10 +137,16 @@ return (
     name?: string;
     /** Disables the control. */
     disabled?: boolean;
+    /**
+     * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+     * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+     * HTML \`readonly\` attribute, so this is enforced behaviourally.
+     */
+    readonly?: boolean;
   }
-  let { id, name, disabled, checked = $bindable(), ...__attrs }: SwitchControlBaseProps & { checked?: boolean } & Record<string, any> = $props()
+  let { id, name, disabled, readonly, checked = $bindable(), ...__attrs }: SwitchControlBaseProps & { checked?: boolean } & Record<string, any> = $props()
 </script>
-<input {...__attrs} class={["switch-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={id} name={name} checked={checked ?? false} aria-checked={checked ? "true" : "false"} disabled={disabled} onchange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} onkeydown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
+<input {...__attrs} class={["switch-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" role="switch" id={id} name={name} checked={checked ?? false} aria-checked={checked ? "true" : "false"} aria-readonly={readonly ? "true" : undefined} disabled={disabled} onchange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} onclick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onkeydown={(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()} />
 ",
   "vue/ISwitchControlBase.vue": "<script setup lang="ts">
   export interface SwitchControlBaseProps {
@@ -118,12 +156,18 @@ return (
     name?: string;
     /** Disables the control. */
     disabled?: boolean;
+    /**
+     * Marks the control read-only: announces \`aria-readonly\` and suppresses the toggle while keeping
+     * the switch focusable and form-submittable (unlike \`disabled\`). A native checkbox ignores the
+     * HTML \`readonly\` attribute, so this is enforced behaviourally.
+     */
+    readonly?: boolean;
   }
   const props = defineProps<SwitchControlBaseProps>()
   const checked = defineModel<boolean>("checked")
 </script>
 <template>
-<input class="switch-field" type="checkbox" role="switch" :id="id" :name="name" :checked="checked ?? false" :aria-checked='checked ? "true" : "false"' :disabled="disabled" @change="(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked" @keydown='(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()' />
+<input class="switch-field" type="checkbox" role="switch" :id="id" :name="name" :checked="checked ?? false" :aria-checked='checked ? "true" : "false"' :aria-readonly='readonly ? "true" : undefined' :disabled="disabled" @change="(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked" @click="(e: { preventDefault: () => void }) => readonly && e.preventDefault()" @keydown='(e: { key: string; currentTarget: HTMLInputElement }) => e.key === "Enter" && e.currentTarget.click()' />
 </template>
 ",
 }

--- a/ui/components/src/components/switch/styled/ISwitch.ink.test.ts
+++ b/ui/components/src/components/switch/styled/ISwitch.ink.test.ts
@@ -129,6 +129,22 @@ describe("ISwitch (styled) on Angular SSR", () => {
     expect(html).toMatch(/<input[^>]*disabled/);
   });
 
+  it("reflects read-only as aria-readonly on the control without disabling it", async () => {
+    const { html } = await mount({ label: "Locked", readonly: true });
+
+    // Read-only announces via aria-readonly and stays enabled — focusable and form-submittable,
+    // unlike disabled. (The toggle-suppression itself is a client-side click guard, not observable in
+    // SSR markup; it's asserted at the headless compile-output layer.)
+    expect(html).toMatch(/<input[^>]*aria-readonly="true"/);
+    expect(html).not.toMatch(/<input[^>]*disabled/);
+  });
+
+  it("omits aria-readonly when the control is not read-only", async () => {
+    const { html } = await mount({ label: "Editable" });
+
+    expect(html).not.toMatch(/aria-readonly/);
+  });
+
   it("forwards id to the control only, not the shell label", async () => {
     const { html } = await mount({ id: "wifi", label: "Wi-Fi" });
 

--- a/ui/components/src/components/switch/styled/ISwitch.ink.tsx
+++ b/ui/components/src/components/switch/styled/ISwitch.ink.tsx
@@ -47,6 +47,7 @@ export default defineComponent(
           name={props.name}
           $bind:checked={checked}
           disabled={props.disabled}
+          readonly={props.readonly}
         />
         <ISwitchLabelBase>
           <Slot>{props.label}</Slot>

--- a/ui/components/src/components/switch/styled/__snapshots__/ISwitch.ink.test.ts.snap
+++ b/ui/components/src/components/switch/styled/__snapshots__/ISwitch.ink.test.ts.snap
@@ -23,7 +23,7 @@ export interface SwitchProps extends SwitchControlBaseProps {
   label?: string;
 }
 @Component({ standalone: true, selector: 'ink-switch', host: { style: 'display: contents' }, imports: [ISwitchBase, ISwitchControlBase, ISwitchLabelBase], template: \`<ink-switch-base [klass]="(shellClassName()) + (klass() ? ' ' + klass() : '')">
-<ink-switch-control-base [klass]="(fieldClassName())" [id]="id()" [name]="name()" [checked]="checked()" [disabled]="disabled()" (checkedChange)="checked.set($event)"></ink-switch-control-base>
+<ink-switch-control-base [klass]="(fieldClassName())" [id]="id()" [name]="name()" [checked]="checked()" [disabled]="disabled()" [readonly]="readonly()" (checkedChange)="checked.set($event)"></ink-switch-control-base>
 <ink-switch-label-base>
 <ng-content>{{ label() }}</ng-content>
 </ink-switch-label-base>
@@ -41,9 +41,10 @@ label = input<string>()
 id = input<string>()
 name = input<string>()
 disabled = input<boolean>()
+readonly = input<boolean>()
 checked = model<boolean>()
 }
-@Component({ standalone: true, selector: 'label[ink-switch]', host: { '[class]': "'switch' + ((shellClassName()) ? ' ' + (shellClassName()) : '') + (klass() ? ' ' + klass() : '')", 'ink-switch-base': '' }, imports: [ISwitchControlBaseHostComponent, ISwitchLabelBaseHostComponent], template: \`<input ink-switch-control-base [klass]="(fieldClassName())" [id]="id()" [name]="name()" [checked]="checked()" [disabled]="disabled()" (checkedChange)="checked.set($event)" />
+@Component({ standalone: true, selector: 'label[ink-switch]', host: { '[class]': "'switch' + ((shellClassName()) ? ' ' + (shellClassName()) : '') + (klass() ? ' ' + klass() : '')", 'ink-switch-base': '' }, imports: [ISwitchControlBaseHostComponent, ISwitchLabelBaseHostComponent], template: \`<input ink-switch-control-base [klass]="(fieldClassName())" [id]="id()" [name]="name()" [checked]="checked()" [disabled]="disabled()" [readonly]="readonly()" (checkedChange)="checked.set($event)" />
 <span ink-switch-label-base>
 <ng-content>{{ label() }}</ng-content>
 </span>\` })
@@ -60,6 +61,7 @@ label = input<string>()
 id = input<string>()
 name = input<string>()
 disabled = input<boolean>()
+readonly = input<boolean>()
 checked = model<boolean>()
 }
 ",
@@ -82,13 +84,13 @@ export interface SwitchProps extends SwitchControlBaseProps {
 }
 type Props = SwitchProps & Record<string, any>
 const props = Astro.props as Props;
-const { color, size, label, id, name, disabled, ...__attrs } = props;
+const { color, size, label, id, name, disabled, readonly, ...__attrs } = props;
 let checked = props.checked
 const shellClassName = switchRecipe({ size: size })
 const fieldClassName = switchFieldRecipe({ color: color, size: size })
 ---
 <ISwitchBase {...__attrs} class={[shellClassName, __attrs.class].filter(Boolean).join(" ")}>
-<ISwitchControlBase class={fieldClassName} id={id} name={name} checked={checked} disabled={disabled} />
+<ISwitchControlBase class={fieldClassName} id={id} name={name} checked={checked} disabled={disabled} readonly={readonly} />
 <ISwitchLabelBase>
 <slot>
 {label}
@@ -118,11 +120,11 @@ export const ISwitch = component$((props: SwitchProps & { checked?: boolean; onU
 {
 const shellClassName = useComputed$(() => switchRecipe({ size: props.size }))
 const fieldClassName = useComputed$(() => switchFieldRecipe({ color: props.color, size: props.size }))
-const { children, color, size, label, id, name, disabled, checked, onUpdateChecked$, ...__attrs } = props
+const { children, color, size, label, id, name, disabled, readonly, checked, onUpdateChecked$, ...__attrs } = props
 return (
 <ISwitchBase {...__attrs} class={[shellClassName.value, props.class].filter(Boolean).join(" ")}>
   <>
-    <ISwitchControlBase class={fieldClassName.value} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} onUpdateChecked$={$(v => props.onUpdateChecked$?.(v))} />
+    <ISwitchControlBase class={fieldClassName.value} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} readonly={props.readonly} onUpdateChecked$={$(v => props.onUpdateChecked$?.(v))} />
     <ISwitchLabelBase>
       <Slot>
         {props.label}
@@ -155,11 +157,11 @@ export function ISwitch(props: SwitchProps & { children?: React.ReactNode } & { 
 {
 const shellClassName = useMemo(() => switchRecipe({ size: props.size }), [props.size])
 const fieldClassName = useMemo(() => switchFieldRecipe({ color: props.color, size: props.size }), [props.color, props.size])
-const { children, color, size, label, id, name, disabled, checked, onUpdateChecked, ...__attrs } = props
+const { children, color, size, label, id, name, disabled, readonly, checked, onUpdateChecked, ...__attrs } = props
 return (
 <ISwitchBase {...__attrs} className={[shellClassName, props.className].filter(Boolean).join(" ")}>
   <>
-    <ISwitchControlBase className={fieldClassName} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} onUpdateChecked={v => props.onUpdateChecked?.(v)} />
+    <ISwitchControlBase className={fieldClassName} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} readOnly={props.readonly} onUpdateChecked={v => props.onUpdateChecked?.(v)} />
     <ISwitchLabelBase>
       {props.children ?? props.label}
     </ISwitchLabelBase>
@@ -190,11 +192,11 @@ export default function ISwitch(props: SwitchProps & { children?: any } & { chec
 {
 const shellClassName = createMemo(() => switchRecipe({ size: props.size }))
 const fieldClassName = createMemo(() => switchFieldRecipe({ color: props.color, size: props.size }))
-const [, __attrs] = splitProps(props, ["children", "color", "size", "label", "id", "name", "disabled", "checked", "onUpdateChecked"])
+const [, __attrs] = splitProps(props, ["children", "color", "size", "label", "id", "name", "disabled", "readonly", "checked", "onUpdateChecked"])
 return (
 <ISwitchBase {...__attrs} class={[shellClassName(), props.class].filter(Boolean).join(" ")}>
   <>
-    <ISwitchControlBase class={fieldClassName()} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} onUpdateChecked={v => props.onUpdateChecked?.(v)} />
+    <ISwitchControlBase class={fieldClassName()} id={props.id} name={props.name} checked={props.checked} disabled={props.disabled} readonly={props.readonly} onUpdateChecked={v => props.onUpdateChecked?.(v)} />
     <ISwitchLabelBase>
       {props.children ?? props.label}
     </ISwitchLabelBase>
@@ -221,12 +223,12 @@ return (
     label?: string;
   }
   import type { Snippet } from "svelte";
-  let { color, size, label, id, name, disabled, checked = $bindable(), children, ...__attrs }: SwitchProps & { checked?: boolean; children?: Snippet } & Record<string, any> = $props()
+  let { color, size, label, id, name, disabled, readonly, checked = $bindable(), children, ...__attrs }: SwitchProps & { checked?: boolean; children?: Snippet } & Record<string, any> = $props()
   let shellClassName = $derived(switchRecipe({ size: size }))
   let fieldClassName = $derived(switchFieldRecipe({ color: color, size: size }))
 </script>
 <ISwitchBase {...__attrs} class={[shellClassName, __attrs.class].filter(Boolean).join(" ")}>
-  <ISwitchControlBase bind:checked={checked} class={fieldClassName} id={id} name={name} disabled={disabled} />
+  <ISwitchControlBase bind:checked={checked} class={fieldClassName} id={id} name={name} disabled={disabled} readonly={readonly} />
   <ISwitchLabelBase>
     {#if children}{@render children()}{:else}{label}{/if}
   </ISwitchLabelBase>
@@ -257,7 +259,7 @@ return (
 </script>
 <template>
 <ISwitchBase :class="shellClassName">
-  <ISwitchControlBase v-model:checked="checked" :class="fieldClassName" :id="id" :name="name" :disabled="disabled" />
+  <ISwitchControlBase v-model:checked="checked" :class="fieldClassName" :id="id" :name="name" :disabled="disabled" :readonly="readonly" />
   <ISwitchLabelBase>
     <slot>
       {{ label }}


### PR DESCRIPTION
## Summary

Adds a `readonly` prop to Switch so a read-only toggle can be expressed (and storied). A native
checkbox ignores the HTML `readonly` attribute, so read-only is enforced behaviourally rather than
via the attribute: the control announces `aria-readonly="true"` and cancels the click's default
action, keeping the switch focusable and form-submittable — unlike `disabled`.

## Changes

- `ISwitchControlBase`: new `readonly?: boolean` prop.
  - `aria-readonly={props.readonly ? "true" : undefined}` — the attribute drops off entirely when unset.
  - `onClick` guard cancels the toggle when `readonly`: `props.readonly && e.preventDefault()`. Mouse
    click, Space (the browser dispatches a click), and Enter (synthesised as a click) all funnel
    through this one guard, so the two-way `checked` model can't change.
  - The change handler is left **unguarded on purpose** — an `&&` guard there would collide with the
    Vue/Svelte model-set lowering (`checked = …`); cancelling the click already stops `change` from
    firing.
- `ISwitch` (styled): `readonly` is inherited via `SwitchProps extends SwitchControlBaseProps` and
  forwarded onto the composed control.
- Tests: conditional `aria-readonly` across all targets; the readonly-gated click guard on every
  interactive target (with a regression assert that the change handler stays intact); Angular SSR
  checks that `aria-readonly="true"` renders without `disabled`, and is absent when not read-only.
- Changeset: `minor` for all seven `@inkline/*` framework packages.

The `switch-field` recipe has no read-only visual state, so this is aria + behaviour only.

## Verification

- `cd ui/components && pnpm build` — all 7 targets, expected notices only (switch emits only INK0045).
- `vp test src/components` — 141 passing (18 files); `vp check` clean.
- Per-target lowering verified in the snapshots (Angular `(click)="readonly() && $event.preventDefault()"`,
  `[attr.aria-readonly]="(readonly() ? 'true' : undefined) ?? null"`; JSX targets
  `props.readonly && e.preventDefault()`; `onChange` unchanged).

## Notes

- Focus and form submission are intentionally unaffected (this is what distinguishes read-only from
  `disabled`).
- The stories/visual side is a follow-up (owned separately); this PR only lands the prop + behaviour.
