### PR TITLE
feat(cli): deduplicate build diagnostics and print a summary line

### DIFF
--- a/.changeset/cli-diagnostic-dedupe-and-summary.md
+++ b/.changeset/cli-diagnostic-dedupe-and-summary.md
@@ -1,0 +1,24 @@
+---
+"@inkline/cli": minor
+---
+
+feat(cli): print each advisory once per source location and close the build with a summary
+
+Build-invariant advisories are pushed once per codegen target with the component's own location, so
+compiling for both Angular and Qwik printed the byte-identical `INK0068` line twice for a single
+`hasSlot()` call site. `inkline compile` now reports a finding once per `(code, file, line, column)`:
+one thing to fix, one line of output. The same code at a different position is a different finding
+and still prints, and deduplication spans the whole build rather than a single file.
+
+Every one-shot compile now ends with a summary of what it did:
+
+```
+$ inkline compile "src/**/*.ink.tsx" --config inkline.config.ts
+…
+Compiled 67 files in 0.34s — 0 errors, 0 warnings, 12 notes
+```
+
+Exit codes are unchanged: `0` clean, `1` when the compile reported errors, `2` for unusable input
+(which produces no summary, because no build ran). The exit status is computed before filtering and
+deduplication, so neither can hide a failure. `--watch` keeps its per-rebuild reporting and its
+`warning` floor.

--- a/.changeset/cli-diagnostic-dedupe-and-summary.md
+++ b/.changeset/cli-diagnostic-dedupe-and-summary.md
@@ -6,9 +6,11 @@ feat(cli): print each advisory once per source location and close the build with
 
 Build-invariant advisories are pushed once per codegen target with the component's own location, so
 compiling for both Angular and Qwik printed the byte-identical `INK0068` line twice for a single
-`hasSlot()` call site. `inkline compile` now reports a finding once per `(code, file, line, column)`:
-one thing to fix, one line of output. The same code at a different position is a different finding
-and still prints, and deduplication spans the whole build rather than a single file.
+`hasSlot()` call site. `inkline compile` now reports a finding once per
+`(code, file, line, column, title)`: one thing to fix, one line of output. The same code at a
+different position — or saying something different at the same position, as `INK0090` and `INK0100`
+do — is a different finding and still prints. Deduplication spans the whole build rather than a
+single file.
 
 Every one-shot compile now ends with a summary of what it did:
 

--- a/.changeset/cli-diagnostic-dedupe-and-summary.md
+++ b/.changeset/cli-diagnostic-dedupe-and-summary.md
@@ -17,7 +17,7 @@ Every one-shot compile now ends with a summary of what it did:
 ```
 $ inkline compile "src/**/*.ink.tsx" --config inkline.config.ts
 …
-Compiled 67 files in 0.34s — 0 errors, 0 warnings, 12 notes
+Compiled 67 files in 0.32s — 0 errors, 0 warnings, 12 notes
 ```
 
 Exit codes are unchanged: `0` clean, `1` when the compile reported errors, `2` for unusable input

--- a/tooling/cli/AGENTS.md
+++ b/tooling/cli/AGENTS.md
@@ -44,6 +44,7 @@ When adding a command:
 | [`errors.ts`](./src/lib/errors.ts)                                   | Exit-code constants and config-error reporting (see "Exit codes" below).             |
 | [`glob.ts`](./src/lib/glob.ts)                                       | Input-file globbing.                                                                 |
 | [`inkline-config-template.ts`](./src/lib/inkline-config-template.ts) | `inkline.config.ts` + example-component templates for `init --compiler`.             |
+| [`report.ts`](./src/lib/report.ts)                                   | Per-build diagnostic reporting: level filter, deduplication, counts, summary line.   |
 | [`styleframe-config.ts`](./src/lib/styleframe-config.ts)             | The `styleframe.config.ts` template seeded by `init`.                                |
 | [`writer.ts`](./src/lib/writer.ts)                                   | Atomic file writes with source-map sidecar support.                                  |
 
@@ -58,6 +59,8 @@ Defined once in [`lib/errors.ts`](./src/lib/errors.ts); never write a bare numbe
 | —                    | `0`  | Success.                                                                       |
 | `EXIT_COMPILE_ERROR` | `1`  | The compile ran and reported at least one `error` diagnostic.                  |
 | `EXIT_USAGE_ERROR`   | `2`  | The CLI never got that far: unusable config, or no files matched the patterns. |
+
+`EXIT_COMPILE_ERROR` is decided from every diagnostic the compile produced, before the reporting level filters any out and before [`report.ts`](./src/lib/report.ts) collapses duplicates — what a build prints may change; what it returns must not.
 
 User-input failures must never surface a stack trace. `resolveOptions` throws `InklineConfigError` carrying a catalog `Diagnostic`; commands validate up front (before `--clean` deletes anything) and hand the error to `reportConfigError`, which formats it and sets `EXIT_USAGE_ERROR`. The stack is printed only under `--verbose`. Anything `reportConfigError` returns `false` for is a real crash — rethrow it.
 

--- a/tooling/cli/AGENTS.md
+++ b/tooling/cli/AGENTS.md
@@ -44,11 +44,13 @@ When adding a command:
 | [`errors.ts`](./src/lib/errors.ts)                                   | Exit-code constants and config-error reporting (see "Exit codes" below).             |
 | [`glob.ts`](./src/lib/glob.ts)                                       | Input-file globbing.                                                                 |
 | [`inkline-config-template.ts`](./src/lib/inkline-config-template.ts) | `inkline.config.ts` + example-component templates for `init --compiler`.             |
-| [`report.ts`](./src/lib/report.ts)                                   | Per-build diagnostic reporting: level filter, deduplication, counts, summary line.   |
+| [`report.ts`](./src/lib/report.ts)                                   | Per-build diagnostic policy: level filter, deduplication, counts, summary line.      |
 | [`styleframe-config.ts`](./src/lib/styleframe-config.ts)             | The `styleframe.config.ts` template seeded by `init`.                                |
 | [`writer.ts`](./src/lib/writer.ts)                                   | Atomic file writes with source-map sidecar support.                                  |
 
 These are internal — no `exports` map entry. If you find yourself importing from `lib/` outside the CLI, lift the utility into a more appropriate package first.
+
+`report.ts` decides _which_ diagnostics are printed; `diagnostics.ts` decides _how_ one is rendered. The reporter must never build a message itself — it calls `formatDiagnostic` and passes the caller's source text through, so a change to the rendering (code frames, relative paths, color) reaches every path that prints a diagnostic.
 
 ## Exit codes
 

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -13,6 +13,7 @@ import { runCommand } from "citty";
 import type { GeneratedFile } from "@inkline/storybook/generator";
 import type { BarrelGroup } from "@inkline/compiler";
 import compile, { flushNamedBarrels, seedNamedBarrels, writeNamespaceBarrels } from "./compile.ts";
+import { EXIT_COMPILE_ERROR, EXIT_USAGE_ERROR } from "../lib/errors.ts";
 import type { BarrelMap, BarrelEntry } from "../lib/barrel.ts";
 
 // compile.ts is exercised in-process here (not via a subprocess like inkline.test.ts) so that the
@@ -230,6 +231,55 @@ describe("compile command (in-process)", () => {
     expect(errs).toContain("INK0045");
   });
 
+  it("prints a target-invariant advisory once when several targets raise it", async () => {
+    const out = tmpDir("dedupe");
+    // `hasSlot()` has no runtime equivalent on either Angular or Qwik, so both emitters push
+    // INK0068 at the component's location. One call site to fix, one line of output.
+    const { exitCode, errs } = await runCompile([
+      resolve(FIXTURES, "HasSlot.ink.tsx"),
+      "--target",
+      "angular,qwik",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(errs.match(/info {2}INK0068/g)?.length).toBe(1);
+    expect(errs).toContain("HasSlot.ink.tsx");
+    // Both targets still compiled — deduplication is a reporting concern, not a codegen one.
+    expect(existsSync(resolve(out, "angular", "HasSlot.component.ts"))).toBe(true);
+    expect(existsSync(resolve(out, "qwik", "HasSlot.tsx"))).toBe(true);
+  });
+
+  it("ends a clean build with a file count, elapsed time, and zero counts", async () => {
+    const out = tmpDir("summary-clean");
+    const { exitCode, logs } = await runCompile([
+      resolve(FIXTURES, "Counter.ink.tsx"),
+      "--target",
+      "react",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(logs).toMatch(/^Compiled 1 file in \d+\.\d\ds — 0 errors, 0 warnings, 0 notes$/m);
+  });
+
+  it("counts reported diagnostics in the summary, after deduplication", async () => {
+    const out = tmpDir("summary-counts");
+    const { logs, errs } = await runCompile([
+      resolve(FIXTURES, "HasSlot.ink.tsx"),
+      "--target",
+      "angular,qwik",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(errs.match(/info {2}INK0068/g)?.length).toBe(1);
+    // The summary agrees with what was printed: one note, not one per target.
+    expect(logs).toMatch(/^Compiled 1 file in \d+\.\d\ds — 0 errors, 0 warnings, 1 note$/m);
+  });
+
   it("cleans target directories before compiling", async () => {
     const out = tmpDir("clean");
     mkdirSync(resolve(out, "react"), { recursive: true });
@@ -311,6 +361,71 @@ describe("compile command (in-process)", () => {
     expect(readFileSync(resolve(reactDir, "stories.ts"), "utf-8")).toContain(
       "export * as IButtonStories from './components/button/stories/IButton.stories.ts';",
     );
+  });
+});
+
+// Deduplication and the summary line changed how diagnostics are counted, so pin the exit status of
+// every path against that: what the build *says* moved, what it *returns* did not.
+describe("compile command exit codes", () => {
+  it("exits 0 on a clean build", async () => {
+    const out = tmpDir("exit-clean");
+    const { exitCode } = await runCompile([
+      resolve(FIXTURES, "Counter.ink.tsx"),
+      "--target",
+      "react",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("exits 0 when the build only produced notes", async () => {
+    const out = tmpDir("exit-info");
+    const { exitCode, logs } = await runCompile([
+      resolve(FIXTURES, "ModelInput.ink.tsx"),
+      "--target",
+      "astro",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(logs).toContain("0 errors");
+  });
+
+  it("exits 1 when a diagnostic is an error, and the summary counts it", async () => {
+    const out = tmpDir("exit-error");
+    const { exitCode, logs } = await runCompile([
+      resolve(FIXTURES, "Diag_ShowNoWhen.ink.tsx"),
+      "--target",
+      "react",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(EXIT_COMPILE_ERROR);
+    expect(logs).toMatch(/— [1-9]\d* errors?,/);
+  });
+
+  it("exits 1 once, not per duplicate, when the same error is raised by two targets", async () => {
+    const out = tmpDir("exit-error-dedupe");
+    const { exitCode } = await runCompile([
+      resolve(FIXTURES, "Diag_ShowNoWhen.ink.tsx"),
+      "--target",
+      "angular,qwik",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(EXIT_COMPILE_ERROR);
+  });
+
+  it("exits 2 without a summary when the input is unusable", async () => {
+    const { exitCode, logs } = await runCompile([
+      resolve(TMP, "does-not-exist", "*.ink.tsx"),
+      "--target",
+      "react",
+    ]);
+    // The build never ran, so there is nothing to summarize.
+    expect(exitCode).toBe(EXIT_USAGE_ERROR);
+    expect(logs).not.toContain("Compiled");
   });
 });
 

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -251,6 +251,28 @@ describe("compile command (in-process)", () => {
     expect(existsSync(resolve(out, "qwik", "HasSlot.tsx"))).toBe(true);
   });
 
+  // UXF-85's source frames reach the one-shot build only if `run()` hands the reporter the source
+  // text for the file it just compiled. `report.test.ts` pins the reporter→formatter seam; this pins
+  // the caller→reporter one. Dropping the source map at the call site is what silently reverted
+  // UXF-85 during the #541 rebase, and it reverted it with every unit test still green.
+  it("prints a source frame for a diagnostic in a real one-shot build", async () => {
+    const out = tmpDir("source-frame");
+    const { exitCode, errs } = await runCompile([
+      resolve(FIXTURES, "HasSlot.ink.tsx"),
+      "--target",
+      "angular",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(errs).toContain("INK0068");
+    // INK0068 is raised at the component's own location: the `defineComponent` call on line 5.
+    expect(errs).toMatch(/^\s*5 \| export default defineComponent\(/m);
+    // The caret row that underlines the frame — present only when the formatter got source text.
+    expect(errs).toMatch(/^\s*\| \^+$/m);
+  });
+
   it("ends a clean build with a file count, elapsed time, and zero counts", async () => {
     const out = tmpDir("summary-clean");
     const { exitCode, logs } = await runCompile([

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -32,6 +32,7 @@ import {
   type BarrelMap,
 } from "../lib/barrel.ts";
 import { formatDiagnostic } from "../lib/diagnostics.ts";
+import { createBuildReporter, formatBuildSummary } from "../lib/report.ts";
 import { EXIT_COMPILE_ERROR, EXIT_USAGE_ERROR, reportConfigError } from "../lib/errors.ts";
 import { writeCompileOutput, writeIfChanged, writeOutput } from "../lib/writer.ts";
 
@@ -162,8 +163,8 @@ export default defineCommand({
       return;
     }
 
-    let hasError = false;
     const reportLevel: DiagnosticSeverity = args.watch ? DEV_REPORT_LEVEL : "info";
+    const reporter = createBuildReporter(reportLevel);
     // Under `--watch`, the initial pass below seeds the watcher's incremental state so the author's
     // first save is incremental rather than a second full build. Empty (and unused) otherwise.
     const seeds: IncrementalSeed[] = [];
@@ -185,6 +186,8 @@ export default defineCommand({
       srcDir,
     });
 
+    const startedAt = performance.now();
+
     if (args.clean) {
       for (const target of targets) {
         rmSync(resolveTargetDir(target, outDir, targetOutDir), { recursive: true, force: true });
@@ -201,11 +204,9 @@ export default defineCommand({
 
       if (args.watch) seeds.push({ fileName: absPath, source, result });
 
-      for (const d of result.diagnostics) {
-        if (!meetsLevel(d.severity, reportLevel)) continue;
-        console.error(formatDiagnostic(d, { source: d.loc.file === absPath ? source : undefined }));
-        if (d.severity === "error") hasError = true;
-      }
+      // The reporter renders through `formatDiagnostic`, so it needs the same source text the
+      // inline loop used to hand it: a diagnostic pointing anywhere but this file gets no frame.
+      reporter.report(result.diagnostics, new Map([[absPath, source]]));
 
       writeCompileOutput(
         result,
@@ -237,7 +238,12 @@ export default defineCommand({
       );
     }
 
-    if (hasError) process.exitCode = EXIT_COMPILE_ERROR;
+    // A build closes with one line stating what it did; the watch loop reports per rebuild instead.
+    console.log(
+      formatBuildSummary(resolvedFiles.length, performance.now() - startedAt, reporter.counts),
+    );
+
+    if (reporter.hasError) process.exitCode = EXIT_COMPILE_ERROR;
   },
 });
 

--- a/tooling/cli/src/lib/report.test.ts
+++ b/tooling/cli/src/lib/report.test.ts
@@ -51,6 +51,50 @@ describe("createBuildReporter", () => {
     expect(reporter.counts.info).toBe(3);
   });
 
+  it("keeps two plugin failures, which share INK0090's unknown location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    // `runPlugins` builds INK0090 at UNKNOWN_LOCATION and puts the payload in the title, so position
+    // cannot separate one failing plugin from another.
+    const unknown = { file: "<unknown>", line: 0, column: 0, offset: 0, length: 0 };
+    reporter.report([
+      makeDiag({
+        code: "INK0090" as Diagnostic["code"],
+        severity: "error",
+        title: "Plugin 'tailwind' threw: Cannot read properties of undefined",
+        loc: unknown,
+      }),
+      makeDiag({
+        code: "INK0090" as Diagnostic["code"],
+        severity: "error",
+        title: "Plugin 'icons' threw: ENOENT: no such file or directory",
+        loc: unknown,
+      }),
+    ]);
+
+    expect(printed).toHaveLength(2);
+  });
+
+  it("keeps two targets failing differently on the same component", () => {
+    const { printed, reporter } = collectingReporter();
+
+    // The per-target emit loop pushes INK0100 at the component's own location, once per target.
+    reporter.report([
+      makeDiag({
+        code: "INK0100" as Diagnostic["code"],
+        severity: "error",
+        title: "Parse failure in component 'IInput': angular: unsupported directive",
+      }),
+      makeDiag({
+        code: "INK0100" as Diagnostic["code"],
+        severity: "error",
+        title: "Parse failure in component 'IInput': qwik: unsupported serialization",
+      }),
+    ]);
+
+    expect(printed).toHaveLength(2);
+  });
+
   it("keeps different codes at the same location", () => {
     const { printed, reporter } = collectingReporter();
 

--- a/tooling/cli/src/lib/report.test.ts
+++ b/tooling/cli/src/lib/report.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import type { Diagnostic } from "@inkline/compiler";
+import { createBuildReporter, formatBuildSummary } from "./report.ts";
+
+function makeDiag(overrides: Partial<Diagnostic> = {}): Diagnostic {
+  return {
+    code: "INK0068" as Diagnostic["code"],
+    severity: "info",
+    title: "hasSlot() always returns true",
+    url: "",
+    loc: { file: "IInput.ink.tsx", line: 39, column: 1, offset: 0, length: 0 },
+    ...overrides,
+  };
+}
+
+function collectingReporter(level: Parameters<typeof createBuildReporter>[0] = "info") {
+  const printed: string[] = [];
+  return { printed, reporter: createBuildReporter(level, (m) => void printed.push(m)) };
+}
+
+describe("createBuildReporter", () => {
+  it("prints one line for a finding raised by several targets at the same location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    // What Angular and Qwik both push for a single `hasSlot()` call site.
+    reporter.report([makeDiag(), makeDiag()]);
+
+    expect(printed).toHaveLength(1);
+    expect(reporter.counts).toEqual({ error: 0, warning: 0, info: 1 });
+  });
+
+  it("deduplicates across compiled files, not just within one", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([makeDiag()]);
+    reporter.report([makeDiag()]);
+
+    expect(printed).toHaveLength(1);
+  });
+
+  it("keeps the same code at a different location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([
+      makeDiag(),
+      makeDiag({ loc: { file: "IInput.ink.tsx", line: 52, column: 1, offset: 0, length: 0 } }),
+      makeDiag({ loc: { file: "IButton.ink.tsx", line: 39, column: 1, offset: 0, length: 0 } }),
+    ]);
+
+    expect(printed).toHaveLength(3);
+    expect(reporter.counts.info).toBe(3);
+  });
+
+  it("keeps different codes at the same location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([makeDiag(), makeDiag({ code: "INK0045" as Diagnostic["code"] })]);
+
+    expect(printed).toHaveLength(2);
+  });
+
+  it("counts each severity separately", () => {
+    const { reporter } = collectingReporter();
+
+    reporter.report([
+      makeDiag({ severity: "error", code: "INK0001" as Diagnostic["code"] }),
+      makeDiag({ severity: "warning", code: "INK0010" as Diagnostic["code"] }),
+      makeDiag({ severity: "info", code: "INK0045" as Diagnostic["code"] }),
+    ]);
+
+    expect(reporter.counts).toEqual({ error: 1, warning: 1, info: 1 });
+  });
+
+  it("drops diagnostics below the reporting level and leaves them out of the counts", () => {
+    const { printed, reporter } = collectingReporter("warning");
+
+    reporter.report([
+      makeDiag({ severity: "info" }),
+      makeDiag({ severity: "warning", code: "INK0010" as Diagnostic["code"] }),
+    ]);
+
+    expect(printed).toHaveLength(1);
+    expect(reporter.counts).toEqual({ error: 0, warning: 1, info: 0 });
+  });
+
+  it("has no error before anything is reported", () => {
+    const { reporter } = collectingReporter();
+    expect(reporter.hasError).toBe(false);
+  });
+
+  it("flags an error even when it is a duplicate or below the reporting level", () => {
+    // Errors outrank every reporting level today, so neither branch is reachable from the CLI's own
+    // wiring — the exit status is computed before filtering precisely so it stays that way.
+    const duplicate = collectingReporter();
+    duplicate.reporter.report([makeDiag({ severity: "error" }), makeDiag({ severity: "error" })]);
+    expect(duplicate.printed).toHaveLength(1);
+    expect(duplicate.reporter.hasError).toBe(true);
+
+    const filtered = createBuildReporter("error", () => {});
+    filtered.report([makeDiag({ severity: "warning" })]);
+    expect(filtered.hasError).toBe(false);
+  });
+});
+
+describe("formatBuildSummary", () => {
+  it("reports file count, elapsed seconds, and counts by severity", () => {
+    expect(formatBuildSummary(67, 450, { error: 0, warning: 0, info: 4 })).toBe(
+      "Compiled 67 files in 0.45s — 0 errors, 0 warnings, 4 notes",
+    );
+  });
+
+  it("singularizes counts of one", () => {
+    expect(formatBuildSummary(1, 1000, { error: 1, warning: 1, info: 1 })).toBe(
+      "Compiled 1 file in 1.00s — 1 error, 1 warning, 1 note",
+    );
+  });
+});

--- a/tooling/cli/src/lib/report.test.ts
+++ b/tooling/cli/src/lib/report.test.ts
@@ -29,6 +29,29 @@ describe("createBuildReporter", () => {
     expect(reporter.counts).toEqual({ error: 0, warning: 0, info: 1 });
   });
 
+  it("renders through formatDiagnostic, so a source frame still reaches the output", () => {
+    const { printed, reporter } = collectingReporter();
+    const source = "const a = 1;\nconst b = 2;\n";
+
+    reporter.report(
+      [makeDiag({ loc: { file: "a.ink.tsx", line: 2, column: 6, offset: 19, length: 1 } })],
+      new Map([["a.ink.tsx", source]]),
+    );
+
+    // Rendering lives in `diagnostics.ts`; a reporter that formatted its own message would drop the
+    // code frame and silently revert it.
+    expect(printed[0]).toContain("2 | const b = 2;");
+    expect(printed[0]).toContain("^");
+  });
+
+  it("omits the frame when no source is supplied for the diagnostic's file", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([makeDiag()], new Map([["other.ink.tsx", "const a = 1;\n"]]));
+
+    expect(printed[0]).not.toContain("|");
+  });
+
   it("deduplicates across compiled files, not just within one", () => {
     const { printed, reporter } = collectingReporter();
 

--- a/tooling/cli/src/lib/report.ts
+++ b/tooling/cli/src/lib/report.ts
@@ -5,15 +5,20 @@ import { formatDiagnostic } from "./diagnostics.ts";
 export type SeverityCounts = Record<DiagnosticSeverity, number>;
 
 /**
- * Identity of a finding: the same code at the same source position is one thing to fix, however many
- * codegen targets noticed it. Build-invariant advisories are pushed once per target with the
- * component's own location — INK0068 from both the Angular and the Qwik emitter, for instance — so a
- * component compiled for both prints the byte-identical line twice today. The author has a single
- * call site to change, so they get a single line. The same code at a different position is a
- * different finding and still prints.
+ * Identity of a finding: the same code saying the same thing at the same source position is one thing
+ * to fix, however many codegen targets noticed it. Build-invariant advisories are pushed once per
+ * target with the component's own location — INK0068 from both the Angular and the Qwik emitter, for
+ * instance — so a component compiled for both prints the byte-identical line twice today. The author
+ * has a single call site to change, so they get a single line.
+ *
+ * The title is part of the key because some codes carry their payload there rather than in the
+ * position: INK0090 reports every plugin failure at `<unknown>:0:0`, and INK0100 reports a per-target
+ * emit failure at the component's location once per target. Two plugins crashing, or two targets
+ * failing differently on one component, are distinct findings sharing a code and a position — the
+ * title is the only thing that tells them apart.
  */
 function identity(d: Diagnostic): string {
-  return [d.code, d.loc.file, d.loc.line, d.loc.column].join("\u0000");
+  return [d.code, d.loc.file, d.loc.line, d.loc.column, d.title].join("\u0000");
 }
 
 /** Source text by absolute file name, for the code frame `formatDiagnostic` renders. */

--- a/tooling/cli/src/lib/report.ts
+++ b/tooling/cli/src/lib/report.ts
@@ -1,0 +1,97 @@
+import { meetsLevel, type Diagnostic, type DiagnosticSeverity } from "@inkline/compiler";
+import { formatDiagnostic } from "./diagnostics.ts";
+
+/** How many diagnostics were reported, per severity. */
+export type SeverityCounts = Record<DiagnosticSeverity, number>;
+
+/**
+ * Identity of a finding: the same code at the same source position is one thing to fix, however many
+ * codegen targets noticed it. Build-invariant advisories are pushed once per target with the
+ * component's own location — INK0068 from both the Angular and the Qwik emitter, for instance — so a
+ * component compiled for both prints the byte-identical line twice today. The author has a single
+ * call site to change, so they get a single line. The same code at a different position is a
+ * different finding and still prints.
+ */
+function identity(d: Diagnostic): string {
+  return [d.code, d.loc.file, d.loc.line, d.loc.column].join("\u0000");
+}
+
+/** Source text by absolute file name, for the code frame `formatDiagnostic` renders. */
+export type SourceMap = ReadonlyMap<string, string>;
+
+export interface BuildReporter {
+  /**
+   * Filter by reporting level, drop repeats of an already-reported finding, print and count the rest.
+   *
+   * Rendering belongs to `formatDiagnostic`, not to this module: `sources` is looked up by the
+   * diagnostic's file and handed straight to the formatter so it can draw its code frame. A caller
+   * with no source text for that file omits it and the frame is skipped, per the formatter's own
+   * contract.
+   */
+  report(diagnostics: readonly Diagnostic[], sources?: SourceMap): void;
+  /** True once any `error` diagnostic has been seen — including filtered and duplicate ones. */
+  readonly hasError: boolean;
+  readonly counts: SeverityCounts;
+}
+
+/**
+ * Collects a whole build's diagnostics: one reporter per compile so deduplication spans files, not
+ * just the targets of a single one.
+ */
+export function createBuildReporter(
+  level: DiagnosticSeverity,
+  print: (message: string) => void = (message) => console.error(message),
+): BuildReporter {
+  const seen = new Set<string>();
+  const counts: SeverityCounts = { error: 0, warning: 0, info: 0 };
+  let hasError = false;
+
+  return {
+    report(diagnostics, sources) {
+      for (const d of diagnostics) {
+        // Exit status is decided before filtering and deduplication: an error hidden by the
+        // reporting level, or repeated by a second target, is still a failed build.
+        if (d.severity === "error") hasError = true;
+        if (!meetsLevel(d.severity, level)) continue;
+
+        const key = identity(d);
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        counts[d.severity]++;
+        print(formatDiagnostic(d, { source: sources?.get(d.loc.file) }));
+      }
+    },
+    get hasError() {
+      return hasError;
+    },
+    get counts() {
+      return counts;
+    },
+  };
+}
+
+/** `info` is the compiler's severity; "note" is what it is called to the person reading the build. */
+const SEVERITY_NOUN: Record<DiagnosticSeverity, string> = {
+  error: "error",
+  warning: "warning",
+  info: "note",
+};
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** One closing line per build, e.g. `Compiled 67 files in 0.45s — 0 errors, 0 warnings, 4 notes`. */
+export function formatBuildSummary(
+  fileCount: number,
+  elapsedMs: number,
+  counts: SeverityCounts,
+): string {
+  const bySeverity = (["error", "warning", "info"] as const)
+    .map((severity) => pluralize(counts[severity], SEVERITY_NOUN[severity]))
+    .join(", ");
+  const elapsed = (elapsedMs / 1000).toFixed(2);
+
+  return `Compiled ${pluralize(fileCount, "file")} in ${elapsed}s — ${bySeverity}`;
+}


### PR DESCRIPTION
## Summary

`inkline compile` now reports a finding once per `(code, file, line, column, title)` instead of once per codegen target that noticed it, and every one-shot build closes with a severity-count + elapsed summary.

Measured on this repo's own `ui/components` build (7 targets, 67 files), both sides re-run at the current base `ea0a20856`:

**Before** — 13 advisory blocks, `INK0068` printed twice for the same call site:

```
src/components/input/styled/IInput.ink.tsx:39:1  info  INK0068  hasSlot() always returns true …
  39 | export default defineComponent(
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    help: …
src/components/input/styled/IInput.ink.tsx:39:1  info  INK0068  hasSlot() always returns true …
  39 | export default defineComponent(
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    help: …
Generated 56 story file(s) for 8 component(s).
```

**After** — 12 blocks, each distinct finding once, code frames intact:

```
src/components/input/styled/IInput.ink.tsx:39:1  info  INK0068  hasSlot() always returns true …
  39 | export default defineComponent(
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    help: …
Generated 56 story file(s) for 8 component(s).
Compiled 67 files in 0.32s — 0 errors, 0 warnings, 12 notes
```

## Related issues

- UXF-86 (parent: UXF-71, Inkline compiler authoring-surface friction audit, finding #10)

## What changed

New `tooling/cli/src/lib/report.ts`:

- **`createBuildReporter(level, print?)`** — one reporter per build. Filters by reporting level, drops repeats of an already-reported finding, counts and prints the rest. State spans the whole build, not one file, so a source file matched twice by a glob does not double-report either.
- **`formatBuildSummary(fileCount, elapsedMs, counts)`** — `Compiled 67 files in 0.32s — 0 errors, 0 warnings, 12 notes`. `info` is called a "note" in output; counts are singularized at 1.

`compile.ts` `run()` swaps its inline print loop for `reporter.report(...)` and prints the summary after the `--watch` branch. **`runWatch()` is untouched** — its per-rebuild reporting, incremental seeding and `warning` floor are entirely #542's, unchanged here.

### `report.ts` decides what prints; `diagnostics.ts` decides how

The reporter never builds a message. It calls `formatDiagnostic` and passes the caller's source text straight through, so the code frames and relative paths #541 added still reach the output — `report.ts` is diagnostic *policy*, `diagnostics.ts` is diagnostic *rendering*, and the split is now written down in `tooling/cli/AGENTS.md`.

This is the sharp edge of landing under #541. A reporter that formatted its own line would merge green, pass every dedupe test, and silently revert an already-shipped feature. Two tests pin it at both seams:

- `report.test.ts` pins **reporter → formatter**: a diagnostic reported with its source in hand must contain the frame in its output. Reverting the passthrough in `report.ts` fails it.
- `compile.test.ts` pins **caller → reporter**: a real one-shot build must print the frame's source row and caret row on stderr. Dropping the source map at the `reporter.report(...)` call site leaves every unit test green and reverts UXF-85 anyway; this is the test that catches that. Contributed by filter as #546 and absorbed into this branch by fast-forward, authorship intact (`999d949`).

### Why identity is `(code, file, line, column, title)`

Build-invariant advisories are pushed once per target with the *component's* location: `INK0068` from both `codegen/targets/angular/index.ts:485` and `codegen/targets/qwik/index.ts:448`, `INK0045` from `codegen/targets/astro/index.ts:165`. A component compiled for Angular and Qwik therefore produced two byte-identical lines. The author has one call site to change, so they get one line. The same code at a different position is a different finding and still prints.

Position alone is not enough to separate findings, because some codes carry their payload in the title rather than in the location — `INK0090` reports every plugin failure at `<unknown>:0:0` (`core/compiler/src/plugin/runner.ts:7-17`), and `INK0100` reports a per-target emit failure at the component's own location once per target (`core/compiler/src/pipeline/compile.ts:288-292`). Two plugins crashing, or two targets failing differently on one component, are distinct findings sharing a code and a position. The title is the only thing that tells them apart, so it is part of the key. The first revision of this PR keyed on position alone and collapsed both; review caught it with a failing repro.

### The property this key depends on, stated deliberately

Adding `title` to the key only preserves the intended collapse if no *currently collapsing* advisory has a title that varies across targets. Verified, not assumed:

- Enumerating every `diagnostics.push(` site in `core/compiler/src` by file and code, exactly one code is emitted from more than one target emitter: `INK0068` (Angular + Qwik). `INK0045` is Astro-only, `INK0111` is Angular-only; every other code comes from a single pipeline pass.
- Both titles that can therefore collapse are static string literals with no `{…}` placeholders — `core/compiler/src/core/diagnostics/codes.ts:36-42` (`INK0045`) and `:123-129` (`INK0068`). `title` is the placeholder-resolved string (`core/diagnostics/create.ts:32`), so a parameterless catalog entry resolves byte-identically on every target.
- Re-verified after #541: that PR's `codes.ts` diff adds `help` strings to INK0060/61/62/65/66/80/90/0100 and touches no `title`; `INK0045` and `INK0068` are not in it at all. `INK0090` moved to `createDiagnostic` in `plugin/runner.ts` and so carries `help` now, but its `loc` is still `UNKNOWN_LOCATION` and its title is still the parameterised `Plugin '{name}' threw: {message}` — the regression test's premise is unchanged, and it typechecks against the current `Diagnostic`.
- Empirically, re-measured a third time at `ea0a20856`: `ui/components` reports **13** advisories before and **12** after, the same 12. Nothing that was collapsing stopped collapsing.

This is a property of today's catalog, not an invariant the compiler enforces. If a future advisory is emitted from two targets *and* interpolates a target name into its title, it will print once per target — correctly, by this key's definition, but the intent would be a single line. The fix then is to move the target name out of the title, which is where it belongs anyway.

## Failure-mode note

- **What breaks:** a diagnostic that is genuinely distinct but shares code, position *and* title with another would be collapsed. That is now the definition of "the same finding" — the two known payload-in-title codes (`INK0090`, `INK0100`) are covered by regression tests; the risk that remains is the future-catalog case described above, which over-prints rather than hides.
- **Detected by:** `report.test.ts` pins "same code, different location", "different codes, same location", "two plugin failures at `<unknown>:0:0`" and "two targets failing differently on one component" as *not* deduplicated. All four fail against the `(code, file, line, column)` key.
- **Recovers:** deduplication is a pure reporting-layer concern. Codegen is untouched; both targets still compile and emit (asserted in `compile.test.ts`). Reverting this PR restores the previous output exactly.
- **Exit-code hazard:** counting *reported* errors would let deduplication or a reporting level hide a failed build. `hasError` is therefore computed from every diagnostic **before** filtering and deduplication. Neither branch is reachable from the CLI's current wiring (errors outrank every level today) — the tests exist so a future level change cannot silently make a build pass.

## Decision: the report-level asymmetry (scope item 3) — resolved, option C

`compile.ts` reads `args.watch ? DEV_REPORT_LEVEL /* "warning" */ : "info"` — the one-shot build that lands in CI logs keeps the `info` floor, while the dev loop where a human is actually reading filters info out. **This PR does not change that.** Option C below was approved; it ships as two follow-ups (UXF-115, then UXF-117), both gated on this PR merging. The options as proposed:

| Option | Verdict |
| --- | --- |
| **A.** Swap the two floors | Reject. Moves the noise into the loop a human watches; solves nothing. |
| **B.** Lower the one-shot build to `warning` too | Reject *as a silent change*. It is probably the right end state, but it removes INK0045/INK0068 from CI output with no way to ask for them back. That is a behavior change users cannot opt out of. |
| **C.** Make the floor addressable first, then flip the default | **Propose.** Add `--report-level <info\|warning\|error>` and a `reportLevel` config key, defaulting to exactly today's values. Once the floor is a knob rather than a constant, flip the one-shot default to `warning` in a separate changeset-flagged PR, and have the summary name what it withheld: `… 0 errors, 0 warnings, 12 notes (run with --report-level info to list)`. One line to flip, one line to revert. |
| **D.** Reclassify target advisories as per-target capability notes reported once at the end | Defer. It splits the diagnostic model into two classes and belongs in the compiler, not the CLI — RFC material, not a follow-up. |

Reasoning for C: deduplication plus a summary already cut the volume and make it countable, so the asymmetry is no longer urgent. And the thing people actually want ("stop showing me target advisories in CI") is a policy knob, not a hardcoded floor — encoding the policy as a constant is what produced the current backwards default in the first place. `DEV_REPORT_LEVEL` semantics are unchanged in this PR.

## Coordination

Rebased twice. Now on `main` @ `ea0a20856`, which brings in three siblings that landed under this branch:

- **#540** (UXF-88) extracted `lib/compile-options.ts` out of the same `run()` this PR rewrites — a textual conflict in the option-building block, resolved by keeping #540's `buildCompileOptions` call and placing this PR's `startedAt` after it.
- **#541** (UXF-85) moved source-frame and relative-path rendering into `formatDiagnostic`. Resolved by delegation rather than by textual merge; see "`report.ts` decides what prints" above. This is the resolution that mattered — the merge-clean alternative would have reverted #541 invisibly.
- **#542** (UXF-87) seeds the watcher from the initial build. Its `if (args.watch) seeds.push(…)` sits immediately above the print loop this PR deletes, so the conflict is *inside* the loop: taking either side wholesale drops the other. Both are kept. Same hazard shape as #541 — deleting `seeds.push` compiles, merges green, and puts the author's first save back on a full rebuild. Pinned by #542's own watch test, which fails on that deletion (verified by reverting the line).

**#546 is absorbed here, not rebased separately.** It was a 22-line test-only PR based on this branch; fast-forwarding before the rebase carried it through with `filter`'s authorship intact and avoided resolving the same `compile.test.ts` conflict twice. #546 can be closed as absorbed.

`compile.test.ts` was a three-way merge — this PR's suites, #542's watch-seeding suite, and #546's frame test. All three are present and green; the file has 27 tests.

## Type of change

- [x] `feat` — new user-facing capability or public API

## Test plan

- [x] `pnpm run ready` passes locally at `ea0a20856` (build + check + full test suite, 0 failures; 3280 compiler tests, 212 CLI tests)
- [x] `report.test.ts` — dedupe across targets and across files; same code at different locations kept; different codes at the same location kept; **two `INK0090` plugin failures at `<unknown>:0:0` kept**; **two `INK0100` targets failing differently on one component kept**; per-severity counts; level filtering excluded from counts; `hasError` set for duplicate and filtered errors; summary formatting including singularization
- [x] `report.test.ts` → **rendering delegation** — a diagnostic reported with its source in hand renders the `#541` code frame; a diagnostic with no source for its file does not. Reverting the passthrough fails the first
- [x] `compile.test.ts` → **source frames end-to-end** (from #546) — a real one-shot build prints the frame's source row and caret row. Dropping the source map at the call site fails it while every unit test stays green
- [x] `compile.test.ts` — `HasSlot.ink.tsx` compiled for `angular,qwik` prints `INK0068` once while both targets still emit output; summary line shape on a clean build; summary counts agree with what was printed after dedupe
- [x] `compile.test.ts` → **`compile command exit codes`** — acceptance criterion 3 as tests, not an assertion: `0` clean, `0` with notes only, `1` on an error diagnostic (with the error counted in the summary), `1` once when two targets raise the same error, `2` on unusable input with no summary printed
- [x] **#542's watch suite survives the merge** — verified by deleting `seeds.push` on the resolved tree: `rebuilds only the edited file on the first save` fails with `Rebuilt 2 file(s), skipped 0` against the expected `Rebuilt 1 file(s), skipped 1`. Restored and re-run green
- [x] Manual, both sides re-run at `ea0a20856`: `ui/components` — 13 → 12 printed advisories, `INK0068` 2 → 1, code frames present in both, summary as quoted above, exit `0`

## Acceptance criteria

1. ✅ Each distinct advisory prints at most once per source location.
2. ✅ Every build ends with a severity-count summary and elapsed time.
3. ✅ Exit-code semantics unchanged — covered by the `compile command exit codes` block.
4. ✅ Tests covering dedupe and summary counts.

## Checklist

- [x] Added a changeset (`.changeset/cli-diagnostic-dedupe-and-summary.md`, `@inkline/cli` minor)
- [x] `tooling/cli/AGENTS.md` updated — `lib/report.ts` added to the module table, the policy/rendering split, plus the exit-code invariant
- [x] Commit message follows the conventional format
- [x] Rebased on `ea0a20856` with a `--force-with-lease` push; no history other than this topic branch was rewritten
