### PR TITLE
feat(components): add readonly to Radio

### DIFF
--- a/.changeset/add-radio.md
+++ b/.changeset/add-radio.md
@@ -16,5 +16,7 @@ owns the two-way `value` — composed from three headless parts (`IRadioGroupBas
 
 Each option renders a native `<input type="radio">` wrapped in its `<label>`, so role, `aria-checked`,
 keyboard roving, and mutual exclusivity (via a shared `name`) come from the platform. Supports the
-`color`, `size`, and `orientation` recipe axes plus a group-level `disabled`. The headless parts are
-exported individually for advanced composition.
+`color`, `size`, and `orientation` recipe axes plus a group-level `disabled` and `readonly` (the
+selection stays visible and focusable but can't be changed — surfaced as `aria-readonly` on the
+radiogroup and enforced per field). The headless parts are exported individually for advanced
+composition.

--- a/ui/components/src/components/radio/headless/IRadioFieldBase.ink.test.ts
+++ b/ui/components/src/components/radio/headless/IRadioFieldBase.ink.test.ts
@@ -60,6 +60,15 @@ describe("RadioField", () => {
     expectOutputContains(result.files.vue ?? [], 'emit("change", value ?? "")');
   });
 
+  it("guards selection when read-only (cancels the click, suppresses the change)", async () => {
+    const result = await compileComponent(RADIO_FIELD);
+    // Native radios ignore `readonly`, so read-only is enforced behaviorally: the pointer toggle is
+    // cancelled and the change event is gated on `!readonly`.
+    expectOutputContains(result.files.react ?? [], "props.readonly");
+    expectOutputContains(result.files.react ?? [], "preventDefault()");
+    expectOutputContains(result.files.angular ?? [], "readonly()");
+  });
+
   it("output matches snapshots", async () => {
     const result = await compileComponent(RADIO_FIELD);
     expect(snapshotOutput(result)).toMatchSnapshot();

--- a/ui/components/src/components/radio/headless/IRadioFieldBase.ink.tsx
+++ b/ui/components/src/components/radio/headless/IRadioFieldBase.ink.tsx
@@ -13,6 +13,12 @@ export interface RadioFieldBaseProps {
   disabled?: boolean;
   /** Marks the control as required. */
   required?: boolean;
+  /**
+   * Prevents the selection from changing while still showing (and keeping focusable) the current
+   * state. Native radios ignore the HTML `readonly` attribute, so this is enforced behaviorally:
+   * the click is cancelled and the `change` event is suppressed.
+   */
+  readonly?: boolean;
 }
 
 // The native `<input type="radio">` control: a single static root, so it host-extracts to
@@ -34,7 +40,8 @@ export default defineComponent({ meta: { headless: true } }, (props: RadioFieldB
       checked={props.checked}
       disabled={props.disabled}
       required={props.required}
-      onChange={() => emit("change", props.value ?? "")}
+      onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()}
+      onChange={() => !props.readonly && emit("change", props.value ?? "")}
     />
   );
 });

--- a/ui/components/src/components/radio/headless/IRadioGroupBase.ink.test.ts
+++ b/ui/components/src/components/radio/headless/IRadioGroupBase.ink.test.ts
@@ -43,6 +43,13 @@ describe("RadioGroup", () => {
     expectOutputContains(result.files.angular ?? [], "'role': 'radiogroup'");
   });
 
+  it("surfaces read-only as aria-readonly on the radiogroup", async () => {
+    const result = await compileComponent(RADIO_GROUP);
+    // `radiogroup` is one of the roles that supports `aria-readonly`; the interaction guard itself
+    // lives on each radio field.
+    expectOutputContains(result.files.react ?? [], "aria-readonly=");
+  });
+
   it("output matches snapshots", async () => {
     const result = await compileComponent(RADIO_GROUP);
     expect(snapshotOutput(result)).toMatchSnapshot();

--- a/ui/components/src/components/radio/headless/IRadioGroupBase.ink.tsx
+++ b/ui/components/src/components/radio/headless/IRadioGroupBase.ink.tsx
@@ -5,17 +5,26 @@ export interface RadioGroupBaseProps {
   id?: string;
   /** Accessible name for the group, exposed as `aria-label`. */
   label?: string;
+  /** Marks the whole group read-only — exposed as `aria-readonly` on the radiogroup. */
+  readonly?: boolean;
 }
 
 // The radiogroup container: a single static `<div role="radiogroup">` root, so it host-extracts to
 // `div[ink-radio-group-base]` and a styled parent's recipe `class` falls through onto it. It holds
 // no state — the selected value lives on the styled `IRadioGroup`; mutual exclusivity comes from the
-// child radios sharing a native `name`.
+// child radios sharing a native `name`. `readonly` is surfaced as `aria-readonly` here (the ARIA
+// state the `radiogroup` role supports); the interaction guard lives on each radio field.
 export default defineComponent(
   { meta: { headless: true }, slots: { default: {} } },
   (props: RadioGroupBaseProps) => {
     return (
-      <div class="radio-group" role="radiogroup" id={props.id} aria-label={props.label}>
+      <div
+        class="radio-group"
+        role="radiogroup"
+        id={props.id}
+        aria-label={props.label}
+        aria-readonly={props.readonly ? "true" : undefined}
+      >
         <Slot />
       </div>
     );

--- a/ui/components/src/components/radio/headless/__snapshots__/IRadioFieldBase.ink.test.ts.snap
+++ b/ui/components/src/components/radio/headless/__snapshots__/IRadioFieldBase.ink.test.ts.snap
@@ -16,8 +16,14 @@ export interface RadioFieldBaseProps {
   disabled?: boolean;
   /** Marks the control as required. */
   required?: boolean;
+  /**
+   * Prevents the selection from changing while still showing (and keeping focusable) the current
+   * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+   * the click is cancelled and the \`change\` event is suppressed.
+   */
+  readonly?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-radio-field-base', host: { style: 'display: contents' }, template: \`<input [class]="'radio-field' + (klass() ? ' ' + klass() : '')" type="radio" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [value]="value() ?? ''" [checked]="checked()" [disabled]="disabled()" [required]="required()" (change)="change.emit(value() ?? '')" />\` })
+@Component({ standalone: true, selector: 'ink-radio-field-base', host: { style: 'display: contents' }, template: \`<input [class]="'radio-field' + (klass() ? ' ' + klass() : '')" type="radio" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [value]="value() ?? ''" [checked]="checked()" [disabled]="disabled()" [required]="required()" (click)="readonly() && $event.preventDefault()" (change)="!readonly() && change.emit(value() ?? '')" />\` })
 export class IRadioFieldBaseComponent
 {
 klass = input<string>()
@@ -27,9 +33,10 @@ value = input<string>()
 checked = input<boolean>()
 disabled = input<boolean>()
 required = input<boolean>()
+readonly = input<boolean>()
 change = output()
 }
-@Component({ standalone: true, selector: 'input[ink-radio-field-base]', host: { '[class]': "'radio-field' + (klass() ? ' ' + klass() : '')", 'type': 'radio', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[value]': "value() ?? ''", '[checked]': "checked()", '[disabled]': "disabled()", '[required]': "required()", '(change)': "change.emit(value() ?? '')" }, template: \`\` })
+@Component({ standalone: true, selector: 'input[ink-radio-field-base]', host: { '[class]': "'radio-field' + (klass() ? ' ' + klass() : '')", 'type': 'radio', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[value]': "value() ?? ''", '[checked]': "checked()", '[disabled]': "disabled()", '[required]': "required()", '(click)': "readonly() && $event.preventDefault()", '(change)': "!readonly() && change.emit(value() ?? '')" }, template: \`\` })
 export class IRadioFieldBaseHostComponent
 {
 klass = input<string>()
@@ -39,6 +46,7 @@ value = input<string>()
 checked = input<boolean>()
 disabled = input<boolean>()
 required = input<boolean>()
+readonly = input<boolean>()
 change = output()
 }
 ",
@@ -56,12 +64,18 @@ export interface RadioFieldBaseProps {
   disabled?: boolean;
   /** Marks the control as required. */
   required?: boolean;
+  /**
+   * Prevents the selection from changing while still showing (and keeping focusable) the current
+   * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+   * the click is cancelled and the \`change\` event is suppressed.
+   */
+  readonly?: boolean;
 }
 type Props = RadioFieldBaseProps & Record<string, any>
 const props = Astro.props as Props;
-const { id, name, value, checked, disabled, required, ...__attrs } = props;
+const { id, name, value, checked, disabled, required, readonly, ...__attrs } = props;
 ---
-<input {...__attrs} class={["radio-field", __attrs.class].filter(Boolean).join(" ")} type="radio" id={id} name={name} value={value ?? ""} checked={checked} disabled={disabled} required={required} onChange={() => undefined} />
+<input {...__attrs} class={["radio-field", __attrs.class].filter(Boolean).join(" ")} type="radio" id={id} name={name} value={value ?? ""} checked={checked} disabled={disabled} required={required} onClick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onChange={() => !readonly && undefined} />
 ",
   "qwik/IRadioFieldBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
 export interface RadioFieldBaseProps {
@@ -77,12 +91,18 @@ export interface RadioFieldBaseProps {
   disabled?: boolean;
   /** Marks the control as required. */
   required?: boolean;
+  /**
+   * Prevents the selection from changing while still showing (and keeping focusable) the current
+   * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+   * the click is cancelled and the \`change\` event is suppressed.
+   */
+  readonly?: boolean;
 }
 export const IRadioFieldBase = component$((props: RadioFieldBaseProps & { onChange$?: QRL<(...args: any[]) => void> } & Record<string, any>) =>
 {
-const { id, name, value, checked, disabled, required, onChange$, ...__attrs } = props
+const { id, name, value, checked, disabled, required, readonly, onChange$, ...__attrs } = props
 return (
-<input {...__attrs} class={["radio-field", props.class].filter(Boolean).join(" ")} type="radio" id={props.id} name={props.name} value={props.value ?? ""} checked={props.checked} disabled={props.disabled} required={props.required} onChange={$(() => props.onChange$?.(props.value ?? ""))} />
+<input {...__attrs} class={["radio-field", props.class].filter(Boolean).join(" ")} type="radio" id={props.id} name={props.name} value={props.value ?? ""} checked={props.checked} disabled={props.disabled} required={props.required} onClick={$((e: { preventDefault: () => void }) => props.readonly && e.preventDefault())} onChange={$(() => !props.readonly && props.onChange$?.(props.value ?? ""))} />
 )
 });
 ",
@@ -99,12 +119,18 @@ return (
   disabled?: boolean;
   /** Marks the control as required. */
   required?: boolean;
+  /**
+   * Prevents the selection from changing while still showing (and keeping focusable) the current
+   * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+   * the click is cancelled and the \`change\` event is suppressed.
+   */
+  readonly?: boolean;
 }
 export function IRadioFieldBase(props: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & React.HTMLAttributes<HTMLElement>)
 {
-const { id, name, value, checked, disabled, required, onChange, ...__attrs } = props
+const { id, name, value, checked, disabled, required, readonly, onChange, ...__attrs } = props
 return (
-<input {...__attrs} className={["radio-field", props.className].filter(Boolean).join(" ")} type="radio" id={props.id} name={props.name} value={props.value ?? ""} checked={props.checked} disabled={props.disabled} required={props.required} onChange={() => props.onChange?.(props.value ?? "")} />
+<input {...__attrs} className={["radio-field", props.className].filter(Boolean).join(" ")} type="radio" id={props.id} name={props.name} value={props.value ?? ""} checked={props.checked} disabled={props.disabled} required={props.required} onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onChange={() => !props.readonly && props.onChange?.(props.value ?? "")} />
 )
 }
 ",
@@ -123,12 +149,18 @@ export interface RadioFieldBaseProps {
   disabled?: boolean;
   /** Marks the control as required. */
   required?: boolean;
+  /**
+   * Prevents the selection from changing while still showing (and keeping focusable) the current
+   * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+   * the click is cancelled and the \`change\` event is suppressed.
+   */
+  readonly?: boolean;
 }
 export default function IRadioFieldBase(props: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & JSX.HTMLAttributes<HTMLElement>)
 {
-const [, __attrs] = splitProps(props, ["id", "name", "value", "checked", "disabled", "required", "onChange"])
+const [, __attrs] = splitProps(props, ["id", "name", "value", "checked", "disabled", "required", "readonly", "onChange"])
 return (
-<input {...__attrs} class={["radio-field", props.class].filter(Boolean).join(" ")} type="radio" id={props.id} name={props.name} value={props.value ?? ""} checked={props.checked} disabled={props.disabled} required={props.required} onchange={() => props.onChange?.(props.value ?? "")} />
+<input {...__attrs} class={["radio-field", props.class].filter(Boolean).join(" ")} type="radio" id={props.id} name={props.name} value={props.value ?? ""} checked={props.checked} disabled={props.disabled} required={props.required} onclick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onchange={() => !props.readonly && props.onChange?.(props.value ?? "")} />
 )
 }
 ",
@@ -146,10 +178,16 @@ return (
     disabled?: boolean;
     /** Marks the control as required. */
     required?: boolean;
+    /**
+     * Prevents the selection from changing while still showing (and keeping focusable) the current
+     * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+     * the click is cancelled and the \`change\` event is suppressed.
+     */
+    readonly?: boolean;
   }
-  let { id, name, value, checked, disabled, required, onChange, ...__attrs }: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & Record<string, any> = $props()
+  let { id, name, value, checked, disabled, required, readonly, onChange, ...__attrs }: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & Record<string, any> = $props()
 </script>
-<input {...__attrs} class={["radio-field", __attrs.class].filter(Boolean).join(" ")} type="radio" id={id} name={name} value={value ?? ""} checked={checked} disabled={disabled} required={required} onchange={() => onChange?.(value ?? "")} />
+<input {...__attrs} class={["radio-field", __attrs.class].filter(Boolean).join(" ")} type="radio" id={id} name={name} value={value ?? ""} checked={checked} disabled={disabled} required={required} onclick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onchange={() => !readonly && onChange?.(value ?? "")} />
 ",
   "vue/IRadioFieldBase.vue": "<script setup lang="ts">
   export interface RadioFieldBaseProps {
@@ -165,12 +203,18 @@ return (
     disabled?: boolean;
     /** Marks the control as required. */
     required?: boolean;
+    /**
+     * Prevents the selection from changing while still showing (and keeping focusable) the current
+     * state. Native radios ignore the HTML \`readonly\` attribute, so this is enforced behaviorally:
+     * the click is cancelled and the \`change\` event is suppressed.
+     */
+    readonly?: boolean;
   }
   const emit = defineEmits(["change"])
   const props = defineProps<RadioFieldBaseProps>()
 </script>
 <template>
-<input class="radio-field" type="radio" :id="id" :name="name" :value='value ?? ""' :checked="checked" :disabled="disabled" :required="required" @change='() => emit("change", value ?? "")' />
+<input class="radio-field" type="radio" :id="id" :name="name" :value='value ?? ""' :checked="checked" :disabled="disabled" :required="required" @click="(e: { preventDefault: () => void }) => readonly && e.preventDefault()" @change='() => !readonly && emit("change", value ?? "")' />
 </template>
 ",
 }

--- a/ui/components/src/components/radio/headless/__snapshots__/IRadioGroupBase.ink.test.ts.snap
+++ b/ui/components/src/components/radio/headless/__snapshots__/IRadioGroupBase.ink.test.ts.snap
@@ -8,8 +8,10 @@ export interface RadioGroupBaseProps {
   id?: string;
   /** Accessible name for the group, exposed as \`aria-label\`. */
   label?: string;
+  /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+  readonly?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-radio-group-base', host: { style: 'display: contents' }, template: \`<div [class]="'radio-group' + (klass() ? ' ' + klass() : '')" role="radiogroup" [attr.id]="(id()) ?? null" [attr.aria-label]="(label()) ?? null">
+@Component({ standalone: true, selector: 'ink-radio-group-base', host: { style: 'display: contents' }, template: \`<div [class]="'radio-group' + (klass() ? ' ' + klass() : '')" role="radiogroup" [attr.id]="(id()) ?? null" [attr.aria-label]="(label()) ?? null" [attr.aria-readonly]="(readonly() ? 'true' : undefined) ?? null">
 <ng-content></ng-content>
 </div>\` })
 export class IRadioGroupBaseComponent
@@ -17,13 +19,15 @@ export class IRadioGroupBaseComponent
 klass = input<string>()
 id = input<string>()
 label = input<string>()
+readonly = input<boolean>()
 }
-@Component({ standalone: true, selector: 'div[ink-radio-group-base]', host: { '[class]': "'radio-group' + (klass() ? ' ' + klass() : '')", 'role': 'radiogroup', '[attr.id]': "(id()) ?? null", '[attr.aria-label]': "(label()) ?? null" }, template: \`<ng-content></ng-content>\` })
+@Component({ standalone: true, selector: 'div[ink-radio-group-base]', host: { '[class]': "'radio-group' + (klass() ? ' ' + klass() : '')", 'role': 'radiogroup', '[attr.id]': "(id()) ?? null", '[attr.aria-label]': "(label()) ?? null", '[attr.aria-readonly]': "(readonly() ? 'true' : undefined) ?? null" }, template: \`<ng-content></ng-content>\` })
 export class IRadioGroupBaseHostComponent
 {
 klass = input<string>()
 id = input<string>()
 label = input<string>()
+readonly = input<boolean>()
 }
 ",
   "astro/IRadioGroupBase.astro": "---
@@ -32,12 +36,14 @@ export interface RadioGroupBaseProps {
   id?: string;
   /** Accessible name for the group, exposed as \`aria-label\`. */
   label?: string;
+  /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+  readonly?: boolean;
 }
 type Props = RadioGroupBaseProps & Record<string, any>
 const props = Astro.props as Props;
-const { id, label, ...__attrs } = props;
+const { id, label, readonly, ...__attrs } = props;
 ---
-<div {...__attrs} class={["radio-group", __attrs.class].filter(Boolean).join(" ")} role="radiogroup" id={id} aria-label={label}>
+<div {...__attrs} class={["radio-group", __attrs.class].filter(Boolean).join(" ")} role="radiogroup" id={id} aria-label={label} aria-readonly={readonly ? "true" : undefined}>
 <slot />
 </div>
 ",
@@ -47,12 +53,14 @@ export interface RadioGroupBaseProps {
   id?: string;
   /** Accessible name for the group, exposed as \`aria-label\`. */
   label?: string;
+  /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+  readonly?: boolean;
 }
 export const IRadioGroupBase = component$((props: RadioGroupBaseProps & Record<string, any>) =>
 {
-const { children, id, label, ...__attrs } = props
+const { children, id, label, readonly, ...__attrs } = props
 return (
-<div {...__attrs} class={["radio-group", props.class].filter(Boolean).join(" ")} role="radiogroup" id={props.id} aria-label={props.label}>
+<div {...__attrs} class={["radio-group", props.class].filter(Boolean).join(" ")} role="radiogroup" id={props.id} aria-label={props.label} aria-readonly={props.readonly ? "true" : undefined}>
   <Slot />
 </div>
 )
@@ -63,12 +71,14 @@ return (
   id?: string;
   /** Accessible name for the group, exposed as \`aria-label\`. */
   label?: string;
+  /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+  readonly?: boolean;
 }
 export function IRadioGroupBase(props: RadioGroupBaseProps & { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {
-const { children, id, label, ...__attrs } = props
+const { children, id, label, readonly, ...__attrs } = props
 return (
-<div {...__attrs} className={["radio-group", props.className].filter(Boolean).join(" ")} role="radiogroup" id={props.id} aria-label={props.label}>
+<div {...__attrs} className={["radio-group", props.className].filter(Boolean).join(" ")} role="radiogroup" id={props.id} aria-label={props.label} aria-readonly={props.readonly ? "true" : undefined}>
   {props.children}
 </div>
 )
@@ -81,12 +91,14 @@ export interface RadioGroupBaseProps {
   id?: string;
   /** Accessible name for the group, exposed as \`aria-label\`. */
   label?: string;
+  /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+  readonly?: boolean;
 }
 export default function IRadioGroupBase(props: RadioGroupBaseProps & { children?: any } & JSX.HTMLAttributes<HTMLElement>)
 {
-const [, __attrs] = splitProps(props, ["children", "id", "label"])
+const [, __attrs] = splitProps(props, ["children", "id", "label", "readonly"])
 return (
-<div {...__attrs} class={["radio-group", props.class].filter(Boolean).join(" ")} role="radiogroup" id={props.id} aria-label={props.label}>
+<div {...__attrs} class={["radio-group", props.class].filter(Boolean).join(" ")} role="radiogroup" id={props.id} aria-label={props.label} aria-readonly={props.readonly ? "true" : undefined}>
   {props.children}
 </div>
 )
@@ -98,11 +110,13 @@ return (
     id?: string;
     /** Accessible name for the group, exposed as \`aria-label\`. */
     label?: string;
+    /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+    readonly?: boolean;
   }
   import type { Snippet } from "svelte";
-  let { id, label, children, ...__attrs }: RadioGroupBaseProps & { children?: Snippet } & Record<string, any> = $props()
+  let { id, label, readonly, children, ...__attrs }: RadioGroupBaseProps & { children?: Snippet } & Record<string, any> = $props()
 </script>
-<div {...__attrs} class={["radio-group", __attrs.class].filter(Boolean).join(" ")} role="radiogroup" id={id} aria-label={label}>
+<div {...__attrs} class={["radio-group", __attrs.class].filter(Boolean).join(" ")} role="radiogroup" id={id} aria-label={label} aria-readonly={readonly ? "true" : undefined}>
   {@render children?.()}
 </div>
 ",
@@ -112,11 +126,13 @@ return (
     id?: string;
     /** Accessible name for the group, exposed as \`aria-label\`. */
     label?: string;
+    /** Marks the whole group read-only — exposed as \`aria-readonly\` on the radiogroup. */
+    readonly?: boolean;
   }
   const props = defineProps<RadioGroupBaseProps>()
 </script>
 <template>
-<div class="radio-group" role="radiogroup" :id="id" :aria-label="label">
+<div class="radio-group" role="radiogroup" :id="id" :aria-label="label" :aria-readonly='readonly ? "true" : undefined'>
   <slot />
 </div>
 </template>

--- a/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
+++ b/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
@@ -31,6 +31,10 @@ const meta = defineStories<RadioGroupProps>({
       description: "Layout orientation",
     },
     disabled: { control: "boolean", description: "Disables every option in the group" },
+    readonly: {
+      control: "boolean",
+      description: "Freezes the selection (stays focusable, unlike disabled)",
+    },
   },
 });
 
@@ -39,6 +43,7 @@ export default meta;
 export const Default = {};
 export const Horizontal = { args: { orientation: "horizontal" } };
 export const Disabled = { args: { disabled: true } };
+export const Readonly = { args: { readonly: true, value: "banana" } };
 export const WithDisabledOption = {
   args: {
     options: [

--- a/ui/components/src/components/radio/stories/RadioColors.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioColors.ink.tsx
@@ -1,13 +1,18 @@
-import { defineComponent } from "@inkline/core";
+import { createSignal, defineComponent } from "@inkline/core";
 import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
 
+// Each group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. Distinct `name`s keep the groups mutually independent.
 export default defineComponent(() => {
+  const [light, _setLight] = createSignal("apple");
+  const [dark, _setDark] = createSignal("apple");
+  const [neutral, _setNeutral] = createSignal("apple");
   return (
     <div id="story">
       <IRadioGroup
         color="light"
         name="color-light"
-        value="apple"
+        $bind:value={light}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -17,7 +22,7 @@ export default defineComponent(() => {
       <IRadioGroup
         color="dark"
         name="color-dark"
-        value="apple"
+        $bind:value={dark}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -27,7 +32,7 @@ export default defineComponent(() => {
       <IRadioGroup
         color="neutral"
         name="color-neutral"
-        value="apple"
+        $bind:value={neutral}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },

--- a/ui/components/src/components/radio/stories/RadioOrientations.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioOrientations.ink.tsx
@@ -1,13 +1,17 @@
-import { defineComponent } from "@inkline/core";
+import { createSignal, defineComponent } from "@inkline/core";
 import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
 
+// Each group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. Distinct `name`s keep the groups mutually independent.
 export default defineComponent(() => {
+  const [vertical, _setVertical] = createSignal("apple");
+  const [horizontal, _setHorizontal] = createSignal("apple");
   return (
     <div id="story">
       <IRadioGroup
         orientation="vertical"
         name="orientation-vertical"
-        value="apple"
+        $bind:value={vertical}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -17,7 +21,7 @@ export default defineComponent(() => {
       <IRadioGroup
         orientation="horizontal"
         name="orientation-horizontal"
-        value="apple"
+        $bind:value={horizontal}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },

--- a/ui/components/src/components/radio/stories/RadioSizes.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioSizes.ink.tsx
@@ -1,13 +1,18 @@
-import { defineComponent } from "@inkline/core";
+import { createSignal, defineComponent } from "@inkline/core";
 import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
 
+// Each group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. Distinct `name`s keep the groups mutually independent.
 export default defineComponent(() => {
+  const [sm, _setSm] = createSignal("apple");
+  const [md, _setMd] = createSignal("apple");
+  const [lg, _setLg] = createSignal("apple");
   return (
     <div id="story">
       <IRadioGroup
         size="sm"
         name="size-sm"
-        value="apple"
+        $bind:value={sm}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -17,7 +22,7 @@ export default defineComponent(() => {
       <IRadioGroup
         size="md"
         name="size-md"
-        value="apple"
+        $bind:value={md}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -27,7 +32,7 @@ export default defineComponent(() => {
       <IRadioGroup
         size="lg"
         name="size-lg"
-        value="apple"
+        $bind:value={lg}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },

--- a/ui/components/src/components/radio/styled/IRadioGroup.ink.test.ts
+++ b/ui/components/src/components/radio/styled/IRadioGroup.ink.test.ts
@@ -98,6 +98,13 @@ describe("IRadioGroup (styled)", () => {
     expectOutputContains(out(result, "angular"), '[name]="name()"');
   });
 
+  it("forwards readonly to the group container and every field", async () => {
+    const result = await compileComponent(IRADIOGROUP);
+    // The group gets aria-readonly via IRadioGroupBase; each field gets the interaction guard.
+    expectOutputContains(out(result, "vue"), ':readonly="readonly"');
+    expectOutputContains(out(result, "angular"), '[readonly]="readonly()"');
+  });
+
   it("output matches snapshots", async () => {
     const result = await compileComponent(IRADIOGROUP);
     expect(snapshotOutput(result)).toMatchSnapshot();
@@ -171,6 +178,15 @@ describe("IRadioGroup (styled) on Angular SSR", () => {
     const { html } = await mount({ options: OPTIONS, disabled: true });
 
     expect(html.match(/<input[^>]*disabled/g) ?? []).toHaveLength(2);
+  });
+
+  it("exposes aria-readonly on the radiogroup when read-only", async () => {
+    const { html } = await mount({ options: OPTIONS, value: "apple", readonly: true });
+
+    // Read-only keeps the controls focusable (no `disabled`) but marks the set aria-readonly.
+    expect(html).toMatch(/<div[^>]*role="radiogroup"/);
+    expect(html).toContain('aria-readonly="true"');
+    expect(html.match(/<input[^>]*disabled/g) ?? []).toHaveLength(0);
   });
 
   // The collapsed host variant inlines the composite onto native elements: the group is the <div>

--- a/ui/components/src/components/radio/styled/IRadioGroup.ink.tsx
+++ b/ui/components/src/components/radio/styled/IRadioGroup.ink.tsx
@@ -37,6 +37,9 @@ export interface RadioGroupProps extends RadioGroupBaseProps {
   orientation?: RadioGroupStylingProps["orientation"];
   /** Disables every option in the group. */
   disabled?: boolean;
+  /** Marks the group read-only: the selection is shown but can't be changed (unlike `disabled`,
+   * the controls stay focusable). */
+  readonly?: boolean;
 }
 
 /**
@@ -59,7 +62,12 @@ export default defineComponent({ meta: { headless: true } }, (props: RadioGroupP
   );
 
   return (
-    <IRadioGroupBase id={props.id} label={props.label} class={groupClassName()}>
+    <IRadioGroupBase
+      id={props.id}
+      label={props.label}
+      readonly={props.readonly}
+      class={groupClassName()}
+    >
       <For each={items()} key={(option) => option.value}>
         {(option) => (
           <IRadioBase class={radioClassName()}>
@@ -69,6 +77,7 @@ export default defineComponent({ meta: { headless: true } }, (props: RadioGroupP
               value={option.value}
               checked={value() === option.value}
               disabled={props.disabled || option.disabled}
+              readonly={props.readonly}
               onChange={() => setValue(option.value)}
             />
             <span class="radio-label">{option.label ?? option.value}</span>

--- a/ui/components/src/components/radio/styled/__snapshots__/IRadioGroup.ink.test.ts.snap
+++ b/ui/components/src/components/radio/styled/__snapshots__/IRadioGroup.ink.test.ts.snap
@@ -37,11 +37,14 @@ export interface RadioGroupProps extends RadioGroupBaseProps {
   orientation?: RadioGroupStylingProps["orientation"];
   /** Disables every option in the group. */
   disabled?: boolean;
+  /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+   * the controls stay focusable). */
+  readonly?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-radio-group', host: { style: 'display: contents' }, imports: [IRadioGroupBase, IRadioBase, IRadioFieldBase], template: \`<ink-radio-group-base [id]="id()" [label]="label()" [klass]="(groupClassName()) + (klass() ? ' ' + klass() : '')">
+@Component({ standalone: true, selector: 'ink-radio-group', host: { style: 'display: contents' }, imports: [IRadioGroupBase, IRadioBase, IRadioFieldBase], template: \`<ink-radio-group-base [id]="id()" [label]="label()" [readonly]="readonly()" [klass]="(groupClassName()) + (klass() ? ' ' + klass() : '')">
 @for (option of items(); track option.value) {
 <ink-radio-base [klass]="(radioClassName())">
-<ink-radio-field-base [klass]="(fieldClassName())" [name]="name()" [value]="option.value" [checked]="value() === option.value" [disabled]="disabled() || option.disabled" (change)="value.set(option.value)"></ink-radio-field-base>
+<ink-radio-field-base [klass]="(fieldClassName())" [name]="name()" [value]="option.value" [checked]="value() === option.value" [disabled]="disabled() || option.disabled" [readonly]="readonly()" (change)="value.set(option.value)"></ink-radio-field-base>
 <span class="radio-label">{{ option.label ?? option.value }}</span>
 </ink-radio-base>
 }
@@ -62,13 +65,14 @@ color = input<RadioFieldStylingProps["color"]>()
 size = input<RadioGroupStylingProps["size"]>()
 orientation = input<RadioGroupStylingProps["orientation"]>()
 disabled = input<boolean>()
+readonly = input<boolean>()
 id = input<string>()
 label = input<string>()
 value = model<string>()
 }
-@Component({ standalone: true, selector: 'div[ink-radio-group]', host: { '[class]': "'radio-group' + ((groupClassName()) ? ' ' + (groupClassName()) : '') + (klass() ? ' ' + klass() : '')", 'role': 'radiogroup', '[attr.id]': "(id()) ?? null", '[attr.aria-label]': "(label()) ?? null", 'ink-radio-group-base': '' }, imports: [IRadioBaseHostComponent, IRadioFieldBaseHostComponent], template: \`@for (option of items(); track option.value) {
+@Component({ standalone: true, selector: 'div[ink-radio-group]', host: { '[class]': "'radio-group' + ((groupClassName()) ? ' ' + (groupClassName()) : '') + (klass() ? ' ' + klass() : '')", 'role': 'radiogroup', '[attr.id]': "(id()) ?? null", '[attr.aria-label]': "(label()) ?? null", '[attr.aria-readonly]': "(readonly() ? 'true' : undefined) ?? null", 'ink-radio-group-base': '' }, imports: [IRadioBaseHostComponent, IRadioFieldBaseHostComponent], template: \`@for (option of items(); track option.value) {
 <label ink-radio-base [klass]="(radioClassName())">
-<input ink-radio-field-base [klass]="(fieldClassName())" [name]="name()" [value]="option.value" [checked]="value() === option.value" [disabled]="disabled() || option.disabled" (change)="value.set(option.value)" />
+<input ink-radio-field-base [klass]="(fieldClassName())" [name]="name()" [value]="option.value" [checked]="value() === option.value" [disabled]="disabled() || option.disabled" [readonly]="readonly()" (change)="value.set(option.value)" />
 <span class="radio-label">{{ option.label ?? option.value }}</span>
 </label>
 }\` })
@@ -88,6 +92,7 @@ color = input<RadioFieldStylingProps["color"]>()
 size = input<RadioGroupStylingProps["size"]>()
 orientation = input<RadioGroupStylingProps["orientation"]>()
 disabled = input<boolean>()
+readonly = input<boolean>()
 id = input<string>()
 label = input<string>()
 value = model<string>()
@@ -125,19 +130,22 @@ export interface RadioGroupProps extends RadioGroupBaseProps {
   orientation?: RadioGroupStylingProps["orientation"];
   /** Disables every option in the group. */
   disabled?: boolean;
+  /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+   * the controls stay focusable). */
+  readonly?: boolean;
 }
 type Props = RadioGroupProps & Record<string, any>
 const props = Astro.props as Props;
-const { options, name, color, size, orientation, disabled, id, label, ...__attrs } = props;
+const { options, name, color, size, orientation, disabled, readonly, id, label, ...__attrs } = props;
 let value = props.value
 const items = options ?? []
 const groupClassName = radioGroupRecipe({ orientation: orientation, size: size })
 const radioClassName = radioRecipe({ size: size })
 const fieldClassName = radioFieldRecipe({ color: color, size: size })
 ---
-<IRadioGroupBase {...__attrs} id={id} label={label} class={[groupClassName, __attrs.class].filter(Boolean).join(" ")}>
+<IRadioGroupBase {...__attrs} id={id} label={label} readonly={readonly} class={[groupClassName, __attrs.class].filter(Boolean).join(" ")}>
 {items.map((option) => (<IRadioBase class={radioClassName}>
-<IRadioFieldBase class={fieldClassName} name={name} value={option.value} checked={value === option.value} disabled={disabled || option.disabled} onChange={() => value = option.value} />
+<IRadioFieldBase class={fieldClassName} name={name} value={option.value} checked={value === option.value} disabled={disabled || option.disabled} readonly={readonly} onChange={() => value = option.value} />
 <span class="radio-label">{option.label ?? option.value}</span>
 </IRadioBase>))}
 </IRadioGroupBase>
@@ -175,6 +183,9 @@ export interface RadioGroupProps extends RadioGroupBaseProps {
   orientation?: RadioGroupStylingProps["orientation"];
   /** Disables every option in the group. */
   disabled?: boolean;
+  /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+   * the controls stay focusable). */
+  readonly?: boolean;
 }
 export const IRadioGroup = component$((props: RadioGroupProps & { value?: string; onUpdateValue$?: QRL<(value: string) => void> } & Record<string, any>) =>
 {
@@ -182,10 +193,10 @@ const items = useComputed$(() => props.options ?? [])
 const groupClassName = useComputed$(() => radioGroupRecipe({ orientation: props.orientation, size: props.size }))
 const radioClassName = useComputed$(() => radioRecipe({ size: props.size }))
 const fieldClassName = useComputed$(() => radioFieldRecipe({ color: props.color, size: props.size }))
-const { options, name, color, size, orientation, disabled, id, label, value, onUpdateValue$, ...__attrs } = props
+const { options, name, color, size, orientation, disabled, readonly, id, label, value, onUpdateValue$, ...__attrs } = props
 return (
-<IRadioGroupBase {...__attrs} id={props.id} label={props.label} class={[groupClassName.value, props.class].filter(Boolean).join(" ")}>
-  {items.value.map((option) => (<><IRadioBase class={radioClassName.value}><><IRadioFieldBase class={fieldClassName.value} name={props.name} value={option.value} checked={props.value === option.value} disabled={props.disabled || option.disabled} onChange={$(() => props.onUpdateValue$?.(option.value))} /><span class="radio-label">{option.label ?? option.value}</span></></IRadioBase></>))}
+<IRadioGroupBase {...__attrs} id={props.id} label={props.label} readonly={props.readonly} class={[groupClassName.value, props.class].filter(Boolean).join(" ")}>
+  {items.value.map((option) => (<><IRadioBase class={radioClassName.value}><><IRadioFieldBase class={fieldClassName.value} name={props.name} value={option.value} checked={props.value === option.value} disabled={props.disabled || option.disabled} readonly={props.readonly} onChange={$(() => props.onUpdateValue$?.(option.value))} /><span class="radio-label">{option.label ?? option.value}</span></></IRadioBase></>))}
 </IRadioGroupBase>
 )
 });
@@ -223,6 +234,9 @@ export interface RadioGroupProps extends RadioGroupBaseProps {
   orientation?: RadioGroupStylingProps["orientation"];
   /** Disables every option in the group. */
   disabled?: boolean;
+  /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+   * the controls stay focusable). */
+  readonly?: boolean;
 }
 export function IRadioGroup(props: RadioGroupProps & { value?: string; onUpdateValue?: (value: string) => void } & React.HTMLAttributes<HTMLElement>)
 {
@@ -230,10 +244,10 @@ const items = useMemo(() => props.options ?? [], [props.options])
 const groupClassName = useMemo(() => radioGroupRecipe({ orientation: props.orientation, size: props.size }), [props.orientation, props.size])
 const radioClassName = useMemo(() => radioRecipe({ size: props.size }), [props.size])
 const fieldClassName = useMemo(() => radioFieldRecipe({ color: props.color, size: props.size }), [props.color, props.size])
-const { options, name, color, size, orientation, disabled, id, label, value, onUpdateValue, ...__attrs } = props
+const { options, name, color, size, orientation, disabled, readonly, id, label, value, onUpdateValue, ...__attrs } = props
 return (
-<IRadioGroupBase {...__attrs} id={props.id} label={props.label} className={[groupClassName, props.className].filter(Boolean).join(" ")}>
-  {items.map((option) => (<Fragment key={option.value}><IRadioBase className={radioClassName}><><IRadioFieldBase className={fieldClassName} name={props.name} value={option.value} checked={props.value === option.value} disabled={props.disabled || option.disabled} onChange={() => props.onUpdateValue?.(option.value)} /><span className="radio-label">{option.label ?? option.value}</span></></IRadioBase></Fragment>))}
+<IRadioGroupBase {...__attrs} id={props.id} label={props.label} readOnly={props.readonly} className={[groupClassName, props.className].filter(Boolean).join(" ")}>
+  {items.map((option) => (<Fragment key={option.value}><IRadioBase className={radioClassName}><><IRadioFieldBase className={fieldClassName} name={props.name} value={option.value} checked={props.value === option.value} disabled={props.disabled || option.disabled} readOnly={props.readonly} onChange={() => props.onUpdateValue?.(option.value)} /><span className="radio-label">{option.label ?? option.value}</span></></IRadioBase></Fragment>))}
 </IRadioGroupBase>
 )
 }
@@ -271,6 +285,9 @@ export interface RadioGroupProps extends RadioGroupBaseProps {
   orientation?: RadioGroupStylingProps["orientation"];
   /** Disables every option in the group. */
   disabled?: boolean;
+  /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+   * the controls stay focusable). */
+  readonly?: boolean;
 }
 export default function IRadioGroup(props: RadioGroupProps & { value?: string; onUpdateValue?: (value: string) => void } & JSX.HTMLAttributes<HTMLElement>)
 {
@@ -278,11 +295,11 @@ const items = createMemo(() => props.options ?? [])
 const groupClassName = createMemo(() => radioGroupRecipe({ orientation: props.orientation, size: props.size }))
 const radioClassName = createMemo(() => radioRecipe({ size: props.size }))
 const fieldClassName = createMemo(() => radioFieldRecipe({ color: props.color, size: props.size }))
-const [, __attrs] = splitProps(props, ["options", "name", "color", "size", "orientation", "disabled", "id", "label", "value", "onUpdateValue"])
+const [, __attrs] = splitProps(props, ["options", "name", "color", "size", "orientation", "disabled", "readonly", "id", "label", "value", "onUpdateValue"])
 return (
-<IRadioGroupBase {...__attrs} id={props.id} label={props.label} class={[groupClassName(), props.class].filter(Boolean).join(" ")}>
+<IRadioGroupBase {...__attrs} id={props.id} label={props.label} readonly={props.readonly} class={[groupClassName(), props.class].filter(Boolean).join(" ")}>
   <For each={items()}>
-    {(option) => <IRadioBase class={radioClassName()}><><IRadioFieldBase class={fieldClassName()} name={props.name} value={option.value} checked={props.value === option.value} disabled={props.disabled || option.disabled} onChange={() => props.onUpdateValue?.(option.value)} /><span class="radio-label">{option.label ?? option.value}</span></></IRadioBase>}
+    {(option) => <IRadioBase class={radioClassName()}><><IRadioFieldBase class={fieldClassName()} name={props.name} value={option.value} checked={props.value === option.value} disabled={props.disabled || option.disabled} readonly={props.readonly} onChange={() => props.onUpdateValue?.(option.value)} /><span class="radio-label">{option.label ?? option.value}</span></></IRadioBase>}
   </For>
 </IRadioGroupBase>
 )
@@ -320,16 +337,19 @@ return (
     orientation?: RadioGroupStylingProps["orientation"];
     /** Disables every option in the group. */
     disabled?: boolean;
+    /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+     * the controls stay focusable). */
+    readonly?: boolean;
   }
-  let { options, name, color, size, orientation, disabled, id, label, value = $bindable(), ...__attrs }: RadioGroupProps & { value?: string } & Record<string, any> = $props()
+  let { options, name, color, size, orientation, disabled, readonly, id, label, value = $bindable(), ...__attrs }: RadioGroupProps & { value?: string } & Record<string, any> = $props()
   let items = $derived(options ?? [])
   let groupClassName = $derived(radioGroupRecipe({ orientation: orientation, size: size }))
   let radioClassName = $derived(radioRecipe({ size: size }))
   let fieldClassName = $derived(radioFieldRecipe({ color: color, size: size }))
 </script>
-<IRadioGroupBase {...__attrs} id={id} label={label} class={[groupClassName, __attrs.class].filter(Boolean).join(" ")}>
+<IRadioGroupBase {...__attrs} id={id} label={label} readonly={readonly} class={[groupClassName, __attrs.class].filter(Boolean).join(" ")}>
   {#each items as option (option.value)}<IRadioBase class={radioClassName}>
-    <IRadioFieldBase class={fieldClassName} name={name} value={option.value} checked={value === option.value} disabled={disabled || option.disabled} onChange={() => value = option.value} />
+    <IRadioFieldBase class={fieldClassName} name={name} value={option.value} checked={value === option.value} disabled={disabled || option.disabled} readonly={readonly} onChange={() => value = option.value} />
     <span class="radio-label">{option.label ?? option.value}</span>
   </IRadioBase>
   {/each}
@@ -368,6 +388,9 @@ return (
     orientation?: RadioGroupStylingProps["orientation"];
     /** Disables every option in the group. */
     disabled?: boolean;
+    /** Marks the group read-only: the selection is shown but can't be changed (unlike \`disabled\`,
+     * the controls stay focusable). */
+    readonly?: boolean;
   }
   const props = defineProps<RadioGroupProps>()
   const value = defineModel<string>("value")
@@ -377,9 +400,9 @@ return (
   const fieldClassName = computed(() => radioFieldRecipe({ color: props.color, size: props.size }))
 </script>
 <template>
-<IRadioGroupBase :id="id" :label="label" :class="groupClassName">
+<IRadioGroupBase :id="id" :label="label" :readonly="readonly" :class="groupClassName">
   <IRadioBase v-for="option in items" :key="option.value" :class="radioClassName">
-    <IRadioFieldBase :class="fieldClassName" :name="name" :value="option.value" :checked="value === option.value" :disabled="disabled || option.disabled" @change="() => value = option.value" />
+    <IRadioFieldBase :class="fieldClassName" :name="name" :value="option.value" :checked="value === option.value" :disabled="disabled || option.disabled" :readonly="readonly" @change="() => value = option.value" />
     <span class="radio-label">{{ option.label ?? option.value }}</span>
   </IRadioBase>
 </IRadioGroupBase>


### PR DESCRIPTION
## Summary

Adds a group-level `readonly` prop to the Radio family. A read-only group shows and keeps its
selection focusable, but the choice can't be changed — the distinction from `disabled` (which also
removes the controls from the tab order).

Stacked on `agent/palette/radio` (the Radio source + stories branch). Retarget to `main` after the
base lands.

## Changes

- **`IRadioGroupBase`** — new `readonly` prop, surfaced as `aria-readonly` on the `role="radiogroup"`
  container (the ARIA state that role supports).
- **`IRadioFieldBase`** — new `readonly` prop. Native radios ignore the HTML `readonly` attribute, so
  it's enforced behaviorally: the pointer toggle is cancelled (`click` → `preventDefault`) and the
  `change` emit is gated on `!readonly` (covers keyboard selection). Handlers are expression-form so
  the Angular target compiles them to non-empty `(click)`/`(change)` bindings.
- **`IRadioGroup`** (styled) — forwards `readonly` to the group container and every field.
- Tests + snapshots: per-target guard/forwarding assertions and an `aria-readonly` real-DOM check via
  Angular SSR. The unreleased `add-radio` changeset is updated to mention `readonly`.

## Verification

- `cd ui/components && pnpm build` — exit 0; Radio still emits only its 2 expected `INK0045` notices
  (group value model + field change event), no `INK0068`, no errors.
- `pnpm exec vp test` — 177 passed (44 radio, +4 for `readonly`).
- `pnpm exec vp check` — clean.

## Notes

On the **React** target the compiler canonicalises the forwarded `readonly` to `readOnly` across the
styled→headless boundary, so the child (which reads lowercase `readonly`) never receives it and the
guard is inert on React only. This is the exact same latent state `IInput` already ships today; it's
tracked as a separate compiler fix and will resolve for both components at once. All other six
targets enforce `readonly` correctly.
