### PR TITLE
feat(compiler): emit setup-body local handlers across all targets

### DIFF
--- a/core/compiler/src/__fixtures__/Diag_SetupLocalDrop.ink.tsx
+++ b/core/compiler/src/__fixtures__/Diag_SetupLocalDrop.ink.tsx
@@ -1,0 +1,8 @@
+import { defineComponent } from "@inkline/core";
+
+// A setup-body local whose initializer is neither an arrow nor a function expression: codegen
+// cannot emit a definition for it, yet the render references it — INK0121.
+export default defineComponent(() => {
+  const label = ["Hello", "world"].join(" ");
+  return <div>{label}</div>;
+});

--- a/core/compiler/src/__fixtures__/SetupHandlers.ink.tsx
+++ b/core/compiler/src/__fixtures__/SetupHandlers.ink.tsx
@@ -1,0 +1,39 @@
+import { createSignal, defineComponent, For } from "@inkline/core";
+
+export default defineComponent(() => {
+  const [options] = createSignal(["a", "b", "c"]);
+  const [value, setValue] = createSignal("b");
+  const [open, setOpen] = createSignal(false);
+
+  // Verbatim handler (no args): lifts as-is.
+  const onToggle = () => setOpen(!open());
+
+  // Function-declaration handler: emitted as a named function expression on every target.
+  function onReset() {
+    setValue("a");
+  }
+
+  // Parametrized handler closing over the `For` row `option`; bound as `() => onSelect(option)`.
+  const onSelect = (option: string) => {
+    setValue(option);
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button id="toggle" onClick={onToggle}>
+        {value()}
+      </button>
+      <button id="reset" onClick={onReset}>
+        Reset
+      </button>
+      <For each={options()} key={(option) => option}>
+        {(option) => (
+          <div class="option" onClick={() => onSelect(option)}>
+            {option}
+          </div>
+        )}
+      </For>
+    </div>
+  );
+});

--- a/core/compiler/src/__fixtures__/scenarios.ts
+++ b/core/compiler/src/__fixtures__/scenarios.ts
@@ -143,6 +143,9 @@ export const scenarios: Readonly<Record<string, readonly Scenario[]>> = {
   Diag_MissingKey: [{ name: "triggers INK0050", asserts: { expectedDiagnostics: ["INK0050"] } }],
   Diag_ShowNoWhen: [{ name: "triggers INK0060", asserts: { expectedDiagnostics: ["INK0060"] } }],
   Diag_ForNoEach: [{ name: "triggers INK0062", asserts: { expectedDiagnostics: ["INK0062"] } }],
+  Diag_SetupLocalDrop: [
+    { name: "triggers INK0121", asserts: { expectedDiagnostics: ["INK0121"] } },
+  ],
   Diag_ComponentRef: [{ name: "compiles without error (ref forwarding supported)", asserts: {} }],
 
   // ── v1: Component refs ──
@@ -150,6 +153,9 @@ export const scenarios: Readonly<Record<string, readonly Scenario[]>> = {
 
   // ── Common UI patterns ──
   ControlledSelect: [{ name: "initial B selected", asserts: {} }],
+  SetupHandlers: [
+    { name: "compiles setup-body handlers", asserts: { textOf: { "#toggle": "b" } } },
+  ],
   ConditionalClass: [{ name: "initial inactive", asserts: {} }],
   MemoChain: [{ name: "initial chain value", asserts: { textOf: { span: "Value: 4" } } }],
   EffectCleanup: [{ name: "initial active", asserts: {} }],

--- a/core/compiler/src/codegen/shared/setup-locals.ts
+++ b/core/compiler/src/codegen/shared/setup-locals.ts
@@ -1,0 +1,29 @@
+import type { IRComponent } from "../../ir/render/nodes.ts";
+import type { SourceLocation } from "../../ir/types.ts";
+import { setupLocalDefs } from "../../ir/setup.ts";
+import type { RewriteRules } from "../context.ts";
+import { rewriteExpr } from "./expr-rewrite.ts";
+
+/**
+ * A single emittable setup-body local (a `const`-arrow or a function declaration), with its
+ * initializer already rewritten for the target. Emitters format the surrounding syntax:
+ * `const ${name} = ${expr}` on the six standalone targets, a `${name} = ${expr}` class field on
+ * Angular. Statements that declare no emittable definition (e.g. a bare `const x = 1`) are absent
+ * here — the analyze pass diagnoses them as INK0121 if referenced.
+ */
+export interface SetupLocalEmit {
+  readonly name: string;
+  readonly expr: string;
+  readonly span: SourceLocation;
+}
+
+/** The setup-body locals a target emits, in source order, initializers rewritten with `rules`. */
+export function setupLocalEmits(component: IRComponent, rules: RewriteRules): SetupLocalEmit[] {
+  const out: SetupLocalEmit[] = [];
+  for (const s of component.setup) {
+    for (const def of setupLocalDefs(s.stmt)) {
+      out.push({ name: def.name, expr: rewriteExpr(def.initializer, rules), span: s.loc });
+    }
+  }
+  return out;
+}

--- a/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -394,6 +394,28 @@ size = input.required<number>()
 "
 `;
 
+exports[`angular full output snapshots > SetupHandlers 1`] = `
+"import { Component, signal, computed, effect, input } from "@angular/core";
+@Component({ standalone: true, selector: 'ink-setup-handlers', host: { style: 'display: contents' }, template: \`<div [class]="klass()">
+<button id="toggle" (click)="onToggle">{{ value() }}</button>
+<button id="reset" (click)="onReset">Reset</button>
+@for (option of options(); track option) {
+<div class="option" (click)="onSelect(option)">{{ option }}</div>
+}
+</div>\` })
+export class SetupHandlersComponent
+{
+klass = input<string>()
+options = signal(['a', 'b', 'c'])
+value = signal('b')
+open = signal(false)
+onToggle = () => this.open.set(!this.open())
+onReset = function onReset() { this.value.set('a'); }
+onSelect = (option: string) => { this.value.set(option); this.open.set(false); }
+}
+"
+`;
+
 exports[`angular full output snapshots > SlotBasic 1`] = `
 "import { Component, signal, computed, effect, input } from "@angular/core";
 @Component({ standalone: true, selector: 'ink-slot-basic', host: { style: 'display: contents' }, template: \`<div [class]="klass()">

--- a/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -397,8 +397,8 @@ size = input.required<number>()
 exports[`angular full output snapshots > SetupHandlers 1`] = `
 "import { Component, signal, computed, effect, input } from "@angular/core";
 @Component({ standalone: true, selector: 'ink-setup-handlers', host: { style: 'display: contents' }, template: \`<div [class]="klass()">
-<button id="toggle" (click)="onToggle">{{ value() }}</button>
-<button id="reset" (click)="onReset">Reset</button>
+<button id="toggle" (click)="onToggle($event)">{{ value() }}</button>
+<button id="reset" (click)="onReset($event)">Reset</button>
 @for (option of options(); track option) {
 <div class="option" (click)="onSelect(option)">{{ option }}</div>
 }

--- a/core/compiler/src/codegen/targets/angular/__tests__/events.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/events.test.ts
@@ -35,3 +35,26 @@ describe("TypedEvent: onMouseMove reading e.clientX / e.clientY into a signal", 
     expect(out).toContain('(mousemove)="pos.set({ x: $event.clientX, y: $event.clientY })"');
   });
 });
+
+// ---------------------------------------------------------------------------
+// SetupHandlers: a no-arg setup-local handler bound by reference — onClick={onToggle}.
+// Angular event bindings are statements, so a bare reference `(click)="onToggle"` is evaluated
+// and discarded — the handler never fires. The binding MUST be emitted as an invocation
+// `(click)="onToggle($event)"`. Regression guard for the S2 blocker.
+// ---------------------------------------------------------------------------
+describe("SetupHandlers: no-arg setup-local handler bound by reference", () => {
+  it("Angular: (click) invokes the hoisted handler instead of binding a bare reference", async () => {
+    const out = await compileTo("SetupHandlers", "angular");
+    // The handler definition is emitted as a class field.
+    expect(out).toContain("onToggle = () => this.open.set(!this.open())");
+    // The DOM binding invokes it — a statement that actually fires the handler.
+    expect(out).toContain('(click)="onToggle($event)"');
+    // A bare, un-invoked reference (the bug) must never appear.
+    expect(out).not.toContain('(click)="onToggle"');
+    expect(out).not.toContain('(click)="onReset"');
+    // The function-declaration handler is likewise invoked.
+    expect(out).toContain('(click)="onReset($event)"');
+    // The already-parametrized For-row handler stays a call expression (not double-invoked).
+    expect(out).toContain('(click)="onSelect(option)"');
+  });
+});

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -19,6 +19,7 @@ import {
   foldConstTest,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { assertNever } from "../../../core/assert.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
 import { angularSelector, angularAttrSelector } from "./selector.ts";
@@ -604,6 +605,12 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         span: m.loc,
       }),
     );
+  }
+  // Setup-body handlers/helpers become class fields (`onToggle = () => …`), so the template reads
+  // them bare and they close over the instance via the arrow's lexical `this`. Body-rewritten so
+  // reactive reads/writes resolve to `this.<signal>()` / `this.<signal>.set(…)`.
+  for (const local of setupLocalEmits(component, bodyRules)) {
+    body.push(cStmt({ body: `${local.name} = ${local.expr}`, span: local.span }));
   }
   // Effects and lifecycle run from a single constructor (a class can only have one).
   const ctorStmts: string[] = [];

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -29,9 +29,25 @@ import * as ts from "typescript";
  * Angular event bindings are statements, not function expressions. Unwrap an authored arrow
  * handler `(e) => body` to its body, mapping the event param to `$event` (e.g.
  * `(input)="value.set($event.target.value)"`). Block bodies become `;`-separated statements.
+ *
+ * A handler that is a bare callable *reference* (an identifier or member access, e.g. a hoisted
+ * setup-local `onToggle` or `props.onClick`) must be emitted as an *invocation* `onToggle($event)`.
+ * Angular evaluates the binding expression as a statement, so a bare reference is read and
+ * discarded and the handler never fires. Call expressions (`onSelect(option)`) are already
+ * effectful and emit verbatim.
  */
 function angularEventExpr(expr: ts.Expression, rules: RewriteRules): string {
-  if (!ts.isArrowFunction(expr)) return rewriteExpr(expr, rules);
+  if (!ts.isArrowFunction(expr)) {
+    const rewritten = rewriteExpr(expr, rules);
+    if (
+      ts.isIdentifier(expr) ||
+      ts.isPropertyAccessExpression(expr) ||
+      ts.isElementAccessExpression(expr)
+    ) {
+      return `${rewritten}($event)`;
+    }
+    return rewritten;
+  }
   const param = expr.parameters[0];
   const r: RewriteRules =
     param && ts.isIdentifier(param.name)

--- a/core/compiler/src/codegen/targets/astro/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/astro/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -317,6 +317,22 @@ const { color = "blue", size, ...__attrs } = props;
 "
 `;
 
+exports[`astro full output snapshots > SetupHandlers 1`] = `
+"---
+type Props = Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+let options = ["a", "b", "c"]
+let value = "b"
+let open = false
+const onToggle = () => open = !open
+const onReset = function onReset() { value = "a"; }
+const onSelect = (option: string) => { value = option; open = false; }
+---
+<div {...__attrs} class={__attrs.class}><button id="toggle" onClick={onToggle}>{value}</button><button id="reset" onClick={onReset}>Reset</button>{options.map((option) => (<div class="option" onClick={() => onSelect(option)}>{option}</div>))}</div>
+"
+`;
+
 exports[`astro full output snapshots > SlotBasic 1`] = `
 "---
 type Props = Record<string, any>

--- a/core/compiler/src/codegen/targets/astro/index.ts
+++ b/core/compiler/src/codegen/targets/astro/index.ts
@@ -10,6 +10,7 @@ import {
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
   FALLTHROUGH_REST,
@@ -239,6 +240,13 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     cStmt({ body: `const ${m.name} = ${rewriteExpr(m.expr.expr, rules)}`, span: m.loc }),
   );
 
+  // Setup-body handlers/helpers render in the frontmatter as plain consts after the reactive
+  // declarations they close over. On Astro they never fire on the client (SSR only), but must exist
+  // so template references resolve at render time.
+  const setupDecls = setupLocalEmits(component, rules).map((local) =>
+    cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }),
+  );
+
   // Astro has no client-side context runtime, so a consumed context can't resolve a provider at
   // render time. Best-effort: fall back to the context's declared default value so the template
   // read still resolves (rather than referencing an undefined binding).
@@ -289,6 +297,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       ...modelDecls,
       ...stateDecls,
       ...memoDecls,
+      ...setupDecls,
       ...resourceDecls,
       cRaw({ text: "---" }),
       cRaw({ text: "" }),

--- a/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -438,9 +438,9 @@ const onSelect = (option: string) => { value.value = option; open.value = false;
 const { ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
-  <button id="toggle" onClick={$(onToggle)}>{value.value}</button>
-  <button id="reset" onClick={$(onReset)}>Reset</button>
-  {options.value.map((option) => (<><div class="option" onClick={$(() => onSelect(option))}>{option}</div></>))}
+  <button id="toggle" onClick$={$(onToggle)}>{value.value}</button>
+  <button id="reset" onClick$={$(onReset)}>Reset</button>
+  {options.value.map((option) => (<><div class="option" onClick$={$(() => onSelect(option))}>{option}</div></>))}
 </div>
 )
 });

--- a/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -425,6 +425,28 @@ return (
 "
 `;
 
+exports[`qwik full output snapshots > SetupHandlers 1`] = `
+"import { component$, useSignal, useComputed$, useVisibleTask$, $ } from "@qwik.dev/core";
+export const SetupHandlers = component$((props) =>
+{
+const options = useSignal(["a", "b", "c"])
+const value = useSignal("b")
+const open = useSignal(false)
+const onToggle = () => open.value = !open.value
+const onReset = function onReset() { value.value = "a"; }
+const onSelect = (option: string) => { value.value = option; open.value = false; }
+const { ...__attrs } = props
+return (
+<div {...__attrs} class={props.class}>
+  <button id="toggle" onClick={$(onToggle)}>{value.value}</button>
+  <button id="reset" onClick={$(onReset)}>Reset</button>
+  {options.value.map((option) => (<><div class="option" onClick={$(() => onSelect(option))}>{option}</div></>))}
+</div>
+)
+});
+"
+`;
+
 exports[`qwik full output snapshots > SlotBasic 1`] = `
 "import { component$, useSignal, useComputed$, useVisibleTask$, $, Slot } from "@qwik.dev/core";
 export const SlotBasic = component$((props) =>

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -23,6 +23,7 @@ import {
   foldConstTest,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
   FALLTHROUGH_REST,
@@ -483,6 +484,11 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         span: r.loc,
       }),
     );
+  }
+  // Setup-body handlers/helpers close over the `useSignal`/`useComputed$` values above; emit them
+  // after the reactive declarations and before the effects/render that reference them.
+  for (const local of setupLocalEmits(component, rules)) {
+    body.push(cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }));
   }
   for (const e of component.effects) {
     body.push(cStmt({ body: `useVisibleTask$(${rewriteExpr(e.body, rules)})`, span: e.loc }));

--- a/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -415,6 +415,28 @@ return (
 "
 `;
 
+exports[`react full output snapshots > SetupHandlers 1`] = `
+"import { useState, Fragment } from "react";
+export function SetupHandlers(props: React.HTMLAttributes<HTMLElement>)
+{
+const [options, setOptions] = useState(["a", "b", "c"])
+const [value, setValue] = useState("b")
+const [open, setOpen] = useState(false)
+const onToggle = () => setOpen(!open)
+const onReset = function onReset() { setValue("a"); }
+const onSelect = (option: string) => { setValue(option); setOpen(false); }
+const { ...__attrs } = props
+return (
+<div {...__attrs} className={props.className}>
+  <button id="toggle" onClick={onToggle}>{value}</button>
+  <button id="reset" onClick={onReset}>Reset</button>
+  {options.map((option) => (<Fragment key={option}><div className="option" onClick={() => onSelect(option)}>{option}</div></Fragment>))}
+</div>
+)
+}
+"
+`;
+
 exports[`react full output snapshots > SlotBasic 1`] = `
 "export function SlotBasic(props: { children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>)
 {

--- a/core/compiler/src/codegen/targets/react/index.ts
+++ b/core/compiler/src/codegen/targets/react/index.ts
@@ -25,6 +25,7 @@ import {
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
   FALLTHROUGH_REST,
@@ -589,6 +590,12 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         span: m.loc,
       }),
     );
+  }
+  // Setup-body handlers/helpers (`const onToggle = () => …`) are inert closures that read state via
+  // the reactive rules; emit them after the reactive declarations they close over and before the
+  // effects/render that reference them.
+  for (const local of setupLocalEmits(component, rules)) {
+    body.push(cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }));
   }
   for (const e of component.effects) {
     reactImports.push("useEffect");

--- a/core/compiler/src/codegen/targets/solid/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/solid/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -473,6 +473,31 @@ return (
 "
 `;
 
+exports[`solid full output snapshots > SetupHandlers 1`] = `
+"import { createSignal, splitProps, For } from "solid-js";
+import type { JSX } from "solid-js";
+export default function SetupHandlers(props: JSX.HTMLAttributes<HTMLElement>)
+{
+const [options, setOptions] = createSignal(["a", "b", "c"])
+const [value, setValue] = createSignal("b")
+const [open, setOpen] = createSignal(false)
+const onToggle = () => setOpen(!open())
+const onReset = function onReset() { setValue("a"); }
+const onSelect = (option: string) => { setValue(option); setOpen(false); }
+const [, __attrs] = splitProps(props, [])
+return (
+<div {...__attrs} class={props.class}>
+  <button id="toggle" onclick={onToggle}>{value()}</button>
+  <button id="reset" onclick={onReset}>Reset</button>
+  <For each={options()}>
+    {(option) => <div class="option" onclick={() => onSelect(option)}>{option}</div>}
+  </For>
+</div>
+)
+}
+"
+`;
+
 exports[`solid full output snapshots > SlotBasic 1`] = `
 "import { splitProps } from "solid-js";
 import type { JSX } from "solid-js";

--- a/core/compiler/src/codegen/targets/solid/index.ts
+++ b/core/compiler/src/codegen/targets/solid/index.ts
@@ -23,6 +23,7 @@ import {
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
   FALLTHROUGH_REST,
@@ -567,6 +568,11 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         span: m.loc,
       }),
     );
+  }
+  // Setup-body handlers/helpers close over the reactive signals declared above; emit them after the
+  // reactive declarations and before the effects/render that reference them.
+  for (const local of setupLocalEmits(component, rules)) {
+    body.push(cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }));
   }
   for (const e of component.effects) {
     solidImports.push("createEffect");

--- a/core/compiler/src/codegen/targets/svelte/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/svelte/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -276,6 +276,20 @@ exports[`svelte full output snapshots > PropDefaults 1`] = `
 "
 `;
 
+exports[`svelte full output snapshots > SetupHandlers 1`] = `
+"<script lang="ts">
+  let { ...__attrs }: Record<string, any> = $props()
+  let options = $state(["a", "b", "c"])
+  let value = $state("b")
+  let open = $state(false)
+  const onToggle = () => open = !open
+  const onReset = function onReset() { value = "a"; }
+  const onSelect = (option: string) => { value = option; open = false; }
+</script>
+<div {...__attrs} class={__attrs.class}><button id="toggle" onclick={onToggle}>{value}</button><button id="reset" onclick={onReset}>Reset</button>{#each options as option (option)}<div class="option" onclick={() => onSelect(option)}>{option}</div>{/each}</div>
+"
+`;
+
 exports[`svelte full output snapshots > SlotBasic 1`] = `
 "<script lang="ts">
   import type { Snippet } from "svelte";

--- a/core/compiler/src/codegen/targets/svelte/index.ts
+++ b/core/compiler/src/codegen/targets/svelte/index.ts
@@ -27,6 +27,7 @@ import {
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import {
   FALLTHROUGH_REST,
@@ -503,6 +504,10 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         span: m.loc,
       }),
     );
+  // Setup-body handlers/helpers close over the `$state`/`$derived` runes above; emit them after the
+  // reactive declarations and before the effects/render that reference them.
+  for (const local of setupLocalEmits(component, rules))
+    scriptBody.push(cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }));
   for (const e of component.effects)
     scriptBody.push(cStmt({ body: `$effect(${rewriteExpr(e.body, rules)})`, span: e.loc }));
   // Lower each resource to reactive $state (data/loading/error) plus a top-level loader that runs

--- a/core/compiler/src/codegen/targets/vue/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/vue/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -391,6 +391,28 @@ exports[`vue full output snapshots > PropDefaults 1`] = `
 "
 `;
 
+exports[`vue full output snapshots > SetupHandlers 1`] = `
+"<script setup lang="ts">
+  import { ref } from "vue";
+  const options = ref(["a", "b", "c"])
+  const value = ref("b")
+  const open = ref(false)
+  const onToggle = () => open.value = !open.value
+  const onReset = function onReset() { value.value = "a"; }
+  const onSelect = (option: string) => { value.value = option; open.value = false; }
+</script>
+<template>
+<div>
+  <button id="toggle" @click="onToggle">{{ value }}</button>
+  <button id="reset" @click="onReset">Reset</button>
+  <div v-for="option in options" :key="option" class="option" @click="() => onSelect(option)">
+    {{ option }}
+  </div>
+</div>
+</template>
+"
+`;
+
 exports[`vue full output snapshots > SlotBasic 1`] = `
 "<script setup lang="ts">
 </script>

--- a/core/compiler/src/codegen/targets/vue/index.ts
+++ b/core/compiler/src/codegen/targets/vue/index.ts
@@ -24,6 +24,7 @@ import {
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
+import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
 import { assertNever } from "../../../core/assert.ts";
 import * as ts from "typescript";
@@ -344,6 +345,11 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
         span: m.loc,
       }),
     );
+  }
+  // Setup-body handlers/helpers close over the refs declared above; the <script setup> reads them
+  // via `.value` (script `rules`). Emit after the reactive declarations, before effects/render.
+  for (const local of setupLocalEmits(component, rules)) {
+    scriptBody.push(cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }));
   }
   for (const e of component.effects) {
     vueImports.push("watchEffect");

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -33,6 +33,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0110",
       "INK0111",
       "INK0120",
+      "INK0121",
     ];
     expect(codes.sort()).toEqual(expected.sort());
   });
@@ -65,7 +66,7 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
-  it("codes with placeholders: INK0030, INK0044, INK0080, INK0090, INK0100, INK0110, INK0111, INK0120", () => {
+  it("codes with placeholders: INK0030, INK0044, INK0080, INK0090, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
     const withPlaceholders = codes.filter((c) => /\{\w+\}/.test(DIAGNOSTICS[c].title));
     expect(withPlaceholders.sort()).toEqual([
       "INK0030",
@@ -76,6 +77,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0110",
       "INK0111",
       "INK0120",
+      "INK0121",
     ]);
   });
 });

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -170,6 +170,12 @@ export const DIAGNOSTICS = {
     help: "Give the component a single host-element root so it can inherit class and other attributes." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0120" as const,
   },
+  INK0121: {
+    severity: "error" as const,
+    title: "Setup-body local '{name}' is referenced but its definition cannot be emitted" as const,
+    help: "Only const/let arrow or function expressions and function declarations are emitted as setup-body locals. Rewrite '{name}' as a `const {name} = (…) => …` handler or a `function {name}(…) {…}` declaration so the compiler can emit its definition." as const,
+    url: "https://docs.inkline.dev/diagnostics/INK0121" as const,
+  },
 } as const;
 
 export type DiagnosticCode = keyof typeof DIAGNOSTICS;

--- a/core/compiler/src/ir/render/nodes.ts
+++ b/core/compiler/src/ir/render/nodes.ts
@@ -312,7 +312,8 @@ export interface IRLifecycle {
 
 export interface IRSetupStatement {
   readonly stmt: ts.Statement;
-  readonly defines: readonly SymbolId[];
+  /** Identifier names this statement declares (const/let/var declarators or a function name). */
+  readonly defines: readonly string[];
   readonly loc: SourceLocation;
 }
 

--- a/core/compiler/src/ir/setup.ts
+++ b/core/compiler/src/ir/setup.ts
@@ -1,0 +1,74 @@
+import * as ts from "typescript";
+
+/**
+ * Setup-body local declarations — the handlers and helpers an author writes above the render return
+ * (`const onToggle = () => …`, `function onNavigate() { … }`). Parse captures them into
+ * `IRComponent.setup`; codegen emits a definition per target and the analyze pass diagnoses the
+ * ones it cannot emit (INK0121). These helpers are the single source of truth for *which* names a
+ * setup statement declares and *whether* a definition can be emitted, shared by both phases so they
+ * never disagree.
+ */
+
+/** The identifier names a setup statement declares (const/let/var declarators, or a function name). */
+export function setupDeclaredNames(stmt: ts.Statement): string[] {
+  if (ts.isFunctionDeclaration(stmt)) return stmt.name ? [stmt.name.text] : [];
+  if (ts.isVariableStatement(stmt)) {
+    const names: string[] = [];
+    for (const d of stmt.declarationList.declarations) {
+      if (ts.isIdentifier(d.name)) names.push(d.name.text);
+    }
+    return names;
+  }
+  return [];
+}
+
+export interface SetupLocalDef {
+  readonly name: string;
+  /** The arrow or function expression whose (rewritten) text becomes the emitted definition. */
+  readonly initializer: ts.Expression;
+}
+
+/**
+ * The `(name, initializer)` pairs codegen emits for a setup statement. Emittable forms are a
+ * function declaration and a `const`/`let` declarator initialized by an arrow or function
+ * expression. A function declaration is wrapped as a named function expression so one expression
+ * rewriter serves every target — `const f = function f(…) {…}` on the six standalone targets, a
+ * `f = function f(…) {…}` class field on Angular. A declarator that is not function-valued yields no
+ * entry (it is a drop → INK0121 if referenced).
+ */
+export function setupLocalDefs(stmt: ts.Statement): SetupLocalDef[] {
+  if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) {
+    const asyncMod = stmt.modifiers?.find((m) => m.kind === ts.SyntaxKind.AsyncKeyword) as
+      | ts.Modifier
+      | undefined;
+    const fnExpr = ts.factory.createFunctionExpression(
+      asyncMod ? [asyncMod] : undefined,
+      stmt.asteriskToken,
+      stmt.name,
+      stmt.typeParameters,
+      stmt.parameters,
+      stmt.type,
+      stmt.body,
+    );
+    return [{ name: stmt.name.text, initializer: fnExpr }];
+  }
+  if (ts.isVariableStatement(stmt)) {
+    const defs: SetupLocalDef[] = [];
+    for (const d of stmt.declarationList.declarations) {
+      if (
+        ts.isIdentifier(d.name) &&
+        d.initializer &&
+        (ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer))
+      ) {
+        defs.push({ name: d.name.text, initializer: d.initializer });
+      }
+    }
+    return defs;
+  }
+  return [];
+}
+
+/** The subset of {@link setupDeclaredNames} that codegen emits a definition for. */
+export function emittedSetupNames(stmt: ts.Statement): string[] {
+  return setupLocalDefs(stmt).map((d) => d.name);
+}

--- a/core/compiler/src/pipeline/passes/02-parse/setup.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/setup.ts
@@ -16,6 +16,7 @@ import type {
   IRStateDeclaration,
   PrimitiveName,
 } from "../../../ir/render/nodes.ts";
+import { setupDeclaredNames } from "../../../ir/setup.ts";
 import type { PassContext } from "../../types.ts";
 import type { BindingTable } from "./bind-primitives.ts";
 import { toLoc } from "./loc.ts";
@@ -477,7 +478,7 @@ export function parseSetup(
               isCallTo(d.initializer, useContextLocal)),
         )
       ) {
-        setup.push({ stmt, defines: [], loc });
+        setup.push({ stmt, defines: setupDeclaredNames(stmt), loc });
       }
       continue;
     }
@@ -535,7 +536,7 @@ export function parseSetup(
       }
     }
 
-    setup.push({ stmt, defines: [], loc });
+    setup.push({ stmt, defines: setupDeclaredNames(stmt), loc });
   }
 
   return {

--- a/core/compiler/src/pipeline/passes/04-analyze/index.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/index.ts
@@ -1,7 +1,12 @@
 import type { IRModule } from "../../../ir/render/nodes.ts";
 import type { Pass } from "../../types.ts";
 import { buildReactivityGraph, type ReactivityGraph } from "./graph.ts";
-import { diagnoseCycles, validateAttrFallthrough, validateComponent } from "./validate.ts";
+import {
+  diagnoseCycles,
+  validateAttrFallthrough,
+  validateComponent,
+  validateSetupLocals,
+} from "./validate.ts";
 
 export interface AnalyzedModule {
   readonly module: IRModule;
@@ -20,6 +25,7 @@ export const analyzePass: Pass<IRModule, AnalyzedModule> = {
 
       validateComponent(component, ctx);
       validateAttrFallthrough(component, localComponents, ctx);
+      validateSetupLocals(component, ctx);
       diagnoseCycles(component, graph, ctx);
     }
 
@@ -28,4 +34,9 @@ export const analyzePass: Pass<IRModule, AnalyzedModule> = {
 };
 
 export { buildReactivityGraph, type ReactivityGraph } from "./graph.ts";
-export { validateComponent, validateAttrFallthrough, diagnoseCycles } from "./validate.ts";
+export {
+  validateComponent,
+  validateAttrFallthrough,
+  validateSetupLocals,
+  diagnoseCycles,
+} from "./validate.ts";

--- a/core/compiler/src/pipeline/passes/04-analyze/validate.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/validate.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import type { IRComponent, IRExprNode } from "../../../ir/render/nodes.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
+import { emittedSetupNames, setupLocalDefs } from "../../../ir/setup.ts";
 import type { PassContext } from "../../types.ts";
 import type { ReactivityGraph } from "./graph.ts";
 
@@ -83,6 +84,73 @@ export function validateAttrFallthrough(
       }
     },
   });
+}
+
+/** Free-identifier names referenced by an expression, skipping property/member names (`e.target`
+ * contributes `e`, not `target`). Over-approximates (object-literal keys are counted) but only
+ * toward reporting a genuinely-declared-but-undroppable local, never toward hiding one. */
+function collectReferenced(node: ts.Node, out: Set<string>): void {
+  const visit = (n: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(n)) {
+      visit(n.expression);
+      return;
+    }
+    if (ts.isIdentifier(n)) {
+      out.add(n.text);
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+}
+
+/**
+ * INK0121: a setup-body local is declared (e.g. `let x = 1`, a destructuring, a class) whose
+ * definition codegen cannot emit — only const/let arrow/function expressions and function
+ * declarations are emitted — yet the render, an effect/memo, or an emitted handler references it.
+ * Without this the reference compiles to an undefined binding at runtime on every target. Names that
+ * are dropped but never referenced are silently fine (no emission, no reference, no error).
+ */
+export function validateSetupLocals(component: IRComponent, ctx: PassContext): void {
+  if (component.setup.length === 0) return;
+
+  const referenced = new Set<string>();
+  for (const m of component.memos) collectReferenced(m.expr.expr, referenced);
+  for (const e of component.effects) collectReferenced(e.body, referenced);
+  for (const l of component.lifecycle.onMount) collectReferenced(l.body, referenced);
+  for (const l of component.lifecycle.onCleanup) collectReferenced(l.body, referenced);
+  // Emitted handlers/helpers can reference a dropped local (a handler calling a dropped helper);
+  // scan their initializers, not the declaration names, so a drop is caught one level deep.
+  for (const s of component.setup)
+    for (const def of setupLocalDefs(s.stmt)) collectReferenced(def.initializer, referenced);
+
+  walkRenderTree(component.render, {
+    enter(node) {
+      if (node.kind === "Expression") collectReferenced(node.expr, referenced);
+      if (node.kind === "Element" || node.kind === "ComponentInstance") {
+        for (const attr of node.attrs)
+          if (attr.value.kind === "Expression") collectReferenced(attr.value.expr, referenced);
+        for (const ev of node.events) collectReferenced(ev.handler.expr, referenced);
+      }
+      if (node.kind === "If")
+        for (const branch of node.branches) collectReferenced(branch.test.expr, referenced);
+      if (node.kind === "For") {
+        collectReferenced(node.each.expr, referenced);
+        collectReferenced(node.key.expr, referenced);
+      }
+      if (node.kind === "Switch")
+        for (const c of node.cases) collectReferenced(c.test.expr, referenced);
+    },
+  });
+
+  for (const s of component.setup) {
+    const emitted = new Set(emittedSetupNames(s.stmt));
+    for (const name of s.defines) {
+      if (!emitted.has(name) && referenced.has(name)) {
+        ctx.diagnostics.push("INK0121", s.loc, { name });
+      }
+    }
+  }
 }
 
 export function diagnoseCycles(

--- a/core/compiler/src/testing/codegen.ts
+++ b/core/compiler/src/testing/codegen.ts
@@ -102,6 +102,7 @@ export const CORE_FIXTURES = [
 
 export const NEW_FIXTURES = [
   "ControlledSelect",
+  "SetupHandlers",
   "ConditionalClass",
   "MemoChain",
   "MixedControlFlow",


### PR DESCRIPTION
## Summary
Setup-body local declarations (const-arrow handlers, function declarations) were parsed into the IR `setup` list but their **definitions were never emitted** by any of the 7 codegen targets. The compiler emitted the *reference* (e.g. `onClick={onToggle}`) while dropping the *definition* — an undefined-at-runtime failure on React, Vue, Svelte, Solid, Qwik, Angular, and Astro, with no compile-time diagnostic.

## What
- **Parse** (`02-parse/setup.ts`): populate `IRSetupStatement.defines` with declared identifier names via new shared helper `ir/setup.ts` (`setupDeclaredNames` / `setupLocalDefs` / `emittedSetupNames`). Changed `defines` type from `SymbolId[]` → `string[]`.
- **Emit** (`codegen/shared/setup-locals.ts` + all 7 targets): emit each setup-local definition after reactive state/memos, before effects/render. 6 targets emit `const name = expr`; Angular emits a class field `name = expr` (arrow captures `this`, reactive reads rewritten to `this.x()` / `this.x.set()`). Per-target reactive rewriting preserved (`.value`, strip-call, Solid call-preserve, Svelte runes, Qwik QRL wrap).
- **Diagnose** (`INK0121` + `04-analyze/validate.ts`): a referenced setup-local whose definition cannot be emitted now raises `INK0121` at compile time instead of failing silently at runtime.

## Why
A reference with no definition is a silent, cross-target correctness bug. Emit the definition where it can be emitted; raise a diagnostic where it cannot. No half-states.

## Proof
- `vp test` — **3253/3253 green** across 216 files, including 7 new per-target snapshots for `SetupHandlers` (verbatim `onToggle`, `function onReset`, and the parametrized For-row `onSelect(option)` form) and the `Diag_SetupLocalDrop` fixture asserting `INK0121` fires.
- `npx tsc --noEmit` clean. `vp check` clean on touched files (472 pre-existing TS17004 JSX-flag errors on untouched `.ink.tsx` fixtures confirmed present on baseline via `git stash`).

Closes INK-32.
