### PR TITLE
docs: establish decision records and file ADR-001 on compiler diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ testing/     @inkline/e2e (Playwright cross-framework visual-parity tests)
 ui/          @inkline/components (single source of truth) + 7 framework output packages
 apps/        website (docs site), storybook (unified aggregator for all 7 frameworks)
 docs/        architecture, conventions, contributing, release-process, authoring, maintenance
+docs/adrs/   architecture decision records — why the codebase is the way it is
 .changeset/  pending changesets — one markdown file per upcoming change
 .github/     CI + changesets workflows, issue/PR templates, community health files
 .old/        archived v0 codebase — read-only reference, do not edit or link into
@@ -62,6 +63,7 @@ Per topic — read the relevant `docs/`:
 | [docs/contributing.md](./docs/contributing.md)                 | Dev workflow, before-PR checklist, CI gate                         |
 | [docs/release-process.md](./docs/release-process.md)           | Changesets + npm publish flow                                      |
 | [docs/maintenance.md](./docs/maintenance.md)                   | How we keep docs from drifting                                     |
+| [docs/adrs/README.md](./docs/adrs/README.md)                   | Why the codebase is the way it is — decision records               |
 
 For the user-facing language reference (primitives, control flow, options), the canonical source is [`core/compiler/README.md`](./core/compiler/README.md).
 

--- a/docs/adrs/001-compiler-dx-invests-in-diagnostics.md
+++ b/docs/adrs/001-compiler-dx-invests-in-diagnostics.md
@@ -10,7 +10,7 @@ The goal set for this round of work was that reading and writing `.ink.tsx` shou
 experience. Two investigations ran in parallel and independently: a survey of prior art in
 compiler and toolchain developer experience, and a hands-on friction audit of this repository.
 
-**Scope note.** The compiler in `core/compiler` is a *component* compiler — `.ink.tsx` with signal
+**Scope note.** The compiler in `core/compiler` is a _component_ compiler — `.ink.tsx` with signal
 primitives to per-target component output via a typed IR ([`core/compiler/package.json`](../../core/compiler/package.json)).
 It is not a styling engine. Styling belongs to the upstream `styleframe` project, so
 token-authoring prior art (Tailwind v4 `@theme`, UnoCSS) was routed there and is out of scope here.
@@ -33,7 +33,7 @@ pipeline and discarded at the last step. The survey and the audit reached this c
 separately and cited the same file.
 
 **The survey under-weighted one class of problem.** The audit's highest-ranked findings were not bad
-diagnostics — they were *absent* ones: JSX spread attributes discarded with no diagnostic and exit
+diagnostics — they were _absent_ ones: JSX spread attributes discarded with no diagnostic and exit
 code 0; nothing type-checking `.ink.tsx`; unknown configuration keys ignored; a documented API that
 does not exist. Every exemplar in the survey (rustc, Elm, Biome, Vite, Sass) improves diagnostics
 that already fire. None of them has a story for a compiler that stays quiet. A code frame drawn on
@@ -48,14 +48,14 @@ three times in one sentence.
 
 **Options that were live and were not chosen this round:**
 
-- *Build-architecture work* (Vite's model: dev cost proportional to the modules on the page, not the
+- _Build-architecture work_ (Vite's model: dev cost proportional to the modules on the page, not the
   project). Declined because the measurement above says there is nothing to fix yet.
-- *Structured autofix suggestions* (rustc `Applicability`, Biome `CodeSuggestion` with safe/unsafe
+- _Structured autofix suggestions_ (rustc `Applicability`, Biome `CodeSuggestion` with safe/unsafe
   fixes). Deferred, not rejected — see the Decision.
-- *A dev-time inspector* (UnoCSS `/__unocss`: per-token, per-file attribution of what the tool did
+- _A dev-time inspector_ (UnoCSS `/__unocss`: per-token, per-file attribution of what the tool did
   and why). Strong option, genuinely useful, but it explains correct output; it does not help the
   case where the output is silently wrong.
-- *Library-author diagnostics* (Sass `@error`/`@warn`, where a library's error message points its
+- _Library-author diagnostics_ (Sass `@error`/`@warn`, where a library's error message points its
   caret at the consumer's call site). Valuable once there is a third-party component ecosystem;
   premature before one exists.
 
@@ -93,7 +93,7 @@ machine-readable confidence level ships in the same release as the first suggest
 - **The strongest evidence available argues this may not work.** Santos & Becker (UKICER 2024,
   arXiv:2409.18661, n=106) found that error-message enhancement has shown "weak to insignificant
   results", that handwritten explanations beat both LLM-generated and conventional messages, and —
-  most damaging — that preference and performance *dissociate*: users rate verbose messages higher
+  most damaging — that preference and performance _dissociate_: users rate verbose messages higher
   while fixing bugs no faster. We are accepting this risk with one mitigation: acceptance criteria
   measure time-to-fix on a fixed scenario set, never satisfaction. A slice that ships and cannot show
   a time-to-fix improvement has failed, regardless of how it feels.

--- a/docs/adrs/001-compiler-dx-invests-in-diagnostics.md
+++ b/docs/adrs/001-compiler-dx-invests-in-diagnostics.md
@@ -1,0 +1,141 @@
+# ADR-001: Invest compiler DX in diagnostics, ordered coverage → rendering → prose
+
+Date: 2026-07-27 · Status: Accepted
+Deciders: Project owner · Informed by: internal tracker UXF-70 (goal), UXF-71 (friction audit), UXF-72 (prior-art survey)
+Supersedes: — · Superseded by: —
+
+## Context
+
+The goal set for this round of work was that reading and writing `.ink.tsx` should be a good
+experience. Two investigations ran in parallel and independently: a survey of prior art in
+compiler and toolchain developer experience, and a hands-on friction audit of this repository.
+
+**Scope note.** The compiler in `core/compiler` is a *component* compiler — `.ink.tsx` with signal
+primitives to per-target component output via a typed IR ([`core/compiler/package.json`](../../core/compiler/package.json)).
+It is not a styling engine. Styling belongs to the upstream `styleframe` project, so
+token-authoring prior art (Tailwind v4 `@theme`, UnoCSS) was routed there and is out of scope here.
+
+**Latency is not the constraint.** The friction audit measured a full build of 67 files at 0.45s and
+a warm incremental rebuild at 209ms. This retired the branch of the survey that would have argued
+for build-architecture work ahead of everything else.
+
+**The diagnostic data model is mostly right; the renderer is not.** Today the compiler has 29 stable
+codes with severity, an optional `help` channel, and a canonical docs URL
+([`core/compiler/src/core/diagnostics/codes.ts`](../../core/compiler/src/core/diagnostics/codes.ts)),
+typed placeholder parameters, an auto-generated reference
+([`core/compiler/scripts/gen-diagnostics.ts`](../../core/compiler/scripts/gen-diagnostics.ts)), and a
+`SourceLocation` that carries `offset` and `length`
+([`core/compiler/src/ir/types.ts`](../../core/compiler/src/ir/types.ts)). The CLI formatter is ten
+lines and prints `file:line:col severity code title` plus `help` and `docs`
+([`tooling/cli/src/lib/diagnostics.ts`](../../tooling/cli/src/lib/diagnostics.ts)). It never prints
+the user's source. The span data needed to draw a code frame is carried the whole way through the
+pipeline and discarded at the last step. The survey and the audit reached this conclusion
+separately and cited the same file.
+
+**The survey under-weighted one class of problem.** The audit's highest-ranked findings were not bad
+diagnostics — they were *absent* ones: JSX spread attributes discarded with no diagnostic and exit
+code 0; nothing type-checking `.ink.tsx`; unknown configuration keys ignored; a documented API that
+does not exist. Every exemplar in the survey (rustc, Elm, Biome, Vite, Sass) improves diagnostics
+that already fire. None of them has a story for a compiler that stays quiet. A code frame drawn on
+a diagnostic that never fires is worth nothing, so coverage has to precede rendering.
+
+**Prose quality is measurably incomplete.** 7 of the 29 codes carry `help: undefined` (`INK0060`,
+`INK0061`, `INK0062`, `INK0065`, `INK0066`, `INK0080`, `INK0090`). Separately, `DiagnosticParams`
+extracts placeholders from `title` only, and the collector interpolates `title` but assigns `help`
+verbatim ([`core/compiler/src/core/diagnostics/collector.ts`](../../core/compiler/src/core/diagnostics/collector.ts)),
+so `help` strings containing `{name}` reach the terminal with the braces intact — `INK0121` does this
+three times in one sentence.
+
+**Options that were live and were not chosen this round:**
+
+- *Build-architecture work* (Vite's model: dev cost proportional to the modules on the page, not the
+  project). Declined because the measurement above says there is nothing to fix yet.
+- *Structured autofix suggestions* (rustc `Applicability`, Biome `CodeSuggestion` with safe/unsafe
+  fixes). Deferred, not rejected — see the Decision.
+- *A dev-time inspector* (UnoCSS `/__unocss`: per-token, per-file attribution of what the tool did
+  and why). Strong option, genuinely useful, but it explains correct output; it does not help the
+  case where the output is silently wrong.
+- *Library-author diagnostics* (Sass `@error`/`@warn`, where a library's error message points its
+  caret at the consumer's call site). Valuable once there is a third-party component ecosystem;
+  premature before one exists.
+
+## Decision
+
+We will spend the compiler developer-experience budget on diagnostics, in this order:
+
+1. **Coverage.** Emit a diagnostic wherever the compiler currently fails silently or throws a raw
+   error that bypasses the diagnostics pipeline.
+2. **Rendering.** Render diagnostics with the user's own source and a caret under the span, using the
+   `offset` and `length` already carried on `SourceLocation`, and print paths relative to the project
+   root rather than absolute.
+3. **Prose.** Every code carries an actionable `help`; placeholders resolve in `help` as well as
+   `title`; `help` says what to change and nothing else.
+
+Structured autofix suggestions are **deferred** until (2) has shipped. If they are ever built, a
+machine-readable confidence level ships in the same release as the first suggestion — not later.
+
+## Consequences
+
+**Good.**
+
+- The three steps are ordered so each one is worth something on its own; nothing is blocked on the
+  step after it.
+- Every step is a two-way door. Nothing here changes the authoring surface, the public API, or the
+  compiled output.
+- The data model already supports all three; this is renderer and catalogue work, not a redesign.
+- Deferring suggestions defers the expensive part. In `rust-lang/rust`, measured 2026-07-27, there
+  are 915 issues labelled `A-suggestion-diagnostics` and 95 open issues with "incorrect" in the
+  title. Wrong suggestions are permanent maintenance; the confidence level is the pressure valve,
+  which is why it is a release-gating condition rather than a follow-up.
+
+**Bad.**
+
+- **The strongest evidence available argues this may not work.** Santos & Becker (UKICER 2024,
+  arXiv:2409.18661, n=106) found that error-message enhancement has shown "weak to insignificant
+  results", that handwritten explanations beat both LLM-generated and conventional messages, and —
+  most damaging — that preference and performance *dissociate*: users rate verbose messages higher
+  while fixing bugs no faster. We are accepting this risk with one mitigation: acceptance criteria
+  measure time-to-fix on a fixed scenario set, never satisfaction. A slice that ships and cannot show
+  a time-to-fix improvement has failed, regardless of how it feels.
+- **The prose is a permanent cost, and it is the expensive half.** Elm's reputation for good errors
+  rests on `Reporting/Error/Syntax.hs`, 5,903 lines of hand-written prose; rustc maintains 518
+  mandatory error-code explanation files. The plumbing is cheap and finite. The writing is neither.
+  Committing to "every code carries an actionable `help`" commits every future diagnostic to the same
+  bar, forever.
+- **More output is a real failure mode in the best implementations.** `rust-lang/rust#115382` is a
+  filed regression about verbosity burying the actual error. A green build here already prints 26
+  informational diagnostics with no summary and no deduplication; adding a source frame to each one
+  makes that worse before a severity and volume policy makes it better.
+- Step 1 will turn currently-green builds red for anyone relying on the silent behaviour. That is the
+  intent, but it is a real cost paid by existing consumers.
+
+**Neutral.**
+
+- The CLI renderer becomes a larger, tested component rather than a ten-line function, and the
+  diagnostic catalogue acquires an editorial standard that reviewers must enforce.
+
+## Revisit triggers
+
+Written now, before any of it ships:
+
+- The instrumented scenario set shows no measurable time-to-fix improvement after step 2 lands. Then
+  Santos & Becker was right about this codebase and the remaining diagnostic budget moves elsewhere.
+- Full-project compile p95 exceeds 2s, or warm incremental exceeds 500ms. Then the latency branch of
+  the survey re-opens and outranks the rest of this.
+- Diagnostic volume on a green build grows past what a reader will scan, or more than three reports
+  arrive of a real error being buried. Then a volume policy (Biome caps output at 20 diagnostics by
+  default) precedes any further rendering work.
+- Autofix suggestions are proposed without a confidence level attached. That is a supersede, not an
+  exception.
+- A decision lands on typing the authoring surface. Typed JSX changes which diagnostics matter and
+  which ones the type checker subsumes, and this ordering should be re-derived rather than assumed.
+
+## Explicitly still undecided
+
+This ADR covers reversible work only. The following were identified in the same round, are one-way
+doors, and are **not** decided here:
+
+- Giving JSX a real `IntrinsicElements` type and type-checking `.ink.tsx`.
+- Narrowing the compiler's public export surface.
+
+Each needs its own RFC and its own ADR before any code is written.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,41 @@
+# Architecture Decision Records
+
+An ADR records a decision that was **actually made** — the context that made it reasonable, the
+decision itself, and the consequences we accepted, including the bad ones. The point is that nobody
+pays for the same lesson twice.
+
+## Index
+
+| #                                                            | Title                                                       | Date       | Status   | Tags                     |
+| ------------------------------------------------------------ | ----------------------------------------------------------- | ---------- | -------- | ------------------------ |
+| [001](./001-compiler-dx-invests-in-diagnostics.md)           | Invest compiler DX in diagnostics, ordered coverage → rendering → prose | 2026-07-27 | Accepted | compiler, cli, dx        |
+
+## Rules
+
+- **Immutable.** An ADR is append-only history. Never edit its substance to match new reality —
+  that turns the archive into retroactive fiction. Typo and link fixes are fine.
+- **Superseding.** Changed decision? Write a new ADR with `Supersedes: ADR-NNN`; flip the old one's
+  status to `Superseded` and add `Superseded by: ADR-MMM`. The chain is the memory.
+- **Statuses.** `Proposed` → `Accepted` → `Superseded` | `Deprecated`.
+- **Numbering.** Sequential, zero-padded to three digits, never reused.
+- **The "Bad" consequences section is mandatory.** An ADR with only upside is a press release.
+- **Revisit triggers are written at decision time**, while judgment is cold — not retrofitted when
+  the decision starts hurting.
+
+## What gets an ADR
+
+Any one of these qualifies:
+
+- Hard or expensive to reverse.
+- Others will build on the assumption.
+- The losing option was real — the decision was genuinely contested.
+- A decision **not** to do something. These prevent the most expensive re-litigations.
+- An override of a recommendation, recorded with the same care as any other decision.
+
+Not ADR material: implementation details inside one owner's lane, reversible defaults, taste.
+
+## See also
+
+- [conventions.md](../conventions.md) — code, file, test, and commit conventions.
+- [architecture.md](../architecture.md) — how `.ink.tsx` becomes seven framework outputs.
+- [scope.md](../scope.md) — capability boundaries and what is deferred.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,9 +6,9 @@ pays for the same lesson twice.
 
 ## Index
 
-| #                                                            | Title                                                       | Date       | Status   | Tags                     |
-| ------------------------------------------------------------ | ----------------------------------------------------------- | ---------- | -------- | ------------------------ |
-| [001](./001-compiler-dx-invests-in-diagnostics.md)           | Invest compiler DX in diagnostics, ordered coverage → rendering → prose | 2026-07-27 | Accepted | compiler, cli, dx        |
+| #                                                  | Title                                                                   | Date       | Status   | Tags              |
+| -------------------------------------------------- | ----------------------------------------------------------------------- | ---------- | -------- | ----------------- |
+| [001](./001-compiler-dx-invests-in-diagnostics.md) | Invest compiler DX in diagnostics, ordered coverage → rendering → prose | 2026-07-27 | Accepted | compiler, cli, dx |
 
 ## Rules
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -38,6 +38,7 @@ Use this table when reviewing your own PR. If the left column changed, check the
 | Storybook port assignments or topology                                                                                    | [contributing.md](./contributing.md), [`apps/storybook/AGENTS.md`](../apps/storybook/AGENTS.md), the per-framework UI AGENTS.md files                  |
 | Adding/removing a workspace package                                                                                       | [AGENTS.md](../AGENTS.md), [architecture.md](./architecture.md) "Dependency layering", create a new `AGENTS.md` for the package                        |
 | Adding a new compilation target                                                                                           | [architecture.md](./architecture.md), [`core/compiler/AGENTS.md`](../core/compiler/AGENTS.md), [adding-a-target.md](./adding-a-target.md)              |
+| Making a decision that is hard to reverse, was genuinely contested, or that others will build on                          | File an ADR in [`docs/adrs/`](./adrs/) and add it to the [index](./adrs/README.md)                                                                     |
 
 This list itself is a duplication risk — keep it short, prefer adding `[[link]]`s in docs over expanding the table.
 
@@ -77,3 +78,4 @@ If a section is starting to feel like a duplicate-prone list (e.g. a registry, a
 - [conventions.md](./conventions.md) — what conventions these docs enforce.
 - [contributing.md](./contributing.md) → "Pull requests" — the soft expectation that docs travel with code.
 - [AGENTS.md](../AGENTS.md) — the entry point this maintenance protects.
+- [adrs/README.md](./adrs/README.md) — decision records. Unlike the docs above, ADRs are immutable: they are never updated to match new reality, only superseded.


### PR DESCRIPTION
## Summary

Establishes `docs/adrs/` as the repository's decision archive and files the first record. ADR-001 captures the decision to spend the compiler developer-experience budget on diagnostics, in the order coverage → rendering → prose, with structured autofix suggestions deferred until a machine-readable confidence level can ship alongside them.

The decision was made in response to two parallel investigations: a survey of compiler and toolchain developer-experience prior art, and a hands-on friction audit of this repository. Both concluded independently that the diagnostic data model is largely right and the renderer is the gap. The audit additionally found a class the survey had under-weighted — cases where no diagnostic fires at all — which is why coverage is ordered ahead of rendering.

## Related issues

Tracked internally as UXF-70 / UXF-71 / UXF-72. The first implementation slices are already landing (#529, #531).

## Type of change

- [x] `docs` — documentation only

## Changes

- `docs/adrs/README.md` — index, immutability and superseding rules, statuses, numbering, and the criteria for what qualifies as an ADR.
- `docs/adrs/001-compiler-dx-invests-in-diagnostics.md` — the record itself: context with file-level receipts, the decision, good/bad/neutral consequences, revisit triggers written at decision time, and an explicit list of the adjacent one-way doors that are **not** decided here.
- `AGENTS.md` — the new directory added to the workspace map and to the per-topic docs table.
- `docs/maintenance.md` — a cross-reference row ("if you make a hard-to-reverse decision, file an ADR") and a "See also" note recording that ADRs are exempt from the usual keep-it-current rule because they are immutable.

## Verification

- Documentation only. No source, no published-package behavior, no API or type changes, so no changeset.
- Every claim in ADR-001 is cited to a file in this repository and was re-read on `main` at `141b28443` before writing:
  - `tooling/cli/src/lib/diagnostics.ts` — the formatter is 10 lines and prints no source frame.
  - `core/compiler/src/ir/types.ts` — `SourceLocation` carries `offset` and `length`.
  - `core/compiler/src/core/diagnostics/codes.ts` — 29 codes, of which 7 have `help: undefined` (`INK0060`, `INK0061`, `INK0062`, `INK0065`, `INK0066`, `INK0080`, `INK0090`); `DiagnosticParams` extracts placeholders from `title` only.
  - `core/compiler/src/core/diagnostics/collector.ts` — `resolvePlaceholders` is applied to `title`; `help` is assigned verbatim.
- The `@inkline/agents-check` link-integrity rule was run against the working tree using the same walk, extraction, and resolution logic as `tooling/agents-check/src/link-integrity.test.ts`: all relative links resolve.

## Notes

ADR-001 records the decision, not a plan of work — the implementation is tracked separately and has already begun. Two adjacent decisions are deliberately left open and called out at the bottom of the record: giving JSX a real `IntrinsicElements` type, and narrowing the compiler's public export surface. Both are one-way doors and each needs its own RFC before any code is written.

The "Bad consequences" section leads with evidence that argues against the decision — Santos & Becker (UKICER 2024, n=106) found error-message enhancement produces weak to insignificant results and that user preference and user performance dissociate. That is deliberate. The mitigation is written into the record: acceptance criteria measure time-to-fix, never satisfaction.
