### PR TITLE
docs(compiler): correct the README props, config, and diagnostics reference

### DIFF
--- a/.changeset/compiler-readme-props-accuracy.md
+++ b/.changeset/compiler-readme-props-accuracy.md
@@ -1,0 +1,19 @@
+---
+"@inkline/compiler": patch
+---
+
+docs(compiler): correct the README props, config, and diagnostics reference
+
+The `Props` section now leads with the typed-parameter form (the form every component in
+`ui/components` uses), documents that defaults in that form are applied at the read site
+(`props.type ?? "button"`), and states the no-destructuring rule and why Solid requires it. The
+options-object form is retained — it is a real, per-target-tested feature — with a note that it does
+not type-check today because `ComponentOptions` in `@inkline/core` declares no `props` key and
+`defineComponent` cannot infer the setup parameter's type from the options object.
+
+Also corrected in the same pass:
+
+- The `INK0100` row described an emit failure; the code is raised on a parse failure.
+- The configuration table was missing `targetOutDir`, `tsconfig`, and `barrels`.
+- The diagnostics table listed 13 of 26 codes with no indication it was partial; it now points at
+  `pnpm docs:diagnostics`, generated from `src/core/diagnostics/codes.ts`.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -186,7 +186,7 @@ export default defineComponent(
 > `TS2339: Property 'color' does not exist on type '{}'`. Until the authoring types catch up, use
 > the typed-parameter form above.
 
-Everything that is *not* a prop also goes in the options object — `slots`, `events`, `runtime`,
+Everything that is _not_ a prop also goes in the options object — `slots`, `events`, `runtime`,
 `name`, and `meta`. Those keys are declared on `ComponentOptions` and type-check today, so they can
 be combined with a typed setup parameter:
 
@@ -438,7 +438,7 @@ export default defineConfig({
 | `targets`       | `TargetName[]`                                | (required)   | Targets to compile for.                                                                                                                                                                                                  |
 | `srcDir`        | `string`                                      | —            | Source root to strip from output paths (e.g. `"src"`). When set, directory structure below `srcDir` is preserved in the output. Without it, the deepest common prefix is used. Also available as `--src-dir` on the CLI. |
 | `outDir`        | `string`                                      | `"dist"`     | Output directory. Files are written to `<outDir>/<target>/`.                                                                                                                                                             |
-| `targetOutDir`  | `Partial<Record<TargetName, string>>`         | `{}`         | Per-target output directory override, replacing `<outDir>/<target>/` for the targets it names.                                                                                                                          |
+| `targetOutDir`  | `Partial<Record<TargetName, string>>`         | `{}`         | Per-target output directory override, replacing `<outDir>/<target>/` for the targets it names.                                                                                                                           |
 | `tsconfig`      | `string`                                      | —            | Path to a `tsconfig.json` whose ambient declarations (e.g. generated `*.d.ts` for virtual modules) are loaded into the per-file program, so `import type` from those modules resolves during prop analysis.              |
 | `barrels`       | `BarrelGroup[]`                               | (see note)   | Per-category re-export barrels written for each target. Read by `@inkline/cli` only — the compiler pipeline ignores it. Omitted, the CLI writes one `index.ts` per target containing every non-story component.          |
 | `sourceMap`     | `"external" \| "inline" \| "none"`            | `"external"` | Source map generation mode.                                                                                                                                                                                              |

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -109,9 +109,10 @@ The compiler tracks which signals each expression reads and maps them to the tar
 
 ### Props
 
-Props can be defined two ways:
-
-**TypeScript parameter type** (preferred):
+Props are declared by annotating the setup function's first parameter. The compiler reads that
+annotation — an inline type literal, or an `interface` / `type` in scope — and emits each target's
+native props declaration. Properties marked optional (`?`) are optional in the output; the rest are
+required.
 
 ```tsx
 export default defineComponent((props: { label: string; disabled?: boolean }) => {
@@ -119,7 +120,41 @@ export default defineComponent((props: { label: string; disabled?: boolean }) =>
 });
 ```
 
-**Options object** (for defaults and metadata):
+Beyond one or two props, declare a named and exported interface so consumers can import the type and
+other components can extend it:
+
+```tsx
+export interface ButtonProps {
+  label?: string;
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
+}
+
+export default defineComponent((props: ButtonProps) => {
+  return (
+    <button type={props.type ?? "button"} disabled={props.disabled}>
+      {props.label}
+    </button>
+  );
+});
+```
+
+This form has no default-value declaration. Apply the default where the prop is read
+(`props.type ?? "button"` above) — one expression that compiles to every target. This is the form
+every component in [`ui/components`](../../ui/components/) uses.
+
+**Never destructure the props object when authoring.** Reads must stay `props.x`: Solid passes props
+as a reactive proxy, so destructuring it in your setup body snapshots the value once and freezes it.
+The Solid target enforces this on its output with the `requirePropsNotDestructured` conformance
+invariant.
+
+**Options object** (for declared defaults):
+
+An options object passed as the first argument declares props with per-prop types, defaults, and a
+required flag. Types are inferred from a constructor reference (`Number` → `number`) or from the
+default value's literal type (`"blue"` → `string`). Each target applies the default in its own
+idiom — `withDefaults(defineProps<…>(), …)` on Vue, `mergeProps` on Solid, a destructured default on
+React/Svelte/Qwik/Astro, a seeded signal input (`input<string>('blue')`) on Angular.
 
 ```tsx
 export default defineComponent(
@@ -139,6 +174,27 @@ export default defineComponent(
   },
   (props) => {
     return <div style={`color: ${props.color}`}>{props.size}</div>;
+  },
+);
+```
+
+> **Known limitation — this form does not type-check yet.**
+> `ComponentOptions` in [`@inkline/core`](../core/src/index.ts) does not declare a `props` key, and
+> `defineComponent` cannot infer the setup parameter's type from the options object. The compiler
+> handles the form correctly (see the `PropDefaults` fixture and the per-target `props.test.ts`
+> suites), but `tsc` reports `TS2353: 'props' does not exist in type 'ComponentOptions'` and
+> `TS2339: Property 'color' does not exist on type '{}'`. Until the authoring types catch up, use
+> the typed-parameter form above.
+
+Everything that is *not* a prop also goes in the options object — `slots`, `events`, `runtime`,
+`name`, and `meta`. Those keys are declared on `ComponentOptions` and type-check today, so they can
+be combined with a typed setup parameter:
+
+```tsx
+export default defineComponent(
+  { slots: { default: {} }, meta: { headless: true } },
+  (props: ButtonProps) => {
+    return <button disabled={props.disabled}>{props.label}</button>;
   },
 );
 ```
@@ -382,6 +438,9 @@ export default defineConfig({
 | `targets`       | `TargetName[]`                                | (required)   | Targets to compile for.                                                                                                                                                                                                  |
 | `srcDir`        | `string`                                      | —            | Source root to strip from output paths (e.g. `"src"`). When set, directory structure below `srcDir` is preserved in the output. Without it, the deepest common prefix is used. Also available as `--src-dir` on the CLI. |
 | `outDir`        | `string`                                      | `"dist"`     | Output directory. Files are written to `<outDir>/<target>/`.                                                                                                                                                             |
+| `targetOutDir`  | `Partial<Record<TargetName, string>>`         | `{}`         | Per-target output directory override, replacing `<outDir>/<target>/` for the targets it names.                                                                                                                          |
+| `tsconfig`      | `string`                                      | —            | Path to a `tsconfig.json` whose ambient declarations (e.g. generated `*.d.ts` for virtual modules) are loaded into the per-file program, so `import type` from those modules resolves during prop analysis.              |
+| `barrels`       | `BarrelGroup[]`                               | (see note)   | Per-category re-export barrels written for each target. Read by `@inkline/cli` only — the compiler pipeline ignores it. Omitted, the CLI writes one `index.ts` per target containing every non-story component.          |
 | `sourceMap`     | `"external" \| "inline" \| "none"`            | `"external"` | Source map generation mode.                                                                                                                                                                                              |
 | `targetOptions` | `Record<TargetName, Record<string, unknown>>` | `{}`         | Per-target options. Unknown keys produce INK0080 warnings.                                                                                                                                                               |
 | `plugins`       | `Plugin[]`                                    | `[]`         | Compiler plugins.                                                                                                                                                                                                        |
@@ -774,6 +833,10 @@ See `docs/adding-a-target.md` for a complete walkthrough.
 
 The compiler produces diagnostics at each pipeline stage. Errors prevent output; warnings are informational.
 
+The codes below are the ones most authors hit. For the complete, always-current list, run
+`pnpm docs:diagnostics` in `core/compiler` — it prints a reference table generated from
+[`src/core/diagnostics/codes.ts`](./src/core/diagnostics/codes.ts), the single source of truth.
+
 | Code    | Severity | Description                                                                                                                             |
 | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | INK0001 | error    | Namespace import (`import * as`) of @inkline/core is not supported. Use named imports.                                                  |
@@ -788,7 +851,7 @@ The compiler produces diagnostics at each pipeline stage. Errors prevent output;
 | INK0070 | error    | Component-ref forwarding is not yet supported (v1).                                                                                     |
 | INK0080 | warning  | Unknown key in `targetOptions`.                                                                                                         |
 | INK0090 | error    | A plugin threw an exception.                                                                                                            |
-| INK0100 | error    | Component failed during emit. Other components continue.                                                                                |
+| INK0100 | error    | Parse failure in a component. That component is skipped; the others in the module still compile.                                        |
 
 Run `inkline check <file>` to check without producing output.
 


### PR DESCRIPTION
## Summary

`core/compiler/README.md` opened the Props section with a `defineComponent` options-object example
that does not type-check. Copying it produces:

```
error TS2353: Object literal may only specify known properties, and 'props' does not exist in type 'ComponentOptions'.
error TS2339: Property 'color' does not exist on type '{}'.
error TS2339: Property 'size' does not exist on type '{}'.
```

The API itself is real: the parser handles `props` in the options object
(`src/pipeline/passes/02-parse/options.ts`), every target emits and defaults it, and
`src/__fixtures__/PropDefaults.ink.tsx` is that example almost verbatim. The gap is in the authoring
types — `ComponentOptions` in `core/core/src/index.ts` declares five keys and `props` is not one of
them, and `defineComponent` cannot infer the setup parameter's type from the options object. It went
unnoticed because `core/compiler/tsconfig.json` excludes `src/__fixtures__/**`, so the fixture is
never type-checked.

The section is therefore kept and annotated rather than deleted, and the typed-parameter form —
the one every component in `ui/components` actually uses — now leads it.

## Changes

- **Props section rewritten.** Typed-parameter form first, with the named-interface variant and the
  read-site default idiom (`props.type ?? "button"`). Adds the no-destructuring rule and why Solid
  requires it. The options-object form follows, with its per-target default idioms and a
  `Known limitation` callout carrying the exact `tsc` errors.
- **`INK0100`** was described as "Component failed during emit"; the code is raised on a parse
  failure and the component is skipped.
- **Configuration table** gained the three real `InklineConfig` options it was missing:
  `targetOutDir`, `tsconfig`, `barrels`.
- **Diagnostics table** listed 13 of the 26 codes in `src/core/diagnostics/codes.ts` with no sign it
  was partial. It now says so and points at `pnpm docs:diagnostics`, which generates the full table
  from that module.
- Patch changeset for `@inkline/compiler`.

## Verification

Every `defineComponent` example in the README was extracted into a scratch project resolving
`@inkline/core` to `core/core/src/index.ts` with `jsx: react-jsx` / `jsxImportSource: @inkline/core`,
then type-checked with TypeScript 5.9.3. All examples pass except the annotated options-object one,
which reproduces the three errors quoted above.

The options-object form was compiled to confirm it is a working feature, not an accident:

```
$ node --experimental-strip-types ... compile PropDefaults.ink.tsx --targets react,vue,solid,angular
--- react ---
export function PropDefaults(props: { color?: string; size: number } & React.HTMLAttributes<HTMLElement>)
{ const { color = "blue", size, ...__attrs } = props ... }
--- vue ---
const props = withDefaults(defineProps<{ color?: string; size: number }>(), { color: "blue" })
--- solid ---
const props = mergeProps({ color: "blue" }, _props)
--- angular ---
color = input<string>('blue')
size = input.required<number>()
diagnostics: []
```

`pnpm docs:diagnostics` was run (via its underlying `node scripts/gen-diagnostics.ts`) and prints the
full 26-code table.

## Notes

Two follow-ups found in the same sweep, neither fixed here because both are code changes rather than
documentation:

1. **`ComponentOptions` is missing `props` and `style`.** Both keys are parsed by the compiler and
   have per-target tests; neither is declared in `core/core/src/index.ts`. Inferring the setup
   parameter's type from the options object is the second half of the fix. Excluding
   `src/__fixtures__/**` from `tsconfig.json` is what hides this from CI.
2. **`@inkline/compiler/testing` is documented but not exported.** The README, `docs/architecture.md`,
   and `docs/scope.md` all reference the subpath; `core/compiler/package.json` exports only `.` and
   `./package.json`, so the import fails to resolve for consumers.

Verified as accurate and left unchanged: the primitives table, reactive-read mapping table,
two-way-binding and `defineEmits` sections, slots and `hasSlot` (including the per-target lowering
table), control flow, lifecycle, refs, the seven target names, all CLI commands and flags, the
programmatic API and `CompileResult` shape, the plugin hooks, `defineTarget` / Code IR builders, and
the testing harness list — every exported name checked against `src/index.ts` and
`src/testing/index.ts`.

