### PR TITLE
feat(compiler): ship the documented @inkline/compiler/testing subpath

### DIFF
--- a/.changeset/compiler-testing-subpath-export.md
+++ b/.changeset/compiler-testing-subpath-export.md
@@ -1,0 +1,22 @@
+---
+"@inkline/compiler": minor
+---
+
+feat(compiler): ship the documented `@inkline/compiler/testing` subpath
+
+The README, `docs/testing.md`, `docs/architecture.md` and `docs/scope.md` all pointed at
+`@inkline/compiler/testing`, but `package.json` only exported `.` and `./package.json`, so the
+import failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` for every consumer of the published package.
+`src/testing/index.ts` is now a second build entry with a matching `./testing` export condition,
+and the fixtures it reads at runtime (`src/__fixtures__/`) ship with the package so
+`compileFixture` and `scenarios` work outside the repo.
+
+The framework runtimes and lint tools the harnesses use (`react`, `react-dom`, `vue`,
+`@vue/server-renderer`, `solid-js`, `svelte`, `eslint`, `oxlint`, `tinybench`) are declared as
+**optional peer dependencies** rather than bundled — without that the published tarball grew from
+328 kB to 7.3 MB. `runBenchSuite` now loads `tinybench` lazily so the subpath still imports when
+it is not installed. Install only the peers for the harnesses you actually call.
+
+No source file imported the subpath, so the gap was invisible in CI. A packaging test now packs a
+tarball, resolves `@inkline/compiler/testing` through Node's exports algorithm and compiles a
+fixture through it, failing if the build entry or the export condition goes missing.

--- a/.changeset/compiler-testing-subpath-export.md
+++ b/.changeset/compiler-testing-subpath-export.md
@@ -19,4 +19,6 @@ it is not installed. Install only the peers for the harnesses you actually call.
 
 No source file imported the subpath, so the gap was invisible in CI. A packaging test now packs a
 tarball, resolves `@inkline/compiler/testing` through Node's exports algorithm and compiles a
-fixture through it, failing if the build entry or the export condition goes missing.
+fixture through it, failing if the build entry or the export condition goes missing. It also parses
+the emitted bundles and fails on any static import of a package listed in `peerDependenciesMeta`,
+since a declared peer is externalised rather than inlined and would otherwise regress silently.

--- a/core/compiler/AGENTS.md
+++ b/core/compiler/AGENTS.md
@@ -117,7 +117,11 @@ Run from this package: `vp test`. Run the full repo: `vp run -r test`. The bench
 
 ## Build
 
-`vp pack` produces a single ESM bundle (`dist/index.mjs`) + types (`dist/index.d.mts`). `vp pack --watch` for incremental rebuild during development.
+`vp pack` produces two ESM bundles + types: `dist/index.mjs` (the `.` export) and `dist/testing.mjs` (the `@inkline/compiler/testing` subpath). `vp pack --watch` for incremental rebuild during development.
+
+Two things keep the `testing` subpath honest, and both must move together — a `pack.entry` in [`vite.config.ts`](./vite.config.ts) and an `exports["./testing"]` condition in `package.json`. [`testing/subpath-export.test.ts`](./src/testing/subpath-export.test.ts) packs a tarball and imports it as a consumer would, so drift between the two fails CI instead of shipping.
+
+The framework runtimes and lint tools the harnesses reach for (`react`, `vue`, `svelte`, `solid-js`, `eslint`, `oxlint`, `tinybench`, …) are **optional peer dependencies**. Load them with `await import(…)`, never a static import: a static one both inlines the whole runtime into the published bundle and breaks the subpath for anyone who has not installed it. `src/__fixtures__/` ships in `files` because `compileFixture` and `scenarios` read it at runtime.
 
 The compiler ships **no runtime code** for components — it is library code consumed by the CLI ([`@inkline/cli`](../../tooling/cli/)), the build plugin ([`@inkline/plugin`](../plugin/)), and end users calling `compile()` programmatically.
 

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -915,6 +915,13 @@ import {
 | `expectMappingAt(file, line, col)`                        | Assert a source-map mapping exists at a position.                                               |
 | `verifyIdentifierMappings(file, identifiers, tolerance?)` | Verify identifier positions round-trip through source maps.                                     |
 
+The framework runtimes and lint tools these harnesses drive — `react`, `react-dom`, `vue`,
+`@vue/server-renderer`, `solid-js`, `svelte`, `eslint`, `oxlint`, `tinybench` — are **optional peer
+dependencies**, loaded on demand. Install only the ones the harnesses you call actually need.
+
+Fixture _names_ are not part of the semver contract: they exist to serve this compiler's own test
+suite and may be added, renamed or removed in any release.
+
 ---
 
 ## v0 Limitations

--- a/core/compiler/package.json
+++ b/core/compiler/package.json
@@ -14,7 +14,8 @@
     "directory": "core/compiler"
   },
   "files": [
-    "dist"
+    "dist",
+    "src/__fixtures__"
   ],
   "type": "module",
   "sideEffects": false,
@@ -22,6 +23,10 @@
     ".": {
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.mts",
+      "default": "./dist/testing.mjs"
     },
     "./package.json": "./package.json"
   },
@@ -69,6 +74,44 @@
     "vue-eslint-parser": "catalog:"
   },
   "peerDependencies": {
-    "typescript": ">=5.4 <8"
+    "@vue/server-renderer": ">=3.4",
+    "eslint": ">=9",
+    "oxlint": ">=1",
+    "react": ">=18",
+    "react-dom": ">=18",
+    "solid-js": ">=1.8",
+    "svelte": ">=5",
+    "tinybench": ">=6",
+    "typescript": ">=5.4 <8",
+    "vue": ">=3.4"
+  },
+  "peerDependenciesMeta": {
+    "@vue/server-renderer": {
+      "optional": true
+    },
+    "eslint": {
+      "optional": true
+    },
+    "oxlint": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "solid-js": {
+      "optional": true
+    },
+    "svelte": {
+      "optional": true
+    },
+    "tinybench": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    }
   }
 }

--- a/core/compiler/src/testing/bench.ts
+++ b/core/compiler/src/testing/bench.ts
@@ -1,12 +1,10 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import type { TaskResultWithStatistics } from "tinybench";
 import { compile } from "../pipeline/compile.ts";
-import { FIXTURES_DIR } from "./harness.ts";
+import { FIXTURES_DIR, PACKAGE_ROOT } from "./harness.ts";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const BASELINE_PATH = resolve(__dirname, "..", "..", ".bench-baseline.json");
+const BASELINE_PATH = resolve(PACKAGE_ROOT, ".bench-baseline.json");
 
 export interface BenchResult {
   readonly name: string;

--- a/core/compiler/src/testing/bench.ts
+++ b/core/compiler/src/testing/bench.ts
@@ -1,8 +1,9 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Bench, type TaskResultWithStatistics } from "tinybench";
+import type { TaskResultWithStatistics } from "tinybench";
 import { compile } from "../pipeline/compile.ts";
+import { FIXTURES_DIR } from "./harness.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BASELINE_PATH = resolve(__dirname, "..", "..", ".bench-baseline.json");
@@ -21,9 +22,10 @@ export interface BenchSuiteResult {
 }
 
 export async function runBenchSuite(): Promise<BenchSuiteResult> {
-  const fixturePath = resolve(__dirname, "..", "__fixtures__", "Counter.ink.tsx");
+  const fixturePath = resolve(FIXTURES_DIR, "Counter.ink.tsx");
   const source = readFileSync(fixturePath, "utf-8");
 
+  const { Bench } = await import("tinybench");
   const bench = new Bench({ warmupIterations: 3, iterations: 20 });
 
   bench.add("compile Counter (react)", async () => {

--- a/core/compiler/src/testing/harness.ts
+++ b/core/compiler/src/testing/harness.ts
@@ -7,14 +7,18 @@ import { compile, type AnalyzedModule } from "../pipeline/compile.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// This module lives at `src/testing/` in the repo but at `dist/` once packed,
-// while the fixtures ship under `src/__fixtures__` in both layouts.
-const REPO_FIXTURES_DIR = resolve(__dirname, "..", "__fixtures__");
-const PACKED_FIXTURES_DIR = resolve(__dirname, "..", "src", "__fixtures__");
+// This module lives at `src/testing/` in the repo but at `dist/` once packed, so every
+// path anchored here needs both layouts. The fixtures ship under `src/__fixtures__` in
+// the tarball, which puts them one level up only in the repo — that tells the two apart.
+const IS_REPO_LAYOUT = existsSync(resolve(__dirname, "..", "__fixtures__"));
 
-export const FIXTURES_DIR: string = existsSync(REPO_FIXTURES_DIR)
-  ? REPO_FIXTURES_DIR
-  : PACKED_FIXTURES_DIR;
+export const PACKAGE_ROOT: string = IS_REPO_LAYOUT
+  ? resolve(__dirname, "..", "..")
+  : resolve(__dirname, "..");
+
+export const FIXTURES_DIR: string = IS_REPO_LAYOUT
+  ? resolve(__dirname, "..", "__fixtures__")
+  : resolve(PACKAGE_ROOT, "src", "__fixtures__");
 
 export interface CompiledFixture {
   readonly ir?: AnalyzedModule;
@@ -28,6 +32,13 @@ export async function compileFixture(
 ): Promise<CompiledFixture> {
   const fileName = `${name}.ink.tsx`;
   const filePath = resolve(FIXTURES_DIR, fileName);
+  if (!existsSync(filePath)) {
+    throw new Error(
+      `Fixture "${fileName}" not found in ${FIXTURES_DIR}. ` +
+        `Fixtures ship with @inkline/compiler under src/__fixtures__; ` +
+        `an empty directory means the package was built without them.`,
+    );
+  }
   const source = readFileSync(filePath, "utf-8");
 
   const result = await compile({ fileName: filePath, source }, { targets });

--- a/core/compiler/src/testing/harness.ts
+++ b/core/compiler/src/testing/harness.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Diagnostic } from "../core/diagnostics/codes.ts";
@@ -6,7 +6,15 @@ import { ALL_TARGETS, type GeneratedFile, type TargetName } from "../codegen/con
 import { compile, type AnalyzedModule } from "../pipeline/compile.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const FIXTURES_DIR = resolve(__dirname, "..", "__fixtures__");
+
+// This module lives at `src/testing/` in the repo but at `dist/` once packed,
+// while the fixtures ship under `src/__fixtures__` in both layouts.
+const REPO_FIXTURES_DIR = resolve(__dirname, "..", "__fixtures__");
+const PACKED_FIXTURES_DIR = resolve(__dirname, "..", "src", "__fixtures__");
+
+export const FIXTURES_DIR: string = existsSync(REPO_FIXTURES_DIR)
+  ? REPO_FIXTURES_DIR
+  : PACKED_FIXTURES_DIR;
 
 export interface CompiledFixture {
   readonly ir?: AnalyzedModule;

--- a/core/compiler/src/testing/subpath-export.test.ts
+++ b/core/compiler/src/testing/subpath-export.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync } 
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as ts from "typescript";
 import { describe, it, expect } from "vitest";
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -10,6 +11,7 @@ const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 interface PackageManifest {
   readonly files: readonly string[];
   readonly exports: Readonly<Record<string, unknown>>;
+  readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>;
 }
 
 const manifest = JSON.parse(
@@ -40,6 +42,51 @@ describe("@inkline/compiler/testing subpath", () => {
   it("ships the fixtures compileFixture and scenarios read at runtime", () => {
     expect(manifest.files).toContain("src/__fixtures__");
   });
+
+  // A statically imported optional peer throws at import time and kills the whole
+  // subpath for anyone who has not installed it. Nothing else catches this: the peer is
+  // declared, so it is externalised rather than inlined (the tarball does not grow), and
+  // the packing test below resolves inside this package's own node_modules, where every
+  // optional peer is also a devDependency. Checked against the emitted bundles rather
+  // than the sources so a transitively bundled static import counts too, and derived
+  // from `peerDependenciesMeta` so a newly declared peer is covered without edits here.
+  it.skipIf(!existsSync(join(packageDir, "dist")))(
+    "never statically imports an optional peer in an emitted bundle",
+    () => {
+      const optionalPeers = Object.entries(manifest.peerDependenciesMeta ?? {})
+        .filter(([, meta]) => meta.optional)
+        .map(([name]) => name);
+      expect(optionalPeers.length).toBeGreaterThan(0);
+
+      const distDir = join(packageDir, "dist");
+      const offenders: string[] = [];
+
+      for (const file of readdirSync(distDir).filter((f) => f.endsWith(".mjs"))) {
+        const source = ts.createSourceFile(
+          file,
+          readFileSync(join(distDir, file), "utf-8"),
+          ts.ScriptTarget.ESNext,
+          false,
+          ts.ScriptKind.JS,
+        );
+
+        for (const statement of source.statements) {
+          // Only declarations count: `await import(...)` is an expression, never a statement here.
+          if (!ts.isImportDeclaration(statement) && !ts.isExportDeclaration(statement)) continue;
+          const specifier = statement.moduleSpecifier;
+          if (!specifier || !ts.isStringLiteral(specifier)) continue;
+
+          const segments = specifier.text.split("/");
+          const pkg = specifier.text.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+          if (optionalPeers.includes(pkg)) {
+            offenders.push(`dist/${file} statically imports "${specifier.text}"`);
+          }
+        }
+      }
+
+      expect(offenders, "optional peers must be loaded with `await import(...)`").toEqual([]);
+    },
+  );
 
   // Packaging can only be checked against a build. CI always builds before testing
   // (the `test` job downloads the `build` job's artifacts); an unbuilt local tree skips.

--- a/core/compiler/src/testing/subpath-export.test.ts
+++ b/core/compiler/src/testing/subpath-export.test.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+interface PackageManifest {
+  readonly files: readonly string[];
+  readonly exports: Readonly<Record<string, unknown>>;
+}
+
+const manifest = JSON.parse(
+  readFileSync(join(packageDir, "package.json"), "utf-8"),
+) as PackageManifest;
+
+/** The harnesses `README.md` → "Testing Utilities" promises at this subpath. */
+const DOCUMENTED_HARNESSES = [
+  "compileFixture",
+  "typecheckEmittedForTarget",
+  "lintEmittedForTarget",
+  "mountForTarget",
+  "runScenarioAcrossTargets",
+  "runBenchSuite",
+  "runConformanceInvariants",
+  "expectMappingAt",
+  "verifyIdentifierMappings",
+] as const;
+
+describe("@inkline/compiler/testing subpath", () => {
+  it("is declared in package.json exports", () => {
+    expect(manifest.exports["./testing"]).toEqual({
+      types: "./dist/testing.d.mts",
+      default: "./dist/testing.mjs",
+    });
+  });
+
+  it("ships the fixtures compileFixture and scenarios read at runtime", () => {
+    expect(manifest.files).toContain("src/__fixtures__");
+  });
+
+  // Packaging can only be checked against a build. CI always builds before testing
+  // (the `test` job downloads the `build` job's artifacts); an unbuilt local tree skips.
+  // Keyed on `dist/` itself, so a build that stops emitting `testing.mjs` fails rather than skips.
+  it.skipIf(!existsSync(join(packageDir, "dist")))(
+    "resolves and loads from a packed tarball the way a consumer would",
+    async () => {
+      // Staged under the package's own node_modules so peer dependencies (typescript)
+      // still resolve by walking up to the workspace root, as they do for a real consumer.
+      const consumerDir = join(packageDir, "node_modules", ".subpath-export-smoke");
+      rmSync(consumerDir, { recursive: true, force: true });
+      mkdirSync(join(consumerDir, "node_modules", "@inkline"), { recursive: true });
+
+      try {
+        execFileSync("pnpm", ["pack", "--pack-destination", consumerDir], {
+          cwd: packageDir,
+          stdio: "pipe",
+        });
+        const tarball = readdirSync(consumerDir).find((f) => f.endsWith(".tgz"));
+        expect(tarball).toBeDefined();
+
+        execFileSync("tar", ["-xzf", join(consumerDir, tarball as string)], { cwd: consumerDir });
+        renameSync(
+          join(consumerDir, "package"),
+          join(consumerDir, "node_modules", "@inkline", "compiler"),
+        );
+
+        const entry = createRequire(join(consumerDir, "index.js")).resolve(
+          "@inkline/compiler/testing",
+        );
+        const mod = (await import(entry)) as Record<string, unknown>;
+
+        for (const name of DOCUMENTED_HARNESSES) {
+          expect(mod[name], `${name} missing from @inkline/compiler/testing`).toBeTypeOf(
+            "function",
+          );
+        }
+
+        // Proves the shipped fixtures are reachable from the packed layout.
+        const compileFixture = mod.compileFixture as (
+          name: string,
+          targets: readonly string[],
+        ) => Promise<{ files: Record<string, { path: string }[]> }>;
+        const compiled = await compileFixture("Counter", ["react"]);
+        expect(compiled.files.react?.map((f) => f.path)).toEqual(["Counter.tsx"]);
+      } finally {
+        rmSync(consumerDir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/core/compiler/vite.config.ts
+++ b/core/compiler/vite.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   pack: {
     entry: {
       index: "src/index.ts",
+      testing: "src/testing/index.ts",
     },
     dts: {
       oxc: true,


### PR DESCRIPTION
## Summary

Ships the `@inkline/compiler/testing` subpath that four documents already advertise. `package.json` exported only `.` and `./package.json`, so `import … from "@inkline/compiler/testing"` failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` for every consumer of the published package.

## Related issues

- Closes UXF-98

## Type of change

- [x] `feat` — new user-facing capability or public API

## What changed

- **`vite.config.ts`** — `src/testing/index.ts` added as a second `pack.entry`, so the build emits `dist/testing.mjs` + `dist/testing.d.mts`.
- **`package.json`** — `exports["./testing"]` condition; `src/__fixtures__` added to `files` so `compileFixture` and `scenarios` resolve outside the repo.
- **Optional peer dependencies** — `react`, `react-dom`, `vue`, `@vue/server-renderer`, `solid-js`, `svelte`, `eslint`, `oxlint`, `tinybench`. tsdown bundles devDependencies, so without this the published tarball grew **328 kB → 7.31 MB** (react, vue, svelte, solid and eslint inlined). With them externalised it is **364 kB**. All marked `optional: true` — install only the peers for the harnesses you call.
- **`bench.ts`** — `tinybench` moved to a lazy `await import(…)`. It was the only static import of an optional peer, so it would have broken the whole subpath at import time for anyone without it.
- **`harness.ts`** — fixtures directory now resolves in both layouts (`src/testing/../__fixtures__` in the repo, `dist/../src/__fixtures__` when packed). `FIXTURES_DIR` is exported and reused by `bench.ts`.
- **`AGENTS.md`** — "Build" section corrected (it claimed a single bundle) and given the rules that keep this from regressing.

## Failure-mode note

| Failure | Detection | Recovery |
| --- | --- | --- |
| Build entry or export condition removed | `subpath-export.test.ts` fails in CI | Restore the pair; the test asserts both |
| A harness gains a *static* import of an optional peer | `subpath-export.test.ts` parses the emitted bundles and fails on any static import of a package in `peerDependenciesMeta` | Convert to `await import(…)` |
| Consumer calls `mountForTarget("vue")` without `vue` installed | `ERR_MODULE_NOT_FOUND` at call time, not import time | Install the optional peer for the harness in use |
| Fixtures dropped from `files` | Smoke test's `compileFixture("Counter")` fails | Restore the `files` entry |

Deliberately **not** changed: the four documents. They described the intended behaviour correctly; the code caught up to them.

## Test plan

- [x] `vp pack` — 6 files, 364.73 kB (baseline `.` bundle unchanged in content).
- [x] Consumer simulation against a real tarball: resolves to `dist/testing.mjs`, exposes all 18 exports, `compileFixture("Counter", ["react"])` → `Counter.tsx`, `scenarios` → 70 keys.
- [x] `vp test` in `core/compiler` — **219 files, 3276 tests passed**.
- [x] Guard verified against all three regressions: deleting `exports["./testing"]` → 2 failures; deleting the `pack.entry` → 1 failure; reverting `tinybench` to a static import → 1 failure (`dist/testing.mjs statically imports "tinybench"`).
- [x] Isolated-rig consumer check (tarball extracted outside the workspace, **only `typescript` installed**): imports, 18 exports, `compileFixture("Counter", ["react"])` → `Counter.tsx`, `scenarios` → 70 keys, `saveBaseline` writes inside the package.
- [x] `npx vp fmt --check` clean (943 files). `npx vp lint` from the repo root — the path CI takes — reports **zero** errors under `core/compiler`. Run package-locally it reports 472, all `TS17004`/`TS2307` in `src/__fixtures__` (the linter does not understand `.ink.tsx`); all pre-existing on a clean tree, and this PR touches no fixture file. Remaining repo errors are pre-existing unbuilt-dependency noise in `ui/*`.
- [x] `tooling/agents-check` passes (doc link integrity).
- [x] `pnpm install` produces no lockfile churn — the new peers are all optional, so `--frozen-lockfile` stays green.
- [x] `pnpm bench` still runs. It reports a regression vs the committed baseline, but a clean-tree run reports the same (-11.8% / -32.1% vs -12.5% / -34.2%) — pre-existing machine variance, not this change.

## Checklist

- [x] Added a changeset (`.changeset/compiler-testing-subpath-export.md`, `minor`).
- [x] `AGENTS.md` updated — this changes public API and build flow.
- [x] Conventional commit.

## Note for reviewers

`src/__fixtures__/` (416 kB, 103 files) now ships in the tarball. That is what makes `compileFixture` and the exported `scenarios` work for a consumer — both are documented in the README table, and without the fixtures they throw `ENOENT`. The trade-off is that fixture names become a de-facto public surface. Reviewed and kept as shipped; the README now states explicitly that fixture names are outside the semver contract.


