### PR TITLE
fix(components): keep the read-only checkbox from toggling

### DIFF
--- a/.changeset/fix-readonly-checkbox-toggle.md
+++ b/.changeset/fix-readonly-checkbox-toggle.md
@@ -1,0 +1,19 @@
+---
+"@inkline/react": patch
+"@inkline/vue": patch
+"@inkline/svelte": patch
+"@inkline/solid": patch
+"@inkline/angular": patch
+"@inkline/qwik": patch
+"@inkline/astro": patch
+---
+
+fix(components): keep the read-only checkbox from toggling
+
+A read-only checkbox stayed focusable but must not change value. The click guard
+(`readonly && preventDefault()`) cancels the toggle synchronously on React, Vue, Solid, Svelte and
+Angular. On Qwik, event handlers are QRLs that resume _after_ the browser's default action, so
+`preventDefault()` there cannot stop the toggle. The `change` handler now re-asserts the control from
+the model when read-only (`el.checked = checked()`) instead of writing to it, snapping the box back
+and leaving the model untouched. The handler is a single expression so Angular's template codegen
+inlines it. Read-only is unchanged elsewhere and stays announced via `aria-readonly`.

--- a/ui/components/src/components/checkbox/headless/ICheckboxControlBase.ink.test.ts
+++ b/ui/components/src/components/checkbox/headless/ICheckboxControlBase.ink.test.ts
@@ -87,6 +87,27 @@ describe("CheckboxControl", () => {
     expectOutputContains(result.files.angular ?? [], "readonly() && $event.preventDefault()");
   });
 
+  it("re-asserts the checked state on change when read-only so Qwik cannot toggle it", async () => {
+    // The click guard is a no-op on Qwik, whose event handlers are QRLs that resume *after* the
+    // browser's default action, so `preventDefault()` there cannot stop the toggle. The change
+    // handler therefore restores the control from the model (`el.checked = checked()`) instead of
+    // writing to it when read-only — snapping the box back and leaving the model untouched. It is a
+    // single expression so Angular's template codegen can inline it.
+    const result = await compileComponent(CHECKBOX_CONTROL);
+    expectOutputContains(
+      result.files.react ?? [],
+      "props.readonly ? (e.currentTarget.checked = props.checked ?? false)",
+    );
+    expectOutputContains(
+      result.files.qwik ?? [],
+      "props.readonly ? (e.currentTarget.checked = props.checked ?? false)",
+    );
+    expectOutputContains(
+      result.files.angular ?? [],
+      "readonly() ? ($event.currentTarget.checked = checked() ?? false)",
+    );
+  });
+
   it("output matches snapshots", async () => {
     const result = await compileComponent(CHECKBOX_CONTROL);
     expect(snapshotOutput(result)).toMatchSnapshot();

--- a/ui/components/src/components/checkbox/headless/ICheckboxControlBase.ink.tsx
+++ b/ui/components/src/components/checkbox/headless/ICheckboxControlBase.ink.tsx
@@ -29,12 +29,17 @@ export interface CheckboxControlBaseProps {
 //     Angular, where the compiler unwraps the element ref to `.nativeElement`.
 //
 // `readonly` has no native effect on a checkbox (the HTML `readonly` attribute is ignored for the
-// checkbox type), so read-only is expressed with `aria-readonly` and enforced by cancelling the click
-// default — which stops both the toggle and the `change` that would follow. The guard is written as a
-// single expression (`props.readonly && e.preventDefault()`) so Angular's template codegen can inline
-// it; a block body collapses to an empty `(click)=""` there. Correct on all seven targets: React's
-// host-only attribute canonicalisation (INK-26 / #515) forwards the `readonly` prop verbatim across
-// the styled→headless boundary, so the value reaches this control everywhere.
+// checkbox type), so read-only is expressed with `aria-readonly` and enforced in two layers:
+//   1. Cancel the click default (`props.readonly && e.preventDefault()`) — synchronous on React, Vue,
+//      Solid, Svelte and Angular, so the toggle (and the `change` that would follow) never happens.
+//   2. On `change`, when read-only, restore the control's checked state from the model instead of
+//      writing to it. Qwik's event handlers are QRLs that resume and run *after* the browser's default
+//      action, so `preventDefault()` there is a no-op and the box does toggle; the change handler still
+//      fires, so re-asserting `el.checked = checked()` snaps it back and the model is never mutated.
+// Both handlers are single expressions so Angular's template codegen can inline them (a block body
+// collapses to an empty binding there). Correct on all seven targets: React's host-only attribute
+// canonicalisation (INK-26 / #515) forwards the `readonly` prop verbatim across the styled→headless
+// boundary, so the value reaches this control everywhere.
 export default defineComponent({ meta: { headless: true } }, (props: CheckboxControlBaseProps) => {
   const [checked, setChecked] = defineModel<boolean>("checked");
   const controlRef = createRef<HTMLInputElement>();
@@ -59,7 +64,11 @@ export default defineComponent({ meta: { headless: true } }, (props: CheckboxCon
       required={props.required}
       aria-readonly={props.readonly ? "true" : undefined}
       onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()}
-      onChange={(e: { currentTarget: HTMLInputElement }) => setChecked(e.currentTarget.checked)}
+      onChange={(e: { currentTarget: HTMLInputElement }) =>
+        props.readonly
+          ? (e.currentTarget.checked = checked() ?? false)
+          : setChecked(e.currentTarget.checked)
+      }
     />
   );
 });

--- a/ui/components/src/components/checkbox/headless/__snapshots__/ICheckboxControlBase.ink.test.ts.snap
+++ b/ui/components/src/components/checkbox/headless/__snapshots__/ICheckboxControlBase.ink.test.ts.snap
@@ -17,7 +17,7 @@ export interface CheckboxControlBaseProps {
   /** Renders the partially-checked ("mixed") state. */
   indeterminate?: boolean;
 }
-@Component({ standalone: true, selector: 'ink-checkbox-control-base', host: { style: 'display: contents' }, template: \`<input [class]="'checkbox-field' + (klass() ? ' ' + klass() : '')" type="checkbox" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [checked]="checked() ?? false" [indeterminate]="indeterminate() ?? false" [disabled]="disabled()" [required]="required()" [attr.aria-readonly]="(readonly() ? 'true' : undefined) ?? null" (click)="readonly() && $event.preventDefault()" (change)="checked.set($event.currentTarget.checked)" #controlRef />\` })
+@Component({ standalone: true, selector: 'ink-checkbox-control-base', host: { style: 'display: contents' }, template: \`<input [class]="'checkbox-field' + (klass() ? ' ' + klass() : '')" type="checkbox" [attr.id]="(id()) ?? null" [attr.name]="(name()) ?? null" [checked]="checked() ?? false" [indeterminate]="indeterminate() ?? false" [disabled]="disabled()" [required]="required()" [attr.aria-readonly]="(readonly() ? 'true' : undefined) ?? null" (click)="readonly() && $event.preventDefault()" (change)="readonly() ? ($event.currentTarget.checked = checked() ?? false) : checked.set($event.currentTarget.checked)" #controlRef />\` })
 export class ICheckboxControlBaseComponent
 {
 klass = input<string>()
@@ -31,7 +31,7 @@ readonly = input<boolean>()
 indeterminate = input<boolean>()
 checked = model<boolean>()
 }
-@Component({ standalone: true, selector: 'input[ink-checkbox-control-base]', host: { '[class]': "'checkbox-field' + (klass() ? ' ' + klass() : '')", 'type': 'checkbox', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[checked]': "checked() ?? false", '[indeterminate]': "indeterminate() ?? false", '[disabled]': "disabled()", '[required]': "required()", '[attr.aria-readonly]': "(readonly() ? 'true' : undefined) ?? null", '(click)': "readonly() && $event.preventDefault()", '(change)': "checked.set($event.currentTarget.checked)" }, template: \`\` })
+@Component({ standalone: true, selector: 'input[ink-checkbox-control-base]', host: { '[class]': "'checkbox-field' + (klass() ? ' ' + klass() : '')", 'type': 'checkbox', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[checked]': "checked() ?? false", '[indeterminate]': "indeterminate() ?? false", '[disabled]': "disabled()", '[required]': "required()", '[attr.aria-readonly]': "(readonly() ? 'true' : undefined) ?? null", '(click)': "readonly() && $event.preventDefault()", '(change)': "readonly() ? ($event.currentTarget.checked = checked() ?? false) : checked.set($event.currentTarget.checked)" }, template: \`\` })
 export class ICheckboxControlBaseHostComponent
 {
 klass = input<string>()
@@ -66,7 +66,7 @@ const props = Astro.props as Props;
 const { id, name, disabled, required, readonly, indeterminate, ...__attrs } = props;
 let checked = props.checked
 ---
-<input {...__attrs} class={["checkbox-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" id={id} name={name} checked={checked ?? false} indeterminate={indeterminate ?? false} disabled={disabled} required={required} aria-readonly={readonly ? "true" : undefined} onClick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onChange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} />
+<input {...__attrs} class={["checkbox-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" id={id} name={name} checked={checked ?? false} indeterminate={indeterminate ?? false} disabled={disabled} required={required} aria-readonly={readonly ? "true" : undefined} onClick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onChange={(e: { currentTarget: HTMLInputElement }) => readonly ? (e.currentTarget.checked = checked ?? false) : checked = e.currentTarget.checked} />
 ",
   "qwik/ICheckboxControlBase.tsx": "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
 export interface CheckboxControlBaseProps {
@@ -89,7 +89,7 @@ const controlRef = useSignal(null)
 useVisibleTask$(() => { const el = controlRef.value; if (el) { el.indeterminate = props.indeterminate ?? false; } })
 const { id, name, disabled, required, readonly, indeterminate, checked, onUpdateChecked$, ...__attrs } = props
 return (
-<input {...__attrs} class={["checkbox-field", props.class].filter(Boolean).join(" ")} type="checkbox" id={props.id} name={props.name} checked={props.checked ?? false} indeterminate={props.indeterminate ?? false} disabled={props.disabled} required={props.required} aria-readonly={props.readonly ? "true" : undefined} onClick={$((e: { preventDefault: () => void }) => props.readonly && e.preventDefault())} onChange={$((e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked$?.(e.currentTarget.checked))} ref={controlRef} />
+<input {...__attrs} class={["checkbox-field", props.class].filter(Boolean).join(" ")} type="checkbox" id={props.id} name={props.name} checked={props.checked ?? false} indeterminate={props.indeterminate ?? false} disabled={props.disabled} required={props.required} aria-readonly={props.readonly ? "true" : undefined} onClick={$((e: { preventDefault: () => void }) => props.readonly && e.preventDefault())} onChange={$((e: { currentTarget: HTMLInputElement }) => props.readonly ? (e.currentTarget.checked = props.checked ?? false) : props.onUpdateChecked$?.(e.currentTarget.checked))} ref={controlRef} />
 )
 });
 ",
@@ -114,7 +114,7 @@ const controlRef = useRef(null)
 useEffect(() => { const el = controlRef.current; if (el) { el.indeterminate = props.indeterminate ?? false; } }, [controlRef.current, props.indeterminate])
 const { id, name, disabled, required, readonly, indeterminate, checked, onUpdateChecked, ...__attrs } = props
 return (
-<input {...__attrs} className={["checkbox-field", props.className].filter(Boolean).join(" ")} type="checkbox" id={props.id} name={props.name} checked={props.checked ?? false} indeterminate={props.indeterminate ?? false} disabled={props.disabled} required={props.required} aria-readonly={props.readonly ? "true" : undefined} onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onChange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} ref={controlRef} />
+<input {...__attrs} className={["checkbox-field", props.className].filter(Boolean).join(" ")} type="checkbox" id={props.id} name={props.name} checked={props.checked ?? false} indeterminate={props.indeterminate ?? false} disabled={props.disabled} required={props.required} aria-readonly={props.readonly ? "true" : undefined} onClick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onChange={(e: { currentTarget: HTMLInputElement }) => props.readonly ? (e.currentTarget.checked = props.checked ?? false) : props.onUpdateChecked?.(e.currentTarget.checked)} ref={controlRef} />
 )
 }
 ",
@@ -140,7 +140,7 @@ createEffect(() => { const el = controlRef; if (el) { el.indeterminate = props.i
 let controlRef: HTMLElement | undefined
 const [, __attrs] = splitProps(props, ["id", "name", "disabled", "required", "readonly", "indeterminate", "checked", "onUpdateChecked"])
 return (
-<input {...__attrs} class={["checkbox-field", props.class].filter(Boolean).join(" ")} type="checkbox" id={props.id} name={props.name} checked={props.checked ?? false} indeterminate={props.indeterminate ?? false} disabled={props.disabled} required={props.required} aria-readonly={props.readonly ? "true" : undefined} onclick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onchange={(e: { currentTarget: HTMLInputElement }) => props.onUpdateChecked?.(e.currentTarget.checked)} ref={(el) => controlRef = el} />
+<input {...__attrs} class={["checkbox-field", props.class].filter(Boolean).join(" ")} type="checkbox" id={props.id} name={props.name} checked={props.checked ?? false} indeterminate={props.indeterminate ?? false} disabled={props.disabled} required={props.required} aria-readonly={props.readonly ? "true" : undefined} onclick={(e: { preventDefault: () => void }) => props.readonly && e.preventDefault()} onchange={(e: { currentTarget: HTMLInputElement }) => props.readonly ? (e.currentTarget.checked = props.checked ?? false) : props.onUpdateChecked?.(e.currentTarget.checked)} ref={(el) => controlRef = el} />
 )
 }
 ",
@@ -163,7 +163,7 @@ return (
   $effect(() => { const el = controlRef; if (el) { el.indeterminate = indeterminate ?? false; } })
   let controlRef = $state<HTMLElement | null>(null)
 </script>
-<input bind:this={controlRef} {...__attrs} class={["checkbox-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" id={id} name={name} checked={checked ?? false} indeterminate={indeterminate ?? false} disabled={disabled} required={required} aria-readonly={readonly ? "true" : undefined} onclick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onchange={(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked} />
+<input bind:this={controlRef} {...__attrs} class={["checkbox-field", __attrs.class].filter(Boolean).join(" ")} type="checkbox" id={id} name={name} checked={checked ?? false} indeterminate={indeterminate ?? false} disabled={disabled} required={required} aria-readonly={readonly ? "true" : undefined} onclick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onchange={(e: { currentTarget: HTMLInputElement }) => readonly ? (e.currentTarget.checked = checked ?? false) : checked = e.currentTarget.checked} />
 ",
   "vue/ICheckboxControlBase.vue": "<script setup lang="ts">
   import { ref, watchEffect } from "vue";
@@ -187,7 +187,7 @@ return (
   watchEffect(() => { const el = controlRef.value; if (el) { el.indeterminate = props.indeterminate ?? false; } })
 </script>
 <template>
-<input class="checkbox-field" type="checkbox" :id="id" :name="name" :checked="checked ?? false" :indeterminate="indeterminate ?? false" :disabled="disabled" :required="required" :aria-readonly='readonly ? "true" : undefined' @click="(e: { preventDefault: () => void }) => readonly && e.preventDefault()" @change="(e: { currentTarget: HTMLInputElement }) => checked = e.currentTarget.checked" ref="controlRef" />
+<input class="checkbox-field" type="checkbox" :id="id" :name="name" :checked="checked ?? false" :indeterminate="indeterminate ?? false" :disabled="disabled" :required="required" :aria-readonly='readonly ? "true" : undefined' @click="(e: { preventDefault: () => void }) => readonly && e.preventDefault()" @change="(e: { currentTarget: HTMLInputElement }) => readonly ? (e.currentTarget.checked = checked ?? false) : checked = e.currentTarget.checked" ref="controlRef" />
 </template>
 ",
 }


### PR DESCRIPTION
## What

Read-only checkboxes stayed focusable but must not change value. This gates the toggle on `readonly` across all seven compiled targets.

- **React / Vue / Solid / Svelte / Angular** — the existing click guard (`readonly && preventDefault()`) already cancels the toggle synchronously; unchanged.
- **Qwik** — its event handlers are QRLs that resume *after* the browser's default action, so `preventDefault()` there is a no-op and the box toggles. The `change` handler now re-asserts the control from the model when read-only (`el.checked = checked()`) instead of writing to it, snapping the box back and leaving the model untouched.

The change handler is a single expression so Angular's template codegen inlines it. Read-only stays announced via `aria-readonly`; no other target's behaviour changes.

## Why

Follow-up to #499: the read-only checkbox story was still interactable. Root cause was the Qwik async-QRL `preventDefault` no-op — the other six targets already enforced read-only correctly.

## Proof

- **Codegen regression test** (`ICheckboxControlBase.ink.test.ts`) asserts the restore expression is emitted for react/qwik/angular — fails before the fix, passes after. Snapshot updated for all seven targets. `vp test ICheckboxControlBase` → 11 passed.
- **Browser-verified** via Playwright: read-only checkbox rejects click and Space on React, Vue, Solid, Svelte and Angular.

### Note for reviewers

Qwik's event handlers could not be exercised in the Storybook dev harness — the `$()` QRL serialises to an invalid inline `onchange` attribute (`Function statements require a function name`), so **no** Qwik handler runs there (this predates and is independent of this change; it affects the original click guard too). The fix is correct per Qwik's documented async-QRL semantics and is validated at the codegen layer; the harness handler-execution gap is a separate follow-up.

Closes INK-6.
