### PR TITLE
fix(compiler): emit Qwik setup-local handlers as QRLs to fix Select SSR crash

### DIFF
--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -99,6 +99,13 @@ export interface RewriteRules {
    */
   readonly propLocals?: ReadonlySet<string>;
   /**
+   * Setup-body local functions emitted as Qwik QRLs (`const onToggle = $(() => …)`) because a render
+   * handler binds them. A handler that is a bare reference to one of these is passed through
+   * un-wrapped (`onToggle$={onToggle}`) rather than re-wrapped in `$()` — `$()` needs a function
+   * literal, not an identifier. Qwik-only; other targets pass plain function references directly.
+   */
+  readonly qrlLocals?: ReadonlySet<string>;
+  /**
    * Props are emitted as Angular signal inputs (`color = input<T>()`), so a `props.x` read must use
    * the call form: `this.color()` in a class body, `color()` in the template. Without it `props.x`
    * reads a plain field, which a `computed`/`effect` cannot track. Angular-only.

--- a/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -432,14 +432,14 @@ export const SetupHandlers = component$((props) =>
 const options = useSignal(["a", "b", "c"])
 const value = useSignal("b")
 const open = useSignal(false)
-const onToggle = () => open.value = !open.value
-const onReset = function onReset() { value.value = "a"; }
-const onSelect = (option: string) => { value.value = option; open.value = false; }
+const onToggle = $(() => open.value = !open.value)
+const onReset = $(function onReset() { value.value = "a"; })
+const onSelect = $((option: string) => { value.value = option; open.value = false; })
 const { ...__attrs } = props
 return (
 <div {...__attrs} class={props.class}>
-  <button id="toggle" onClick$={$(onToggle)}>{value.value}</button>
-  <button id="reset" onClick$={$(onReset)}>Reset</button>
+  <button id="toggle" onClick$={onToggle}>{value.value}</button>
+  <button id="reset" onClick$={onReset}>Reset</button>
   {options.value.map((option) => (<><div class="option" onClick$={$(() => onSelect(option))}>{option}</div></>))}
 </div>
 )

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -1,7 +1,9 @@
+import * as ts from "typescript";
 import type { Target, CodegenContext, CodeModule, RewriteRules } from "../../context.ts";
 import { qwikConformance } from "./conformance.ts";
 import type { Code } from "../../code-ir/nodes.ts";
 import type { IRComponent, IRNode } from "../../../ir/render/nodes.ts";
+import { setupLocalDefs } from "../../../ir/setup.ts";
 import {
   cFile,
   cImport,
@@ -116,13 +118,19 @@ function jsxAttrs(
     const name = e.twoWayProp
       ? `${eventToCallbackProp(e.name)}$`
       : `${rewriteEventName(e.name, rules)}$`;
+    // A handler that is a bare reference to a QRL-emitted setup local is already a QRL — pass it
+    // straight through. Wrapping it (`$(onToggle)`) would hand `$()` an identifier instead of a
+    // function literal, which the optimizer rejects (and SSR surfaces as a thrown `[object Promise]`).
+    const handler = e.handler.expr;
+    const isDirectQrlLocal =
+      ts.isIdentifier(handler) && rules.qrlLocals?.has(handler.text) === true;
+    const text = isDirectQrlLocal
+      ? rewriteExpr(handler, rules)
+      : `$(${rewriteExpr(handler, rules)})`;
     out.push(
       cJsxAttr({
         name,
-        value: {
-          kind: "expr",
-          expr: cExpr({ text: `$(${rewriteExpr(e.handler.expr, rules)})` }),
-        },
+        value: { kind: "expr", expr: cExpr({ text }) },
       }),
     );
   }
@@ -377,6 +385,102 @@ function hasTransition(node: IRNode): boolean {
   }
 }
 
+// Every event-handler expression bound in the render tree (element and component-instance events).
+// A Qwik `$()` boundary is opened around each of these, so any setup-body local a handler references
+// (directly, `onToggle$={onToggle}`, or captured inside an inline handler, `$(() => onSelect(row))`)
+// crosses into a QRL scope and must itself be a QRL — a plain local function cannot be serialized
+// into a QRL's lexical scope (the optimizer rejects it: "scope is not a function, but it's capturing
+// local identifiers"), and at SSR the failed extraction surfaces as a thrown `[object Promise]`.
+function collectEventHandlerExprs(node: IRNode, out: ts.Expression[]): void {
+  switch (node.kind) {
+    case "Element":
+      for (const e of node.events) out.push(e.handler.expr);
+      node.children.forEach((c) => collectEventHandlerExprs(c, out));
+      return;
+    case "ComponentInstance":
+      for (const e of node.events) out.push(e.handler.expr);
+      node.slots.forEach((s) => collectEventHandlerExprs(s.body, out));
+      return;
+    case "Fragment":
+      node.children.forEach((c) => collectEventHandlerExprs(c, out));
+      return;
+    case "If":
+      node.branches.forEach((b) => collectEventHandlerExprs(b.body, out));
+      if (node.fallback) collectEventHandlerExprs(node.fallback, out);
+      return;
+    case "For":
+      collectEventHandlerExprs(node.body, out);
+      return;
+    case "Switch":
+      node.cases.forEach((c) => collectEventHandlerExprs(c.body, out));
+      if (node.fallback) collectEventHandlerExprs(node.fallback, out);
+      return;
+    case "Transition":
+      collectEventHandlerExprs(node.child, out);
+      return;
+    default:
+      return;
+  }
+}
+
+// Free identifier names referenced by an expression, ignoring the member side of a property access
+// (`props.onToggle` reads `props`, not a local `onToggle`). Used to intersect handler/local bodies
+// with the set of setup-local names, so a coincidentally-named object member is not a false hit.
+function collectReferencedNames(expr: ts.Expression, out: Set<string>): void {
+  const visit = (n: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(n)) {
+      visit(n.expression);
+      return;
+    }
+    if (ts.isIdentifier(n)) {
+      out.add(n.text);
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(expr);
+}
+
+// The setup-body local functions that must be emitted as QRLs (`const f = $(() => …)`) for Qwik: any
+// local reachable from an event handler, followed transitively through other locals it references.
+// A local used only synchronously (a render/memo helper) is absent — QRL-wrapping it would make a
+// bare `f(x)` render call return a Promise (`[object Promise]`).
+function qwikQrlLocalNames(component: IRComponent): Set<string> {
+  const localInit = new Map<string, ts.Expression>();
+  for (const s of component.setup) {
+    for (const def of setupLocalDefs(s.stmt)) localInit.set(def.name, def.initializer);
+  }
+  if (localInit.size === 0) return new Set();
+
+  const handlerExprs: ts.Expression[] = [];
+  collectEventHandlerExprs(component.render, handlerExprs);
+
+  const seed = new Set<string>();
+  for (const expr of handlerExprs) collectReferencedNames(expr, seed);
+
+  const qrl = new Set<string>();
+  const worklist: string[] = [];
+  for (const name of seed) {
+    if (localInit.has(name)) {
+      qrl.add(name);
+      worklist.push(name);
+    }
+  }
+  // Transitive closure: a QRL local's body captures every local it references, so those become QRLs
+  // too (e.g. a handler that delegates to another hoisted handler).
+  while (worklist.length > 0) {
+    const refs = new Set<string>();
+    collectReferencedNames(localInit.get(worklist.pop()!)!, refs);
+    for (const name of refs) {
+      if (localInit.has(name) && !qrl.has(name)) {
+        qrl.add(name);
+        worklist.push(name);
+      }
+    }
+  }
+  return qrl;
+}
+
 const QWIK_TRANSITION_HELPER = `const __InkTransition = component$((props: { name?: string; appear?: boolean; children?: any }) => {
   const name = props.name ?? "ink";
   const ref = useSignal<HTMLDivElement>();
@@ -493,9 +597,13 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     );
   }
   // Setup-body handlers/helpers close over the `useSignal`/`useComputed$` values above; emit them
-  // after the reactive declarations and before the effects/render that reference them.
+  // after the reactive declarations and before the effects/render that reference them. A local a
+  // render handler binds (`onToggle$={onToggle}`) is emitted as a QRL so Qwik can extract and resume
+  // it; a synchronous helper stays a plain function so a render-time call is not a Promise.
+  const qrlLocals = qwikQrlLocalNames(component);
   for (const local of setupLocalEmits(component, rules)) {
-    body.push(cStmt({ body: `const ${local.name} = ${local.expr}`, span: local.span }));
+    const init = qrlLocals.has(local.name) ? `$(${local.expr})` : local.expr;
+    body.push(cStmt({ body: `const ${local.name} = ${init}`, span: local.span }));
   }
   for (const e of component.effects) {
     body.push(cStmt({ body: `useVisibleTask$(${rewriteExpr(e.body, rules)})`, span: e.loc }));
@@ -581,7 +689,12 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   const resourceReads = new Set(
     component.resources.flatMap((r) => [r.name, r.loadingName, r.errorName].filter(Boolean)),
   ) as Set<string>;
-  const renderRules: RewriteRules = { ...rules, reactiveBindings: resourceReads, propLocals };
+  const renderRules: RewriteRules = {
+    ...rules,
+    reactiveBindings: resourceReads,
+    propLocals,
+    qrlLocals,
+  };
 
   const renderTree = emitNode(component.render, renderRules);
 

--- a/ui/qwik/test/generate-fixtures.ts
+++ b/ui/qwik/test/generate-fixtures.ts
@@ -12,14 +12,37 @@ import { compile } from "@inkline/compiler";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-/** One headless `.ink.tsx` source → its generated Qwik `.tsx` on disk. */
+const componentsSrc = (rel: string) => resolve(here, "../../components/src/components", rel);
+
+/** One `.ink.tsx` source → its generated Qwik `.tsx` on disk. */
 const FIXTURES = [
   {
-    source: resolve(
-      here,
-      "../../components/src/components/checkbox/headless/ICheckboxControlBase.ink.tsx",
-    ),
+    source: componentsSrc("checkbox/headless/ICheckboxControlBase.ink.tsx"),
     out: resolve(here, "__generated__/ICheckboxControlBase.tsx"),
+  },
+  // The full Select tree (styled root + its four headless parts), mirrored so the styled component's
+  // relative imports (`../headless/ISelect*`) resolve. The SSR test (INK-35) imports the styled root
+  // and renders it through qwikVite to prove the codegen'd QRL handlers survive extraction instead of
+  // throwing `[object Promise]` at SSR.
+  {
+    source: componentsSrc("select/styled/ISelect.ink.tsx"),
+    out: resolve(here, "__generated__/select/styled/ISelect.tsx"),
+  },
+  {
+    source: componentsSrc("select/headless/ISelectBase.ink.tsx"),
+    out: resolve(here, "__generated__/select/headless/ISelectBase.tsx"),
+  },
+  {
+    source: componentsSrc("select/headless/ISelectTriggerBase.ink.tsx"),
+    out: resolve(here, "__generated__/select/headless/ISelectTriggerBase.tsx"),
+  },
+  {
+    source: componentsSrc("select/headless/ISelectListboxBase.ink.tsx"),
+    out: resolve(here, "__generated__/select/headless/ISelectListboxBase.tsx"),
+  },
+  {
+    source: componentsSrc("select/headless/ISelectOptionBase.ink.tsx"),
+    out: resolve(here, "__generated__/select/headless/ISelectOptionBase.tsx"),
   },
 ] as const;
 

--- a/ui/qwik/test/select-ssr.behaviour.test.tsx
+++ b/ui/qwik/test/select-ssr.behaviour.test.tsx
@@ -1,0 +1,56 @@
+// INK-35 regression: proves the styled Select's Qwik codegen renders on the server instead of
+// throwing `[object Promise]`.
+//
+// The defect was in the Qwik target's setup-body handler emission: hoisted handler locals were bound
+// as `onToggle$={$(onToggle)}` (a `$()` wrapping a bare identifier, which the optimizer rejects) and
+// captured inside inline handlers (`$(() => onSelect(row))`) as plain — not serializable — functions.
+// Qwik's optimizer turned the failed extraction into a rejected Promise, so SSR of the default story
+// (listbox closed) produced an `errored-host` and logged `Unknown Error: [object Promise]`.
+//
+// `test/generate-fixtures.ts` (globalSetup) compiles the real Select tree to Qwik under
+// `test/__generated__/select/`; importing the styled root routes it through qwikVite — the same QRL
+// extraction a production build runs. On a broken build the render throws and the assertions below
+// fail loudly.
+import { describe, it, expect, beforeAll } from "vitest";
+import { component$, useSignal, $, type Component } from "@qwik.dev/core";
+import { renderToString } from "@qwik.dev/core/server";
+
+const GENERATED_SELECT = "./__generated__/select/styled/ISelect.tsx";
+let ISelect: Component<Record<string, unknown>>;
+
+beforeAll(async () => {
+  ({ ISelect } = await import(GENERATED_SELECT));
+});
+
+/** The default story: a Select with a bound value and the listbox closed (its crashing state). */
+function DefaultStory() {
+  return component$(() => {
+    const value = useSignal("apple");
+    return (
+      <ISelect
+        id="select-default"
+        label="Fruit"
+        value={value.value}
+        options={[
+          { value: "apple", label: "Apple" },
+          { value: "banana", label: "Banana" },
+          { value: "cherry", label: "Cherry" },
+        ]}
+        onUpdateValue$={$((v: string) => (value.value = v))}
+      />
+    );
+  });
+}
+
+describe("Qwik Select — SSR render (INK-35)", () => {
+  it("renders select--default (listbox closed) without throwing [object Promise]", async () => {
+    const Story = DefaultStory();
+    const { html } = await renderToString(<Story />, { containerTagName: "div" });
+
+    // A real combobox is in the DOM — not Qwik's error boundary.
+    expect(html).not.toContain("errored-host");
+    expect(html).not.toContain("[object Promise]");
+    expect(html).toContain('role="combobox"');
+    expect(html).toContain("select-container");
+  });
+});


### PR DESCRIPTION
## What
Fixes the Qwik target's setup-body handler emission so styled Select renders on the server instead of throwing `[object Promise]` / `errored-host`.

## Why
`select--default` (listbox closed) crashed at Qwik SSR: the DOM contained only `<errored-host>` and the server logged `Vite [Unhandled rejection] Unknown Error: [object Promise]`. Root cause was in the compiler, not the Select source:

- Setup-body local handlers (`const onToggle = () => …`) were emitted as plain functions and bound as `onToggle$={$(onToggle)}` — `$()` wrapping a bare identifier, which Qwik's optimizer rejects ("Qrl($) scope is not a function, but it's capturing local identifiers").
- Inline handlers capturing those plain locals (`$(() => onSelect(row))`) hit the same wall — a plain function can't be serialized into a QRL's lexical scope.

The failed QRL extraction became a rejected Promise, surfacing at SSR as `[object Promise]`.

## Fix
In the Qwik codegen, compute the set of setup-locals reachable from a render event handler (transitively), emit those as QRLs (`const onToggle = $(() => …)`), and pass direct handler references through un-wrapped (`onToggle$={onToggle}`). Locals used only synchronously (render/memo helpers) stay plain functions, so a render-time call is never a Promise. Scoped Qwik-only via a new `qrlLocals` rewrite set — the other six targets are untouched.

## Proof
- New regression test `ui/qwik/test/select-ssr.behaviour.test.tsx` SSRs the styled Select through qwikVite (real QRL extraction) and asserts no `errored-host`, no `[object Promise]`, a real `role="combobox"`. Verified it fails with the exact optimizer error on a reverted compiler, passes with the fix.
- `core/compiler` suite green (259 output-snapshot tests; the `SetupHandlers` Qwik golden snapshot updated to the corrected QRL binding).
- `ui/qwik` suite green (3 tests); `vp check` (tsc + lint) clean.

Closes INK-35