### PR TITLE
feat(components): make Radio inline arg stories interactive (INK-29)

### DIFF
--- a/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
+++ b/ui/components/src/components/radio/stories/IRadioGroup.ink.stories.ts
@@ -40,19 +40,14 @@ const meta = defineStories<RadioGroupProps>({
 
 export default meta;
 
-export const Default = {};
-export const Horizontal = { args: { orientation: "horizontal" } };
-export const Disabled = { args: { disabled: true } };
-export const Readonly = { args: { readonly: true, value: "banana" } };
-export const WithDisabledOption = {
-  args: {
-    options: [
-      { value: "apple", label: "Apple" },
-      { value: "banana", label: "Banana", disabled: true },
-      { value: "cherry", label: "Cherry" },
-    ],
-  },
-};
+// `value` is a two-way `defineModel`, so it can't be a Storybook argType. These stories therefore use
+// render helpers that own a local `createSignal` bound via `$bind:value` — the same pattern as the
+// showcases below — so each has a default selection and clicks actually move it.
+export const Default = { render: "./RadioDefault.ink.tsx" };
+export const Horizontal = { render: "./RadioHorizontal.ink.tsx" };
+export const Disabled = { render: "./RadioDisabled.ink.tsx" };
+export const Readonly = { render: "./RadioReadonly.ink.tsx" };
+export const WithDisabledOption = { render: "./RadioWithDisabledOption.ink.tsx" };
 export const Sizes = { render: "./RadioSizes.ink.tsx" };
 export const Colors = { render: "./RadioColors.ink.tsx" };
 export const Orientations = { render: "./RadioOrientations.ink.tsx" };

--- a/ui/components/src/components/radio/stories/RadioDefault.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioDefault.ink.tsx
@@ -1,0 +1,21 @@
+import { createSignal, defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+// The group owns a writable signal for `value`, two-way bound via `$bind:value`, so a click actually
+// moves the selection. It defaults to "apple" so one option is selected on load.
+export default defineComponent(() => {
+  const [value, _setValue] = createSignal("apple");
+  return (
+    <div id="story">
+      <IRadioGroup
+        name="fruit"
+        $bind:value={value}
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/radio/stories/RadioDisabled.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioDisabled.ink.tsx
@@ -1,0 +1,22 @@
+import { createSignal, defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+// Group-level `disabled`: the selection ("apple") stays visible but nothing can be clicked — that's
+// the point of the story. The signal still backs `value` so the default selection renders.
+export default defineComponent(() => {
+  const [value, _setValue] = createSignal("apple");
+  return (
+    <div id="story">
+      <IRadioGroup
+        disabled
+        name="fruit"
+        $bind:value={value}
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/radio/stories/RadioHorizontal.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioHorizontal.ink.tsx
@@ -1,0 +1,22 @@
+import { createSignal, defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+// A horizontally-laid-out group with a writable signal for `value`, two-way bound via `$bind:value`,
+// defaulting to "apple" so one option is selected on load and clicks move the selection.
+export default defineComponent(() => {
+  const [value, _setValue] = createSignal("apple");
+  return (
+    <div id="story">
+      <IRadioGroup
+        orientation="horizontal"
+        name="fruit"
+        $bind:value={value}
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/radio/stories/RadioReadonly.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioReadonly.ink.tsx
@@ -1,0 +1,22 @@
+import { createSignal, defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+// `readonly` freezes the selection ("banana") while keeping the controls focusable — unlike disabled.
+// The signal backs `value` so the default selection renders; clicks can't change it, by design.
+export default defineComponent(() => {
+  const [value, _setValue] = createSignal("banana");
+  return (
+    <div id="story">
+      <IRadioGroup
+        readonly
+        name="fruit"
+        $bind:value={value}
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});

--- a/ui/components/src/components/radio/stories/RadioWithDisabledOption.ink.tsx
+++ b/ui/components/src/components/radio/stories/RadioWithDisabledOption.ink.tsx
@@ -1,0 +1,21 @@
+import { createSignal, defineComponent } from "@inkline/core";
+import IRadioGroup from "../styled/IRadioGroup.ink.tsx";
+
+// One option is disabled at the option level while the group stays interactive: the enabled options
+// ("apple", "cherry") are clickable, "banana" isn't. The signal defaults to "apple".
+export default defineComponent(() => {
+  const [value, _setValue] = createSignal("apple");
+  return (
+    <div id="story">
+      <IRadioGroup
+        name="fruit"
+        $bind:value={value}
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana", disabled: true },
+          { value: "cherry", label: "Cherry" },
+        ]}
+      />
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary

Makes the Radio inline arg stories interactive. `Default`, `Horizontal`, `Disabled`, `Readonly`, and `WithDisabledOption` had no default selection and couldn't be clicked to change the value.

Root cause: those five were inline-args stories rendering `IRadioGroup` off static Storybook `args`. `value` is a two-way `defineModel`, so behind static args there's no signal setter — nothing was selected by default, and a click fired `update:value` into the void. The component is correct (fully controlled: `checked={value === option.value}`), which is exactly why unbound static args can't toggle. The already-interactive showcases (`Sizes`/`Colors`/`Orientations`) work because they're render helpers with a local `createSignal` + `$bind:value`; these five just never got that treatment.

Stacked on the Radio branch (`agent/palette/radio`, #498) — radio isn't on `main` yet.

## Changes

- Add render helpers, each owning a local `createSignal` two-way bound via `$bind:value` (mirrors `RadioOrientations.ink.tsx`):
  - `RadioDefault` — default `"apple"`, clickable.
  - `RadioHorizontal` — `orientation="horizontal"`, default `"apple"`, clickable.
  - `RadioDisabled` — group `disabled`, default `"apple"` visible, non-interactive by design.
  - `RadioReadonly` — `readonly`, default `"banana"`, visible + focusable but frozen by design.
  - `RadioWithDisabledOption` — default `"apple"`, enabled options clickable, the `disabled` option not.
- Point the five story exports at their render helpers. Story ids are unchanged, so the e2e suite that drives all seven frameworks by id keeps working.

## Verification

- `cd ui/components && pnpm exec vp check` — clean (formatting + no lint/type errors across 90 files).
- `pnpm build` — clean; exactly the 2 expected radio `INK0045` notices (`IRadioGroup.ink.tsx`, `IRadioFieldBase.ink.tsx`) and no new ones from the helpers.
- Generated React CSF confirms interactivity, e.g. `RadioDefault` lowers to `value={value}` + `onUpdateValue={v => _setValue(v)}` with a default of `"apple"`.

## Notes

- `value` still can't be a Storybook argType (two-way model), so the primary `Default` story loses its live `value` args control — unavoidable given the two-way model, and consistent with how the showcases are authored. The `argTypes` remain as prop documentation.
- Component source is unchanged — this is entirely `ui/components/src/components/radio/stories/**`.
