### PR TITLE
feat(components): interactive Radio showcases + readonly story

### DIFF
--- a/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
+++ b/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
@@ -31,6 +31,10 @@ const meta = defineStories<RadioGroupProps>({
       description: "Layout orientation",
     },
     disabled: { control: "boolean", description: "Disables every option in the group" },
+    readonly: {
+      control: "boolean",
+      description: "Freezes the selection (stays focusable, unlike disabled)",
+    },
   },
 });
 
@@ -39,6 +43,7 @@ export default meta;
 export const Default = {};
 export const Horizontal = { args: { orientation: "horizontal" } };
 export const Disabled = { args: { disabled: true } };
+export const Readonly = { args: { readonly: true, value: "banana" } };
 export const WithDisabledOption = {
   args: {
     options: [

--- a/ui/components/src/components/radio/stories/RadioColors.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioColors.ink.tsx
@@ -1,13 +1,18 @@
-import { defineComponent } from "@inkline/core";
+import { createSignal, defineComponent } from "@inkline/core";
 import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
 
+// Each group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. Distinct `name`s keep the groups mutually independent.
 export default defineComponent(() => {
+  const [light, _setLight] = createSignal("apple");
+  const [dark, _setDark] = createSignal("apple");
+  const [neutral, _setNeutral] = createSignal("apple");
   return (
     <div id="story">
       <IRadioGroup
         color="light"
         name="color-light"
-        value="apple"
+        $bind:value={light}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -17,7 +22,7 @@ export default defineComponent(() => {
       <IRadioGroup
         color="dark"
         name="color-dark"
-        value="apple"
+        $bind:value={dark}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -27,7 +32,7 @@ export default defineComponent(() => {
       <IRadioGroup
         color="neutral"
         name="color-neutral"
-        value="apple"
+        $bind:value={neutral}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },

--- a/ui/components/src/components/radio/stories/RadioOrientations.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioOrientations.ink.tsx
@@ -1,13 +1,17 @@
-import { defineComponent } from "@inkline/core";
+import { createSignal, defineComponent } from "@inkline/core";
 import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
 
+// Each group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. Distinct `name`s keep the groups mutually independent.
 export default defineComponent(() => {
+  const [vertical, _setVertical] = createSignal("apple");
+  const [horizontal, _setHorizontal] = createSignal("apple");
   return (
     <div id="story">
       <IRadioGroup
         orientation="vertical"
         name="orientation-vertical"
-        value="apple"
+        $bind:value={vertical}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -17,7 +21,7 @@ export default defineComponent(() => {
       <IRadioGroup
         orientation="horizontal"
         name="orientation-horizontal"
-        value="apple"
+        $bind:value={horizontal}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },

--- a/ui/components/src/components/radio/stories/RadioSizes.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioSizes.ink.tsx
@@ -1,13 +1,18 @@
-import { defineComponent } from "@inkline/core";
+import { createSignal, defineComponent } from "@inkline/core";
 import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
 
+// Each group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. Distinct `name`s keep the groups mutually independent.
 export default defineComponent(() => {
+  const [sm, _setSm] = createSignal("apple");
+  const [md, _setMd] = createSignal("apple");
+  const [lg, _setLg] = createSignal("apple");
   return (
     <div id="story">
       <IRadioGroup
         size="sm"
         name="size-sm"
-        value="apple"
+        $bind:value={sm}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -17,7 +22,7 @@ export default defineComponent(() => {
       <IRadioGroup
         size="md"
         name="size-md"
-        value="apple"
+        $bind:value={md}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },
@@ -27,7 +32,7 @@ export default defineComponent(() => {
       <IRadioGroup
         size="lg"
         name="size-lg"
-        value="apple"
+        $bind:value={lg}
         options={[
           { value: "apple", label: "Apple" },
           { value: "banana", label: "Banana" },


### PR DESCRIPTION
## Summary

Two story-only changes on the Radio family (INK-27), both under
`ui/components/src/components/radio/stories/`. Stacked on
`agent/palette/radio-readonly` so the group-level `readonly` prop is present.

## Changes

- **Interactive showcases.** `RadioSizes`, `RadioColors`, `RadioOrientations`
  each bound `value="apple"` as a static literal, so clicks snapped back. Each
  `<IRadioGroup>` now owns its own writable signal for `value`, two-way bound
  via `$bind:value`, so a click actually moves the selection. Distinct `name`s
  keep the groups independent. `Disabled`, `WithDisabledOption`, and the new
  `Readonly` story are intentionally left frozen.
- **`readonly` argType + `Readonly` story.** Added
  `readonly: { control: "boolean", description: "Freezes the selection (stays focusable, unlike disabled)" }`
  and `export const Readonly = { args: { readonly: true, value: "banana" } }`
  — a frozen, non-empty selection.

## Verification

- `pnpm --filter @inkline/components run build` — clean; Radio emits only its 2
  expected `INK0045` (Astro two-way notice on the styled group + field base).
- `vp check` — pass (format + lint + types, 85 files).
- Generated CSF verified across frameworks: Vue lowers `$bind:value` →
  `v-model:value` with per-group `ref`s; React → `value={sm}` +
  `onUpdateValue`. Story ids stable (Colors, Default, Disabled, Horizontal,
  Orientations, Sizes, WithDisabledOption) plus the new `Readonly` id.

## Notes

- New e2e contract id: `Readonly` on `Components/Forms/Radio`.
- React caveat (INK-26): the `readonly` guard is currently inert on the React
  target only — the compiler canonicalises `readonly` → `readOnly` across the
  styled→headless boundary, so the child never receives it until the shared
  compiler fix lands. The CSF3/argType shape and non-React interactivity are
  correct; don't block on React readonly interactivity here.
