### PR TITLE
docs(qwik): record codegen-only verification boundary for Qwik interactive behaviour (INK-31)

### DIFF
--- a/apps/storybook/AGENTS.md
+++ b/apps/storybook/AGENTS.md
@@ -94,6 +94,36 @@ compose other components and pull classes from a `virtual:styleframe` recipe) co
   Qwik 2.0-beta resumes an empty container. This is an upstream Storybook↔Qwik integration
   issue, not a codegen problem.
 
+### Qwik interactive-behaviour verification boundary (INK-31)
+
+The empty-container resume failure above has a second consequence: **Qwik event handlers do
+not run in any of our harnesses.** An emitted `$()` handler that closes over local scope
+(e.g. a control's `checked()` / `setChecked` / `props`) must be extracted by the Qwik
+optimizer into a lazy-loadable chunk and wired up on resume — Qwik forbids inlining a QRL
+whose captured values are not importable, `const`, and serialisable, so `sync$` is not an
+option for these handlers. When resume fails, the handler QRL is never bound to a served
+chunk and Qwik falls back to writing the raw closure into an inline `onchange` attribute,
+which an anonymous scope-capturing arrow cannot legally be — the parser rejects it with
+`Function statements require a function name`, and no handler fires.
+
+Neither runtime harness closes this gap today:
+
+- **Unit SSR mount** ([`tooling/test-utils/src/mount.ts`](../../tooling/test-utils/src/mount.ts))
+  deliberately omits Qwik from its mountable targets — there is no stable Qwik-SSR-in-Node
+  path.
+- **Visual-parity e2e** ([`testing/e2e`](../../testing/e2e/AGENTS.md)) hits the same port-6011
+  canary and only _tolerates_ the broken resume (`storybook.ts` `waitForStoryReady` waits for
+  `q:container="resumed"`, then captures whatever is there). It is also the wrong oracle for
+  behaviour: it pixel-diffs against React, and a correct read-only _reject_ produces zero
+  visual delta — indistinguishable from "no handler ran." Only an observable _toggle_ would
+  register, and only if resume fired.
+
+**Standing boundary: Qwik interactive behaviour is verified at the codegen layer only —
+codegen assertions plus documented QRL semantics — until upstream Storybook↔Qwik resume
+lands.** Closing it requires a _behaviour_-asserting e2e (role locator +
+`await expect(checkbox).toBeChecked()` after a click, not a screenshot), which still gates on
+that same upstream fix. The other six targets are runtime-verified via the SSR mount harness.
+
 Angular styled rendering was fixed by the Angular-target redesign — kebab-case `ink-*`
 selectors, a `klass` input that merges a forwarded class onto each component's own root, and
 full `imports` declaration. Styled components are verified by `@angular/platform-server` SSR

--- a/tooling/test-utils/src/mount.ts
+++ b/tooling/test-utils/src/mount.ts
@@ -9,6 +9,9 @@ export interface MountResult {
   readonly warnings: readonly string[];
 }
 
+// Qwik is intentionally absent: there is no stable Qwik-SSR-in-Node path, so its interactive
+// behaviour ($() QRL handlers) is verified at the codegen layer only. See INK-31 and
+// apps/storybook/AGENTS.md → "Qwik interactive-behaviour verification boundary".
 const MOUNTABLE_TARGETS: ReadonlySet<TargetName> = new Set([
   "react",
   "vue",

--- a/ui/qwik/AGENTS.md
+++ b/ui/qwik/AGENTS.md
@@ -29,6 +29,10 @@ Peer dep: `@qwik.dev/core >= 2.0.0-beta.0`.
 
 Runs on **port 6011**. `pnpm storybook` here or `pnpm run storybook:qwik` from the repo root. Uses [`storybook-framework-qwik`](https://www.npmjs.com/package/storybook-framework-qwik) (a canary build pinned via the catalog in [`pnpm-workspace.yaml`](../../pnpm-workspace.yaml)).
 
+## Interactive-behaviour verification boundary
+
+Qwik event handlers (`$()` QRLs) do not run in any of our harnesses while the upstream `storybook-framework-qwik` resume is broken — so Qwik interactive behaviour is verified at the **codegen layer only** (codegen assertions + documented QRL semantics). See [`apps/storybook/AGENTS.md`](../../apps/storybook/AGENTS.md) → "Qwik interactive-behaviour verification boundary (INK-31)" for the root cause and what would close it.
+
 ## Build
 
 `vp build`. Output goes to `dist/` (`index.qwik.mjs`, `headless.qwik.mjs`, `stories.qwik.mjs`).


### PR DESCRIPTION
## Summary

Records the **codegen-only verification boundary for Qwik interactive behaviour** (INK-31). This is a docs decision — accept + document — not a code fix.

Root cause: an emitted `$()` event-handler QRL that closes over local scope (a control's `checked()` / `setChecked` / `props`) must be extracted by the Qwik optimizer into a lazy chunk and wired up on resume — Qwik forbids inlining a QRL whose captured values are not importable, `const`, and serialisable, so `sync$` is not an option. While the upstream `storybook-framework-qwik` (canary, Qwik 2.0-beta) resume is broken, the handler is never bound to a served chunk; Qwik falls back to writing the raw closure into an inline `onchange` attribute, which an anonymous scope-capturing arrow cannot legally be, and the parser rejects it with `Function statements require a function name`. No handler fires. The emitted codegen is correct Qwik authoring.

Neither runtime harness closes the gap: the unit SSR mount deliberately omits Qwik, and the visual-parity e2e both inherits the same broken resume and is the wrong oracle — a correct read-only *reject* produces zero visual delta, indistinguishable from "no handler ran." Closing it needs a *behaviour*-asserting e2e (role locator + `await expect(checkbox).toBeChecked()` after a click), which still gates on the same upstream fix.

## Changes

- `apps/storybook/AGENTS.md` — extend the existing Qwik "Known rendering limitations" note with the event-handler manifestation and the standing boundary statement (canonical home).
- `ui/qwik/AGENTS.md` — add a short "Interactive-behaviour verification boundary" section pointing to the canonical note.
- `tooling/test-utils/src/mount.ts` — comment explaining why Qwik is absent from `MOUNTABLE_TARGETS`.

## Verification

- Docs-only + one code comment; no behaviour change.
- Root cause grounded in source (`core/compiler/src/codegen/targets/qwik/index.ts` handler emission; `tooling/test-utils/src/mount.ts` Qwik exclusion; `testing/e2e/storybook.ts` `waitForStoryReady`; `testing/e2e/visual-parity.spec.ts`) and Qwik's documented inline-QRL constraints.

## Notes

- No changeset: only internal `AGENTS.md` docs and a source comment change — no published `@inkline/*` package surface is affected.
- Standing boundary: **Qwik interactive behaviour is codegen-verified only until upstream Storybook↔Qwik resume lands.** The other six targets remain runtime-verified via the SSR mount harness.
- Tracked by INK-31.
