### PR TITLE
fix(cli): give compile --out-dir precedence over config outDir

### DIFF
--- a/.changeset/cli-out-dir-flag-precedence.md
+++ b/.changeset/cli-out-dir-flag-precedence.md
@@ -1,0 +1,16 @@
+---
+"@inkline/cli": patch
+---
+
+fix(cli): give `compile --out-dir` precedence over the config file's `outDir`
+
+`inkline compile --out-dir <path>` was ignored whenever a config file set `outDir`: the resolution
+order was config-first, and the flag also carried a citty `default: "dist"` that made it impossible
+to tell "flag omitted" from "flag passed as dist". In practice the flag did nothing for any project
+with a config file. It now resolves flag > config > `dist`, matching `--target`, `--src-dir` and
+`--source-map`.
+
+Behaviour change: a project that relied on the config value winning over an explicitly passed
+`--out-dir` will now write to the flag's path. Remove the flag from that invocation to keep the
+previous output location. A per-target `targetOutDir` entry in the config is unchanged and still
+overrides both for the targets it names.

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -302,6 +302,63 @@ describe("compile command (in-process)", () => {
   });
 });
 
+describe("compile command --out-dir precedence", () => {
+  const SOURCE = () => resolve(FIXTURES, "Counter.ink.tsx");
+
+  function writeOutDirConfig(dir: string, outDir: string): string {
+    const configPath = resolve(dir, "inkline.config.mjs");
+    writeFileSync(configPath, `export default { outDir: ${JSON.stringify(outDir)} };\n`);
+    return configPath;
+  }
+
+  it("prefers the --out-dir flag over the config file's outDir", async () => {
+    const base = tmpDir("out-dir-flag");
+    const fromConfig = resolve(base, "a");
+    const fromFlag = resolve(base, "b");
+    const configPath = writeOutDirConfig(base, fromConfig);
+
+    const { exitCode } = await runCompile([
+      SOURCE(),
+      "--target",
+      "react",
+      "--config",
+      configPath,
+      "--out-dir",
+      fromFlag,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(resolve(fromFlag, "react", "Counter.tsx"))).toBe(true);
+    expect(existsSync(fromConfig)).toBe(false);
+  });
+
+  it("falls back to the config file's outDir when the flag is absent", async () => {
+    const base = tmpDir("out-dir-config");
+    const fromConfig = resolve(base, "a");
+    const configPath = writeOutDirConfig(base, fromConfig);
+
+    const { exitCode } = await runCompile([SOURCE(), "--target", "react", "--config", configPath]);
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(resolve(fromConfig, "react", "Counter.tsx"))).toBe(true);
+  });
+
+  it("falls back to dist when neither the flag nor the config sets an output directory", async () => {
+    // `dist` resolves against the process cwd, so run from an empty temp dir that also has no
+    // discoverable inkline.config.* — otherwise the repo's own config/dist would be in play.
+    const base = tmpDir("out-dir-default");
+    const cwd = process.cwd();
+    process.chdir(base);
+    try {
+      const { exitCode } = await runCompile([SOURCE(), "--target", "react"]);
+      expect(exitCode).toBe(0);
+      expect(existsSync(resolve(base, "dist", "react", "Counter.tsx"))).toBe(true);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});
+
 describe("compile command watch mode", () => {
   it("rebuilds on a component change and regenerates stories on a story change", async () => {
     const configDir = tmpDir("watch");

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -105,7 +105,9 @@ export default defineCommand({
     pattern: { type: "positional", description: "Glob pattern for .ink.tsx files", required: true },
     target: { type: "string", description: "Comma-separated targets" },
     "src-dir": { type: "string", description: "Source root directory to strip from output paths" },
-    "out-dir": { type: "string", description: "Default output directory", default: "dist" },
+    // No citty `default` here: it would make `args["out-dir"]` always defined, so the resolution
+    // chain below could never fall through to the config file. The `"dist"` fallback lives there.
+    "out-dir": { type: "string", description: "Default output directory (default: dist)" },
     "source-map": { type: "string", description: "external | inline | none", default: "external" },
     config: { type: "string", description: "Path to config file" },
     verbose: { type: "boolean", description: "Verbose plugin error logs", default: false },
@@ -127,7 +129,10 @@ export default defineCommand({
     }
 
     const targets = targetStr.split(",").map((t) => t.trim()) as TargetName[];
-    const outDir = fileConfig.outDir ?? args["out-dir"] ?? "dist";
+    // Flag > config > default, matching `--target`, `--src-dir` and `--source-map`. Note that a
+    // config `targetOutDir` entry is a per-target absolute override and still wins for that target
+    // (see `resolveTargetDir`): the more specific setting beats the general one either way.
+    const outDir = args["out-dir"] ?? fileConfig.outDir ?? "dist";
     const targetOutDir = fileConfig.targetOutDir ?? {};
     const barrels = fileConfig.barrels ?? DEFAULT_BARRELS;
     const namedGroups = barrels.filter((g) => g.mode !== "namespace");


### PR DESCRIPTION
## Summary

`inkline compile --out-dir <path>` was silently ignored whenever a config file set `outDir`. This inverts the resolution order so the CLI flag wins, matching every neighbouring option.

Closes UXF-79.

## Changes

- `tooling/cli/src/commands/compile.ts:135` — `args["out-dir"] ?? fileConfig.outDir ?? "dist"` (was config-first).
- `tooling/cli/src/commands/compile.ts:110` — removed the citty `default: "dist"` on the flag. With it, `args["out-dir"]` was never `undefined`, so the config branch of the `??` chain was unreachable and the flag was dead code for any project with a config file. `"dist"` remains the final fallback in the resolution chain; the default is now documented in the flag description instead.
- `targetOutDir` is untouched: a per-target entry is a specific override and still wins for the targets it names (`resolveTargetDir`). Documented inline.
- Changeset (`@inkline/cli`, patch) describing the behaviour change.

## Verification

Three tests added in `tooling/cli/src/commands/compile.test.ts` covering the full precedence chain:

| case | expected |
| --- | --- |
| config `outDir: a` + `--out-dir b` | writes to `b`, `a` never created |
| config `outDir: a`, no flag | writes to `a` |
| no config, no flag | writes to `dist` (run from a clean cwd) |

- `vp test` in `tooling/cli`: **131 passed / 14 files**.
- Regression guard confirmed: reverting only the precedence line fails `prefers the --out-dir flag over the config file's outDir` and nothing else.
- `vp check`: no format, lint, or type errors across 34 files.

## Notes

**Behaviour change.** Anyone who passed `--out-dir` *and* set `outDir` in config previously got the config path; they now get the flag path. Fix is to drop the flag from that invocation. Called out in the changeset. Classified as a bug fix — the flag currently does nothing.

Out of scope but same root cause, worth a follow-up: `--source-map` also carries a citty `default: "external"`, which makes `fileConfig.sourceMap` unreachable in `compile.ts:140` for exactly the same reason. Left alone here to keep the diff and the behaviour change surgical.
