### PR TITLE
refactor(website): re-point docs onto renamed @uxfront/layer-docs

### DIFF
--- a/apps/website/AGENTS.md
+++ b/apps/website/AGENTS.md
@@ -2,13 +2,13 @@
 
 The documentation and marketing site for Inkline. Private (`"private": true` in [`package.json`](./package.json)) — never published to npm. Deployed as a static site (deploy target out of scope here).
 
-A Nuxt 4 + Nuxt Content app that **extends** the published [`@uxfront/docs-theme`](https://www.npmjs.com/package/@uxfront/docs-theme) layer. The theme supplies the shell (layout, left-nav, TOC, search, dark mode, mobile menu, i18n, content components); this app supplies only Inkline's brand, its section topology, and its markdown.
+A Nuxt 4 + Nuxt Content app that **extends** the published [`@uxfront/layer-docs`](https://www.npmjs.com/package/@uxfront/layer-docs) layer. The theme supplies the shell (layout, left-nav, TOC, search, dark mode, mobile menu, i18n, content components); this app supplies only Inkline's brand, its section topology, and its markdown.
 
 ## Layout
 
 ```
 apps/website/
-├── nuxt.config.ts          # extends ["@uxfront/docs-theme"], css, site, llms, routeRules
+├── nuxt.config.ts          # extends ["@uxfront/layer-docs"], css, site, llms, routeRules
 ├── content.config.ts       # defineDocsCollections([...DOCS_SECTIONS])
 ├── tsconfig.json           # Nuxt project references
 ├── app/
@@ -68,7 +68,7 @@ The acceptance gate for this app is a clean `nitro prerender`: `nuxt generate` m
 ## Conventions
 
 - `typescript` is pinned to `catalog:ts6` here: `@vue/compiler-sfc` breaks under the default TS7 catalog, so the docs app holds back to TS6.
-- `@uxfront/docs-theme` is listed in the root `pnpm-workspace.yaml` `minimumReleaseAgeExclude` — the package was published recently and would otherwise trip pnpm's 24h supply-chain guard on install.
+- `@uxfront/layer-docs` is covered by the `@uxfront/*` glob in the root `pnpm-workspace.yaml` `minimumReleaseAgeExclude` — the package was published recently and would otherwise trip pnpm's 24h supply-chain guard on install.
 - Content lives under `content/docs/<NN.section>/<NN.page>.md`; the numeric prefixes drive order and are stripped from the route. Sections must match `DOCS_SECTIONS` in `app/constants/sections.ts`.
 - Only document real, shipped components. The Button page mirrors `ui/components`'s `IButton` stories (story ids under `Components/Actions/Button`).
 
@@ -79,4 +79,4 @@ The acceptance gate for this app is a clean `nitro prerender`: `nuxt generate` m
 ## See also
 
 - [docs/contributing.md](../../docs/contributing.md) — repo-wide dev loops.
-- [`@uxfront/docs-theme`](https://www.npmjs.com/package/@uxfront/docs-theme) — the extended docs layer.
+- [`@uxfront/layer-docs`](https://www.npmjs.com/package/@uxfront/layer-docs) — the extended docs layer.

--- a/apps/website/app/app.config.ts
+++ b/apps/website/app/app.config.ts
@@ -1,6 +1,6 @@
 export default defineAppConfig({
   /**
-   * Inkline branding for the docs site. The @uxfront/docs-theme layer ships
+   * Inkline branding for the docs site. The @uxfront/layer-docs layer ships
    * neutral defaults; these values are merged over them by Nuxt's `defu` layer
    * merge (consumer wins). `modules/config.ts` also fills `seo`/`header`/`github`
    * from the consumer's `package.json` + git as fallbacks.

--- a/apps/website/app/assets/css/main.css
+++ b/apps/website/app/assets/css/main.css
@@ -1,7 +1,7 @@
-@import "@uxfront/docs-theme/app/assets/css/main.css";
+@import "@uxfront/layer-docs/app/assets/css/main.css";
 
 /*
- * Inkline brand palette. The docs-theme package ships neutral (palette-free);
+ * Inkline brand palette. The layer-docs package ships neutral (palette-free);
  * this consumer supplies the purple scale and maps it onto Nuxt UI's
  * --ui-primary. The base hue is derived from the committed brand mark
  * (public/favicon.svg, #863bff), with saturation and lightness eased for

--- a/apps/website/app/constants/sections.ts
+++ b/apps/website/app/constants/sections.ts
@@ -1,8 +1,8 @@
-import type { DocsSectionDescriptor } from "@uxfront/docs-theme/content";
+import type { DocsSectionDescriptor } from "@uxfront/layer-docs/content";
 
 /**
  * Documentation section topology for the Inkline docs site. This descriptor is
- * the single source of truth the `@uxfront/docs-theme` layer reads (via global
+ * the single source of truth the `@uxfront/layer-docs` layer reads (via global
  * auto-import — see `imports.dirs` in nuxt.config) to build the content
  * collections, the nav tree and the sub-header. Add a section here + a matching
  * `content/docs/<folder>/` subtree and it appears everywhere automatically.

--- a/apps/website/content.config.ts
+++ b/apps/website/content.config.ts
@@ -1,4 +1,4 @@
-import { defineDocsCollections } from "@uxfront/docs-theme/content";
+import { defineDocsCollections } from "@uxfront/layer-docs/content";
 import { DOCS_SECTIONS } from "./app/constants/sections.js";
 
 // One-liner content config: the section topology lives in app/constants and the

--- a/apps/website/content/index.md
+++ b/apps/website/content/index.md
@@ -13,7 +13,7 @@ source using a signal-based reactivity model, and the Inkline compiler emits
 idiomatic **React, Vue 3, Svelte 5, Solid, Angular, Qwik, and Astro** output —
 with no runtime dependency on Inkline in the generated components.
 
-This site is built on the `@uxfront/docs-theme` Nuxt layer; Inkline supplies
+This site is built on the `@uxfront/layer-docs` Nuxt layer; Inkline supplies
 only its branding, section topology and content.
 
 ## ::u-button

--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -1,13 +1,13 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   // Consume the published, cross-repo docs theme. inkline is a separate repo,
-  // so this resolves from the npm registry (@uxfront/docs-theme@^0.1.0), not a
+  // so this resolves from the npm registry (@uxfront/layer-docs@^0.1.0), not a
   // workspace link. Branding, section topology and content stay local (below).
-  extends: ["@uxfront/docs-theme"],
+  extends: ["@uxfront/layer-docs"],
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },
   // Local brand palette + --ui-primary map. Imports the palette-free package
-  // base; keeps @uxfront/docs-theme brand-free (the UXF-6/UXF-10 boundary).
+  // base; keeps @uxfront/layer-docs brand-free (the UXF-6/UXF-10 boundary).
   css: ["./app/assets/css/main.css"],
   // Auto-import DOCS_SECTIONS / findDocsSectionBySlug from app/constants/ so the
   // theme layer can reference them as globals (overrides the layer's empty

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -18,7 +18,7 @@
     "@nuxt/ui": "^4.8.2",
     "@nuxtjs/robots": "^6.1.1",
     "@nuxtjs/sitemap": "^8.2.1",
-    "@uxfront/docs-theme": "catalog:",
+    "@uxfront/layer-docs": "catalog:",
     "better-sqlite3": "^12.10.1",
     "nuxt": "^4.4.8",
     "nuxt-llms": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,9 @@ catalogs:
     '@typescript-eslint/parser':
       specifier: ^8.61.0
       version: 8.61.0
-    '@uxfront/docs-theme':
-      specifier: ^0.1.1
-      version: 0.1.1
+    '@uxfront/layer-docs':
+      specifier: ^0.1.0
+      version: 0.1.0
     '@vitejs/plugin-react':
       specifier: ^6.0.2
       version: 6.0.2
@@ -271,9 +271,9 @@ importers:
       '@nuxtjs/sitemap':
         specifier: ^8.2.1
         version: 8.2.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.8(2c0e20ee74a4760945f21ada5dbe6054))(vite@8.0.10(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(@typescript/typescript6@6.0.2))(zod@3.25.76)
-      '@uxfront/docs-theme':
+      '@uxfront/layer-docs':
         specifier: 'catalog:'
-        version: 0.1.1(0537599299aaaf779500bd5c0cedd1c4)
+        version: 0.1.0(0537599299aaaf779500bd5c0cedd1c4)
       better-sqlite3:
         specifier: ^12.10.1
         version: 12.11.1
@@ -7177,8 +7177,8 @@ packages:
     peerDependencies:
       vue: '>=3.5.18'
 
-  '@uxfront/docs-theme@0.1.1':
-    resolution: {integrity: sha512-NnQmsIo2jROfQAdJAPqnv/YUDXL6Zd0pagFe5rM1nLZ5Y8pg1xreQRLuZyAeqZe3Lbo1rCLTkOXPbarRrqpbUA==}
+  '@uxfront/layer-docs@0.1.0':
+    resolution: {integrity: sha512-UTWvToIFLPqmwmnAZoiXET2+om6EFHi9FpsIt20z5XLNZ1BlLMeO/hT0VyFGhN8hXJoG3rX3G/w/2B0zZlY0zQ==}
     peerDependencies:
       '@nuxt/content': ^3.14.0
       '@nuxt/image': ^1.11.0
@@ -21588,7 +21588,7 @@ snapshots:
       unhead: 2.1.15
       vue: 3.5.38(@typescript/typescript6@6.0.2)
 
-  '@uxfront/docs-theme@0.1.1(0537599299aaaf779500bd5c0cedd1c4)':
+  '@uxfront/layer-docs@0.1.0(0537599299aaaf779500bd5c0cedd1c4)':
     dependencies:
       '@nuxt/content': 3.15.0(@farmfe/core@1.7.11(@types/node@26.1.1))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(better-sqlite3@12.11.1)(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.0.0-rc.17)(rollup@4.62.0)(valibot@1.4.1(@typescript/typescript6@6.0.2))(vite@8.0.10(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       '@nuxt/image': 1.11.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
   - tools/*
 allowBuilds:
   "@parcel/watcher": true
-  "@uxfront/docs-theme": false
+  "@uxfront/layer-docs": false
   better-sqlite3: true
   core-js: true
   esbuild: true
@@ -18,7 +18,7 @@ allowBuilds:
 
 # pnpm 11 enforces a default minimumReleaseAge (24h) supply-chain guard.
 # Exclude the styleframe first-party ecosystem (intentionally fresh, trusted),
-# the uxfront docs-theme layer the website extends (freshly published,
+# the uxfront layer-docs layer the website extends (freshly published,
 # first-party), and pin the exact versions of unrelated transitive deps caught
 # as collateral so the guard still applies to any future releases of those.
 minimumReleaseAgeExclude:
@@ -65,7 +65,7 @@ catalog:
   "@types/react": ^19.2.17
   "@types/react-dom": ^19.2.3
   "@typescript-eslint/parser": ^8.61.0
-  "@uxfront/docs-theme": ^0.1.1
+  "@uxfront/layer-docs": ^0.1.0
   "@vitejs/plugin-react": ^6.0.2
   "@vitejs/plugin-vue": ^6.0.7
   "@vitest/coverage-v8": ^4.1.8


### PR DESCRIPTION
## What
Re-points inkline `apps/website` off the stale `@uxfront/docs-theme` name onto the current published `@uxfront/layer-docs@0.1.0`, so all three docs consumers (uxfront, inkline, styleframe) sit on one package name and a consistent version.

## Why
The shared docs layer was renamed mid-flight from `@uxfront/docs-theme` → `@uxfront/layer-docs`. uxfront and styleframe (reference consumer, PR #327) already moved; inkline was the last consumer on the stale name. The old catalog pin `^0.1.1` was also unresolvable — only `0.1.0` is published.

## Changes
- `apps/website/package.json` — dependency `@uxfront/docs-theme` → `@uxfront/layer-docs`.
- `nuxt.config.ts` — `extends: ["@uxfront/layer-docs"]`.
- `content.config.ts`, `app/constants/sections.ts` — `@uxfront/layer-docs/content` subpath imports.
- `app/assets/css/main.css` — `@uxfront/layer-docs/app/assets/css/main.css` import.
- `pnpm-workspace.yaml` — catalog pin `@uxfront/docs-theme: ^0.1.1` → `@uxfront/layer-docs: ^0.1.0`; `allowBuilds` + comment updated.
- Docs/comments (`AGENTS.md`, `content/index.md`) and lockfile updated.
- Local Inkline branding (`app.config.ts` seo/header/palette) and the `docsTheme` app-config key (the layer's own namespace, not the package name) are unchanged.

No residual `@uxfront/docs-theme` references remain (grep-verified across source + lockfile).

## Proof
`pnpm --filter website generate` prerenders **24 routes clean, no errors**. Verified in the generated output:
- Nav sections (Getting Started / Guide / Components), TOC, search, and dark-mode toggle all render.
- Multi-framework Button page (`/docs/components/button`) renders the generalized switcher with all 7 framework tabs (React, Vue, Svelte, Solid, Angular, Qwik, Astro) and per-tab Storybook `<iframe>` embeds.
- Inkline branding (purple `--ui-primary` scale, title) sourced from local config only.

Closes UXF-37.
