### PR TITLE
fix(core/compiler): categorize component-instance refs as component in P3 (INK-15)

### DIFF
--- a/.changeset/react-component-ref-forwardref.md
+++ b/.changeset/react-component-ref-forwardref.md
@@ -1,0 +1,6 @@
+---
+"@inkline/compiler": patch
+"@inkline/react": patch
+---
+
+fix(react): wrap a component holding a component-instance ref in `forwardRef`

--- a/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -552,8 +552,8 @@ return (
 )
 }
 
-import { useRef, useEffect } from "react";
-export function ComponentRef(props: React.HTMLAttributes<HTMLElement>)
+import { useRef, useEffect, forwardRef } from "react";
+export const ComponentRef = forwardRef(function ComponentRef(props: React.HTMLAttributes<HTMLElement>, ref)
 {
 const childRef = useRef(null)
 useEffect(() => { console.log(childRef.current); }, [])
@@ -561,6 +561,6 @@ const { ...__attrs } = props
 return (
 <Child {...__attrs} className={props.className} ref={childRef} />
 )
-}
+});
 "
 `;

--- a/core/compiler/src/pipeline/passes/03-lower/refs.test.ts
+++ b/core/compiler/src/pipeline/passes/03-lower/refs.test.ts
@@ -101,11 +101,12 @@ describe("refs", () => {
     expect(result.refs[0]!.elementType).toBe("HTMLElement");
   });
 
-  it("classifies refs on ComponentInstance as component category", () => {
-    const refExpr = createExpr({
-      expr: mockExpr("myRef"),
-      deps: [{ symbolId: refSymbolId, kind: "ref", name: "myRef", path: [], conditional: false }],
-    });
+  it("classifies refs on ComponentInstance as component category (without resolved deps)", () => {
+    // A component-instance ref binding carries an empty `deps` array in the real pipeline, so the
+    // link to its declaration must resolve through the binding's identifier text — not
+    // `deps[0].symbolId` (INK-15). Build the binding with no deps to pin that behavior directly.
+    const refExpr = createExpr({ expr: mockExpr("myRef") });
+    expect(refExpr.deps).toHaveLength(0);
     const ci = createComponentInstance({
       reference: ident("Button"),
       refs: [{ ref: refExpr, category: "element", loc: UNKNOWN_LOCATION }],

--- a/core/compiler/src/pipeline/passes/03-lower/refs.ts
+++ b/core/compiler/src/pipeline/passes/03-lower/refs.ts
@@ -27,10 +27,22 @@ const TAG_TO_ELEMENT_TYPE: Record<string, string> = {
 export function refs(component: IRComponent, _ctx: PassContext): IRComponent {
   const updates = new Map<SymbolId, { category: IRRefCategory; elementType?: string }>();
 
+  // A ref binding references its declaration by identifier (`ref={myRef}`). Unlike attribute and
+  // event expressions, ref-binding `deps` are never resolved by the parse deps pass, and a
+  // component-instance ref binding in particular carries an empty `deps` array — so keying off
+  // `deps[0].symbolId` never resolves it and the declaration keeps the parser's `"element"` default
+  // (INK-15). Link the binding to its declaration through the identifier text instead, mirroring how
+  // the Angular target already derives its element-ref set from the render tree.
+  const refIdByName = new Map<string, SymbolId>();
+  for (const decl of component.refs) refIdByName.set(decl.name, decl.symbolId);
+
   walkRenderTree(component.render, {
     enter(node) {
       if (node.kind === "Element") {
         for (const ref of node.refs) {
+          // Element refs still key off resolved `deps`: their `elementType` inference is a separate
+          // latent gap (deps are likewise empty here) whose fix would shift element-ref output, so
+          // it is intentionally left untouched by this categorization-only change.
           const symbolId = ref.ref.deps[0]?.symbolId;
           if (symbolId) {
             updates.set(symbolId, {
@@ -41,7 +53,7 @@ export function refs(component: IRComponent, _ctx: PassContext): IRComponent {
         }
       } else if (node.kind === "ComponentInstance") {
         for (const ref of node.refs) {
-          const symbolId = ref.ref.deps[0]?.symbolId;
+          const symbolId = refIdByName.get(ref.ref.expr.getText());
           if (symbolId) {
             updates.set(symbolId, { category: "component" });
           }


### PR DESCRIPTION
## Summary

The P3 lower pass (`core/compiler/src/pipeline/passes/03-lower/refs.ts`) miscategorized **component-instance** ref bindings as `"element"` refs. It linked a ref binding to its declaration through `ref.ref.deps[0]?.symbolId`, but ref-binding `deps` are never resolved by the parse deps pass — and a component-instance ref binding carries an empty `deps` array — so the `"component"` branch never fired and the declaration kept the parser's `"element"` default (INK-15).

## Changes

- `03-lower/refs.ts`: link a component-instance ref binding to its declaration by the binding's identifier text (`ref.ref.expr.getText()` against `component.refs[].name`) instead of the unresolved `deps[0].symbolId`, mirroring how the Angular target already derives its element-ref set from the render tree. Component-instance refs now resolve to `category: "component"`.
- `03-lower/refs.test.ts`: the ComponentInstance categorization test now builds the binding with an **empty** `deps` array (matching the real pipeline) and asserts `category === "component"` directly — pinning the deps-independent behavior.
- React `ComponentRef` output snapshot updated to reflect the intended `forwardRef` wrapping.

## Cross-target impact assessment

`category` is read by exactly one consumer: React's `hasComponentRefs` (`react/index.ts:651`). Correcting it makes a component that holds a component-instance ref emit a `forwardRef` wrapper — the one intended output change (React `ComponentRef` snapshot). The other six targets read `elementType`, not `category`, so their `ComponentRef` output is byte-identical. The Angular `.nativeElement` unwrap (INK-14 / #503) already derives element-vs-component from the render tree, so it is unaffected (its render-tree workaround is now redundant but left in place — out of scope here).

Element-ref `elementType` inference remains a separate latent gap (same empty-deps root cause) and is intentionally left untouched to keep element-ref output stable.

## Verification

- `vp test` (core/compiler): 3210 passed / 216 files.
- `vp check` (core/compiler): clean (pre-existing `.ink.tsx` fixture diagnostics unrelated).
- `vp pack` (core/compiler): dist rebuilt clean.
- Snapshot diff confirmed: only React `ComponentRef` changed (forwardRef); the other six targets show zero drift.

## Notes

- Latent fix: no component relies on this today; filed so the root cause is tracked.