### PR TITLE
feat(website): add Inkline brand-token palette for docs-theme

### DIFF
--- a/apps/website/app/app.config.ts
+++ b/apps/website/app/app.config.ts
@@ -1,28 +1,37 @@
+// `defineAppConfig` is a Nuxt auto-import, but apps/website is still vanilla
+// Vite (the Nuxt + Nuxt Content conversion is tracked separately). Until that
+// lands, this local identity helper keeps the file type-checkable and
+// lint-clean while remaining functionally identical to Nuxt's helper (both just
+// return the config object). Remove this shim when the app moves to Nuxt.
+function defineAppConfig<const T>(config: T): T {
+  return config;
+}
+
 export default defineAppConfig({
-	seo: {
-		title: "Inkline",
-		titleTemplate: "%s - Inkline",
-		description:
-			"Write-once, compile-everywhere UI components for React, Vue, Svelte, Solid, Angular, Qwik and Astro.",
-	},
-	header: {
-		title: "Inkline",
-		// logo: { alt, light, dark } — no header wordmark exists in the live tree yet
-		// (only the icon favicon at public/favicon.svg). Text title is used until a
-		// wordmark asset lands.
-	},
-	github: {
-		url: "https://github.com/inkline/inkline",
-		branch: "main",
-	},
-	footer: {
-		credits: `Copyright © ${new Date().getFullYear()} Inkline`,
-	},
-	// socials: {} — no verified handles in the live tree; add when confirmed.
-	ui: {
-		colors: {
-			primary: "purple",
-			neutral: "slate",
-		},
-	},
+  seo: {
+    title: "Inkline",
+    titleTemplate: "%s - Inkline",
+    description:
+      "Write-once, compile-everywhere UI components for React, Vue, Svelte, Solid, Angular, Qwik and Astro.",
+  },
+  header: {
+    title: "Inkline",
+    // logo: { alt, light, dark } — no header wordmark exists in the live tree yet
+    // (only the icon favicon at public/favicon.svg). Text title is used until a
+    // wordmark asset lands.
+  },
+  github: {
+    url: "https://github.com/inkline/inkline",
+    branch: "main",
+  },
+  footer: {
+    credits: `Copyright © ${new Date().getFullYear()} Inkline`,
+  },
+  // socials: {} — no verified handles in the live tree; add when confirmed.
+  ui: {
+    colors: {
+      primary: "purple",
+      neutral: "slate",
+    },
+  },
 });

--- a/apps/website/app/app.config.ts
+++ b/apps/website/app/app.config.ts
@@ -1,0 +1,28 @@
+export default defineAppConfig({
+	seo: {
+		title: "Inkline",
+		titleTemplate: "%s - Inkline",
+		description:
+			"Write-once, compile-everywhere UI components for React, Vue, Svelte, Solid, Angular, Qwik and Astro.",
+	},
+	header: {
+		title: "Inkline",
+		// logo: { alt, light, dark } — no header wordmark exists in the live tree yet
+		// (only the icon favicon at public/favicon.svg). Text title is used until a
+		// wordmark asset lands.
+	},
+	github: {
+		url: "https://github.com/inkline/inkline",
+		branch: "main",
+	},
+	footer: {
+		credits: `Copyright © ${new Date().getFullYear()} Inkline`,
+	},
+	// socials: {} — no verified handles in the live tree; add when confirmed.
+	ui: {
+		colors: {
+			primary: "purple",
+			neutral: "slate",
+		},
+	},
+});

--- a/apps/website/app/assets/css/main.css
+++ b/apps/website/app/assets/css/main.css
@@ -1,0 +1,31 @@
+@import "@uxfront/docs-theme/app/assets/css/main.css";
+
+/*
+ * Inkline brand palette. The docs-theme package ships neutral (palette-free);
+ * this consumer supplies the purple scale and maps it onto Nuxt UI's
+ * --ui-primary. The base hue is derived from the committed brand mark
+ * (public/favicon.svg, #863bff), with saturation and lightness eased for
+ * comfortable UI legibility across the full scale.
+ *
+ * Pairs with `ui.colors.primary: "purple"` in app.config.ts — the scale name
+ * below (`--color-purple`) must match that string for Nuxt UI to resolve
+ * component variants onto this scale.
+ */
+@theme static {
+	--color-purple: hsl(263, 90%, 60%);
+	--color-purple-50: hsl(from var(--color-purple) h s 5%);
+	--color-purple-100: hsl(from var(--color-purple) h s 10%);
+	--color-purple-200: hsl(from var(--color-purple) h s 20%);
+	--color-purple-300: hsl(from var(--color-purple) h s 30%);
+	--color-purple-400: hsl(from var(--color-purple) h s 40%);
+	--color-purple-500: hsl(from var(--color-purple) h s 60%);
+	--color-purple-600: hsl(from var(--color-purple) h s 60%);
+	--color-purple-700: hsl(from var(--color-purple) h s 70%);
+	--color-purple-800: hsl(from var(--color-purple) h s 80%);
+	--color-purple-900: hsl(from var(--color-purple) h s 90%);
+	--color-purple-950: hsl(from var(--color-purple) h s 95%);
+}
+
+:root {
+	--ui-primary: var(--color-purple);
+}

--- a/apps/website/app/assets/css/main.css
+++ b/apps/website/app/assets/css/main.css
@@ -12,20 +12,20 @@
  * component variants onto this scale.
  */
 @theme static {
-	--color-purple: hsl(263, 90%, 60%);
-	--color-purple-50: hsl(from var(--color-purple) h s 5%);
-	--color-purple-100: hsl(from var(--color-purple) h s 10%);
-	--color-purple-200: hsl(from var(--color-purple) h s 20%);
-	--color-purple-300: hsl(from var(--color-purple) h s 30%);
-	--color-purple-400: hsl(from var(--color-purple) h s 40%);
-	--color-purple-500: hsl(from var(--color-purple) h s 60%);
-	--color-purple-600: hsl(from var(--color-purple) h s 60%);
-	--color-purple-700: hsl(from var(--color-purple) h s 70%);
-	--color-purple-800: hsl(from var(--color-purple) h s 80%);
-	--color-purple-900: hsl(from var(--color-purple) h s 90%);
-	--color-purple-950: hsl(from var(--color-purple) h s 95%);
+  --color-purple: hsl(263, 90%, 60%);
+  --color-purple-50: hsl(from var(--color-purple) h s 5%);
+  --color-purple-100: hsl(from var(--color-purple) h s 10%);
+  --color-purple-200: hsl(from var(--color-purple) h s 20%);
+  --color-purple-300: hsl(from var(--color-purple) h s 30%);
+  --color-purple-400: hsl(from var(--color-purple) h s 40%);
+  --color-purple-500: hsl(from var(--color-purple) h s 60%);
+  --color-purple-600: hsl(from var(--color-purple) h s 60%);
+  --color-purple-700: hsl(from var(--color-purple) h s 70%);
+  --color-purple-800: hsl(from var(--color-purple) h s 80%);
+  --color-purple-900: hsl(from var(--color-purple) h s 90%);
+  --color-purple-950: hsl(from var(--color-purple) h s 95%);
 }
 
 :root {
-	--ui-primary: var(--color-purple);
+  --ui-primary: var(--color-purple);
 }


### PR DESCRIPTION
## Summary

Defines Inkline's brand-token contract input for the `@uxfront/docs-theme` docs
package (UXF-10): the consumer-local purple palette + `ui.colors` mapping that
themes the shared theme without touching it. The package stays palette-free;
all brand values live here in `apps/website`.

## Changes

- `apps/website/app/assets/css/main.css` — imports the theme base, defines the
  `--color-purple` scale, and maps it onto Nuxt UI's `--ui-primary`. Base hue is
  derived from the committed brand mark (`public/favicon.svg`, `#863bff` =
  `hsl(263 100% 62%)`), eased to `hsl(263 90% 60%)` for comfortable UI legibility
  across the full scale (5.3:1 on white, WCAG AA).
- `apps/website/app/app.config.ts` — brand identity fields (`seo`, `header`,
  `github`, `footer`) plus `ui.colors` (`primary: "purple"`, `neutral: "slate"`).
- No changeset: `website` is a private, ignore-listed package (never published).

## Verification

The files sit at their target Nuxt paths but are inert on the current Vite app —
`tsconfig.json` includes only `src`, and nothing under `src/` imports them, so
the `build-website` CI job (`tsc && vp build`) does not pick them up. Confirmed:

```
$ grep '"include"' apps/website/tsconfig.json
  "include": ["src"]
$ grep -rn "app/app.config\|app/assets" apps/website/src
(no matches)
```

They become live when `apps/website` is converted to Nuxt + Nuxt Content, at
which point `nuxt.config.ts` registers the CSS via `css: ["./app/assets/css/main.css"]`.

## Notes

- Scoped to the brand-token contract only — layer wiring, content tree, and
  `nitro prerender` validation are the separate docs stand-up (UXF-9).
- `header.logo` and `socials` are intentionally omitted: no header wordmark or
  verified social handles exist in the live tree (the `.old/` tree is
  reference-only per its `AGENTS.md`). Text-title fallback renders meanwhile.
- Cross-brand note for design review: this purple (hue 263) sits close to the
  sibling uxfront brand (violet, hue 255). Inkline's color is taken faithfully
  from its committed mark rather than shifted; whether to differentiate is a
  deliberate design call, reversible via one CSS variable.
