### PR TITLE
build(website): switch typecheck from tsc (TS6) to tsgo (TS7) (INK-21)

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vp dev",
-    "build": "tsc && vp build",
+    "build": "tsgo && vp build",
     "preview": "vp preview"
   },
   "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260613.1",
     "typescript": "catalog:",
     "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.24",
     "vite-plus": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ catalogs:
       version: 0.16.2
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.2.1
   vitest: npm:@voidzero-dev/vite-plus-test@^0.1.24
 
 importers:
@@ -240,11 +240,14 @@ importers:
 
   apps/website:
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260613.1
+        version: 7.0.0-dev.20260613.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.1
         version: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'
@@ -441,7 +444,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.1
         version: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
       webpack:
         specifier: ^4 || ^5
@@ -12323,7 +12326,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.21(@types/node@25.9.3)
-      '@vitejs/plugin-basic-ssl': 2.1.4(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
+      '@vitejs/plugin-basic-ssl': 2.1.4(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))
       beasties: 0.4.1
       browserslist: 4.28.2
       esbuild: 0.27.3
@@ -12344,7 +12347,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 6.0.3
       undici: 7.24.4
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)(zone.js@0.16.2)
@@ -16567,10 +16570,6 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-basic-ssl@2.1.4(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))':
-    dependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
-
   '@vitejs/plugin-basic-ssl@2.1.4(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0))':
     dependencies:
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
@@ -16739,6 +16738,7 @@ snapshots:
       tsx: 4.22.4
       typescript: 6.0.3
       yaml: 2.9.0
+    optional: true
 
   '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
@@ -16757,6 +16757,7 @@ snapshots:
       tsx: 4.22.4
       typescript: 5.9.3
       yaml: 2.9.0
+    optional: true
 
   '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
@@ -16811,6 +16812,24 @@ snapshots:
       terser: 5.46.0
       tsx: 4.22.4
       typescript: 6.0.3
+      yaml: 2.9.0
+
+  '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)':
+    dependencies:
+      '@oxc-project/runtime': 0.136.0
+      '@oxc-project/types': 0.136.0
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optionalDependencies:
+      '@types/node': 25.9.3
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      less: 4.4.2
+      sass: 1.99.0
+      terser: 5.48.0
+      tsx: 4.22.4
+      typescript: 5.9.3
       yaml: 2.9.0
 
   '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)':
@@ -17563,8 +17582,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)'
-      vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)'
+      vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -24661,9 +24680,9 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)):
+  vitefu@1.1.3(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)'
 
   vitefu@1.1.3(vite@8.0.10(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,6 +87,9 @@ catalog:
   tslib: ^2.8.1
   tsx: ^4.22.4
   typescript: ^6.0.3
+  # Deliberately de-floated from `@latest`: a floating tag re-resolves on every
+  # install and silently drags in vite-plus-core upgrades. Pinned to the exact
+  # version — bump this line manually to move vite forward.
   vite: npm:@voidzero-dev/vite-plus-core@0.2.1
   vite-plugin-solid: ^2.11.12
   vite-plus: ^0.1.24

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,7 +87,7 @@ catalog:
   tslib: ^2.8.1
   tsx: ^4.22.4
   typescript: ^6.0.3
-  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.2.1
   vite-plugin-solid: ^2.11.12
   vite-plus: ^0.1.24
   vitest: npm:@voidzero-dev/vite-plus-test@^0.1.24


### PR DESCRIPTION
## Summary

Switches `apps/website` build-time typecheck from `tsc` (TS6) to `tsgo` (TS7), making the website the last holdout to join the rest of the monorepo on the TypeScript native CLI. Deferred out of INK-18 to keep that PR surgical.

## Changes

- **`pnpm-workspace.yaml`** — pin the `vite` catalog entry from `npm:@voidzero-dev/vite-plus-core@latest` to the already-resolved `@0.2.1`. This is the sequencing step: it removes the float so the non-frozen install that native-preview forces cannot drag an unrelated `0.2.1 → 0.2.4` bump into the lockfile. Same resolved version as before — no behavior change.
- **`apps/website/package.json`** — add `@typescript/native-preview@7.0.0-dev.20260613.1` (the exact version core/compiler already uses) to devDeps, and change `"build": "tsc && vp build"` → `"build": "tsgo && vp build"`.
- **`pnpm-lock.yaml`** — the resulting diff is the pin specifier, the native-preview add, and consolidation of a couple of stale transitive `vite` peers onto the pinned `0.2.1`. **No `0.2.4` anywhere.**

The website `tsconfig.json` already sets `noEmit: true`; `tsgo` honors it as a pure typecheck.

## Verification

- `pnpm --filter website build` — green under tsgo (`tsgo` typecheck passes, `vp build` emits `dist/`).
- `tsgo --version` → `7.0.0-dev.20260613.1`.
- Lockfile diff scoped: `git diff pnpm-lock.yaml` contains no `0.2.4` — confirmed no `vite-plus-core` float bump riding along. 45 lines changed (well under the ~79-line churn a `0.2.4` bump would have caused).

## Notes

- Kept the catalog pin in this PR rather than splitting it out: it stayed a one-line, no-behavior-change pin to the currently-locked version and is directly required to keep the lockfile diff clean, so it never became its own coordination thread.
