### PR TITLE
fix(cli): inkline check accepts globs and honours the same config as compile

### DIFF
--- a/.changeset/check-compile-option-parity.md
+++ b/.changeset/check-compile-option-parity.md
@@ -1,0 +1,17 @@
+---
+"@inkline/cli": patch
+---
+
+`inkline check` now accepts the same inputs and honours the same config as `inkline compile`.
+
+`check` takes a glob pattern instead of a single file, and a pattern that matches nothing prints
+`no files matched the given patterns` and exits `2` instead of throwing a raw `ENOENT` stack trace.
+
+Both commands now build their compiler options through one shared mapping, closing four ways `check`
+could pass while `compile` failed: `tsconfig` (ambient `.d.ts` type files were never loaded, so
+`check` ran against a weaker TypeScript program), `targetOptions` (unknown target option keys went
+unreported and codegen ran with defaults), `verbose`, and `outDir`/`srcDir`/`targetOutDir` as seen by
+plugins. `sourceMap` remains the one intentional difference — `check` writes no output.
+
+`check` no longer silently falls back to `react,solid,vue,svelte` when no targets are configured; it
+reports INK0084 and exits `2`, matching `compile`.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -477,7 +477,7 @@ inkline <command> [options]
 
 Commands:
   compile <glob>   Compile .ink.tsx files and generate stories.
-  check <file>     Run diagnostics on a file without writing output.
+  check <glob>     Run diagnostics without writing output.
   init             Initialize an Inkline project.
   add <component>  Add a component to your project.
 ```
@@ -509,7 +509,14 @@ Report diagnostics without producing output:
 
 ```bash
 inkline check src/Counter.ink.tsx --target react
+
+# Globs, same as compile
+inkline check "src/**/*.ink.tsx" --config inkline.config.ts
 ```
+
+Flags: `--target`, `--config`, `--verbose`. `check` accepts the same patterns as `compile` and reads
+the same config file, so it reports exactly the diagnostics the build would report — the only
+difference is that it writes nothing and skips source maps.
 
 ### Exit codes
 

--- a/tooling/cli/AGENTS.md
+++ b/tooling/cli/AGENTS.md
@@ -16,7 +16,9 @@ All commands live in [`src/commands/`](./src/commands/) and are wired into the r
 | `inkline init`    | [`init.ts`](./src/commands/init.ts)       | Set up Inkline in an existing app: detect package manager/framework/bundler, run `styleframe init` + seed `styleframe.config.ts`, install deps, wire the build plugin. `--compiler` additionally scaffolds `inkline.config.ts` and an example component. |
 | `inkline add`     | [`add.ts`](./src/commands/add.ts)         | Add a component to an existing project. Currently a stub — prints "not yet implemented".                                                                                                                                                                 |
 | `inkline compile` | [`compile.ts`](./src/commands/compile.ts) | Compile `.ink.tsx` globs to target frameworks and generate per-target Storybook story files. Accepts `--src-dir` to set the source root for output path resolution (also `srcDir` in config).                                                            |
-| `inkline check`   | [`check.ts`](./src/commands/check.ts)     | Run diagnostics without writing output: compiles with `sourceMap: "none"`, prints formatted diagnostics, exits non-zero on any error.                                                                                                                    |
+| `inkline check`   | [`check.ts`](./src/commands/check.ts)     | Run diagnostics without writing output: same globs and same config as `compile`, compiles with `sourceMap: "none"`, prints formatted diagnostics, exits non-zero on any error.                                                                           |
+
+`check` is the correctness gate for `compile`, so it must compile against the same program. Both build their option bag through [`buildCompileOptions`](./src/lib/compile-options.ts) and nowhere else — `sourceMap` is the single sanctioned divergence (`check` writes no output, so maps would be waste). A new `InklineConfig` field goes into that mapper, not into a command; [`commands/check.test.ts`](./src/commands/check.test.ts) fails if the two bags stop matching.
 
 When adding a command:
 
@@ -34,6 +36,7 @@ When adding a command:
 | [`add-build-plugin.ts`](./src/lib/add-build-plugin.ts)               | Wire the inkline plugin into a bundler config via magicast (used by `init`).         |
 | [`barrel.ts`](./src/lib/barrel.ts)                                   | Generate framework-specific barrel files (re-export `index.ts`) for compiled output. |
 | [`common-prefix.ts`](./src/lib/common-prefix.ts)                     | Longest-common-prefix helper for input glob → output path resolution.                |
+| [`compile-options.ts`](./src/lib/compile-options.ts)                 | The one config → `compile()` options mapping, shared by `compile` and `check`.       |
 | [`config.ts`](./src/lib/config.ts)                                   | Bridge to [`@inkline/config-loader`](../../core/config-loader/) with CLI defaults.   |
 | [`detect-bundler.ts`](./src/lib/detect-bundler.ts)                   | Detect the project's bundler config file (used by `init`).                           |
 | [`detect-framework.ts`](./src/lib/detect-framework.ts)               | Detect the project's framework(s) from its dependencies (used by `init`).            |

--- a/tooling/cli/src/commands/check.test.ts
+++ b/tooling/cli/src/commands/check.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCommand, type ArgsDef, type CommandDef } from "citty";
+import type { InklineConfig } from "@inkline/compiler";
+
+// `check` and `compile` are exercised in-process against a stubbed `compile()` so the option bag each
+// one hands the compiler can be captured and compared directly. The point of these tests is the
+// plumbing between config file and compiler, not the compilation itself.
+const { compileCalls } = vi.hoisted(() => ({
+  compileCalls: [] as Partial<InklineConfig>[],
+}));
+
+vi.mock("@inkline/compiler", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@inkline/compiler")>();
+  return {
+    ...actual,
+    compile: async (_input: unknown, options: Partial<InklineConfig>) => {
+      compileCalls.push(options);
+      return { files: {}, diagnostics: [] };
+    },
+  };
+});
+
+// Story generation is a side effect of `compile` only; stub it so the two commands differ in nothing
+// but the option bag under test.
+vi.mock("@inkline/storybook/generator", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@inkline/storybook/generator")>();
+  return { ...actual, generate: async () => ({ files: [], components: [] }) };
+});
+
+const checkCommand = (await import("./check.ts")).default;
+const compileCommand = (await import("./compile.ts")).default;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TMP = resolve(__dirname, "..", "..", ".tmp-check-unit");
+
+const COMPONENT = `import { defineComponent } from "@inkline/core";\nexport default defineComponent(() => <button />);\n`;
+
+/** A config that sets every field the CLI is expected to forward to the compiler. */
+function writeFixture(dir: string): string {
+  mkdirSync(resolve(dir, "src"), { recursive: true });
+  writeFileSync(resolve(dir, "src", "A.ink.tsx"), COMPONENT);
+  writeFileSync(resolve(dir, "src", "B.ink.tsx"), COMPONENT);
+  writeFileSync(resolve(dir, "types.tsconfig.json"), `{ "files": [] }\n`);
+
+  const configPath = resolve(dir, "inkline.config.mjs");
+  writeFileSync(
+    configPath,
+    `export default {
+      targets: ["react"],
+      srcDir: "src",
+      outDir: "out",
+      targetOutDir: { react: "out/react" },
+      sourceMap: "inline",
+      targetOptions: { react: { forwardRef: true } },
+      plugins: [{ name: "fixture-plugin" }],
+      verbose: true,
+      tsconfig: "types.tsconfig.json",
+      barrels: [{ file: "index.ts", match: "" }],
+    };\n`,
+  );
+  return configPath;
+}
+
+async function run<T extends ArgsDef>(
+  command: CommandDef<T>,
+  rawArgs: string[],
+): Promise<{ errs: string; exitCode: number }> {
+  const errs: string[] = [];
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => void errs.push(a.join(" ")));
+  process.exitCode = 0;
+  await runCommand(command, { rawArgs });
+  return { errs: errs.join("\n"), exitCode: Number(process.exitCode) };
+}
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = process.cwd();
+  compileCalls.length = 0;
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  process.exitCode = 0;
+  vi.restoreAllMocks();
+  if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("check command inputs", () => {
+  it("expands a glob and checks every matching file", async () => {
+    const dir = resolve(TMP, "glob");
+    writeFixture(dir);
+    process.chdir(dir);
+
+    const { exitCode } = await run(checkCommand, [
+      "src/**/*.ink.tsx",
+      "--config",
+      "inkline.config.mjs",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(compileCalls).toHaveLength(2);
+  });
+
+  it("reports a zero-match pattern instead of throwing ENOENT", async () => {
+    const dir = resolve(TMP, "no-match");
+    writeFixture(dir);
+    process.chdir(dir);
+
+    const { errs, exitCode } = await run(checkCommand, [
+      "src/**/*.nonexistent",
+      "--config",
+      "inkline.config.mjs",
+    ]);
+
+    expect(exitCode).toBe(2);
+    expect(errs).toContain("no files matched the given patterns");
+    expect(compileCalls).toHaveLength(0);
+  });
+});
+
+describe("check / compile option parity", () => {
+  it("builds identical compile options from the same config file", async () => {
+    const dir = resolve(TMP, "parity");
+    const configPath = writeFixture(dir);
+    process.chdir(dir);
+
+    await run(compileCommand, ["src/A.ink.tsx", "--config", configPath]);
+    const compileOptions = compileCalls.at(-1);
+    compileCalls.length = 0;
+
+    await run(checkCommand, ["src/A.ink.tsx", "--config", configPath]);
+    const checkOptions = compileCalls.at(-1);
+
+    expect(compileOptions).toBeDefined();
+    // `sourceMap` is the single sanctioned divergence: `check` writes no output, so producing maps
+    // would be wasted work. Every other field — notably `tsconfig`, `targetOptions` and `verbose` —
+    // must match, or `check` grades against a different program than the build compiles.
+    expect(checkOptions).toEqual({ ...compileOptions, sourceMap: "none" });
+    expect(checkOptions?.tsconfig).toBe("types.tsconfig.json");
+    expect(checkOptions?.targetOptions).toEqual({ react: { forwardRef: true } });
+  });
+
+  it("reports missing targets as a diagnostic rather than inventing a target set", async () => {
+    const dir = resolve(TMP, "no-targets");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "A.ink.tsx"), COMPONENT);
+    const configPath = resolve(dir, "inkline.config.mjs");
+    writeFileSync(configPath, `export default {};\n`);
+    process.chdir(dir);
+
+    const { errs, exitCode } = await run(checkCommand, ["A.ink.tsx", "--config", configPath]);
+
+    expect(exitCode).toBe(2);
+    expect(errs).toContain("INK0084");
+    expect(compileCalls).toHaveLength(0);
+  });
+});

--- a/tooling/cli/src/commands/check.ts
+++ b/tooling/cli/src/commands/check.ts
@@ -1,15 +1,17 @@
 import { defineCommand } from "citty";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { compile, resolveOptions, type TargetName } from "@inkline/compiler";
+import { compile, resolveOptions } from "@inkline/compiler";
 import { loadInklineConfig } from "../lib/config.ts";
+import { buildCompileOptions, resolveOutDir, resolveTargets } from "../lib/compile-options.ts";
+import { expandGlobs } from "../lib/glob.ts";
 import { formatDiagnostic } from "../lib/diagnostics.ts";
-import { EXIT_COMPILE_ERROR, reportConfigError } from "../lib/errors.ts";
+import { EXIT_COMPILE_ERROR, EXIT_USAGE_ERROR, reportConfigError } from "../lib/errors.ts";
 
 export default defineCommand({
   meta: { name: "check", description: "Run diagnostics without writing output" },
   args: {
-    file: { type: "positional", description: "File to check", required: true },
+    pattern: { type: "positional", description: "Glob pattern for .ink.tsx files", required: true },
     target: { type: "string", description: "Comma-separated targets" },
     config: { type: "string", description: "Path to config file" },
     verbose: {
@@ -21,11 +23,7 @@ export default defineCommand({
   async run({ args }) {
     const fileConfig = await loadInklineConfig(args.config);
     const verbose = args.verbose || fileConfig.verbose === true;
-    const targetStr = args.target ?? fileConfig.targets?.join(",") ?? "react,solid,vue,svelte";
-    const targets = targetStr
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean) as TargetName[];
+    const targets = resolveTargets(args.target, fileConfig);
 
     try {
       resolveOptions({ targets, registry: fileConfig.registry });
@@ -34,16 +32,29 @@ export default defineCommand({
       throw err;
     }
 
+    const resolvedFiles = expandGlobs([...args._]);
+    if (resolvedFiles.length === 0) {
+      console.error("Error: no files matched the given patterns.");
+      process.exitCode = EXIT_USAGE_ERROR;
+      return;
+    }
+
+    // `check` writes nothing, so generating source maps would be pure waste — this is the one option
+    // it is allowed to resolve differently from `compile`. Everything else comes from the shared
+    // mapper so the diagnostics reported here are exactly the ones the build would report.
+    const options = buildCompileOptions(fileConfig, {
+      targets,
+      outDir: resolveOutDir(undefined, fileConfig),
+      sourceMap: "none",
+      verbose,
+    });
+
     let hasError = false;
 
-    const files = [...args._];
-    for (const filePath of files) {
+    for (const filePath of resolvedFiles) {
       const absPath = resolve(filePath);
       const source = readFileSync(absPath, "utf-8");
-      const result = await compile(
-        { fileName: absPath, source },
-        { targets, sourceMap: "none", plugins: fileConfig.plugins, registry: fileConfig.registry },
-      );
+      const result = await compile({ fileName: absPath, source }, options);
 
       for (const d of result.diagnostics) {
         console.error(formatDiagnostic(d));

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -14,6 +14,7 @@ import {
 } from "@inkline/compiler";
 import { activeFrameworks, generate, type GeneratedFile } from "@inkline/storybook/generator";
 import { loadInklineConfig } from "../lib/config.ts";
+import { buildCompileOptions, resolveOutDir, resolveTargets } from "../lib/compile-options.ts";
 import { expandGlobs } from "../lib/glob.ts";
 import { commonPrefix } from "../lib/common-prefix.ts";
 import {
@@ -124,11 +125,7 @@ export default defineCommand({
     const fileConfig = await loadInklineConfig(args.config);
     const verbose = args.verbose || fileConfig.verbose === true;
 
-    const targetStr = args.target ?? fileConfig.targets?.join(",");
-    const targets = (targetStr
-      ?.split(",")
-      .map((t) => t.trim())
-      .filter(Boolean) ?? []) as TargetName[];
+    const targets = resolveTargets(args.target, fileConfig);
 
     // Resolve up front so a missing or misspelled target is reported before `--clean` deletes
     // output directories. `compile` resolves the same options again; this only fails earlier.
@@ -142,7 +139,7 @@ export default defineCommand({
     // Flag > config > default, matching `--target`, `--src-dir` and `--source-map`. Note that a
     // config `targetOutDir` entry is a per-target absolute override and still wins for that target
     // (see `resolveTargetDir`): the more specific setting beats the general one either way.
-    const outDir = args["out-dir"] ?? fileConfig.outDir ?? "dist";
+    const outDir = resolveOutDir(args["out-dir"], fileConfig);
     const targetOutDir = fileConfig.targetOutDir ?? {};
     const barrels = fileConfig.barrels ?? DEFAULT_BARRELS;
     const namedGroups = barrels.filter((g) => g.mode !== "namespace");
@@ -169,6 +166,16 @@ export default defineCommand({
         : srcDir + "/"
       : commonPrefix(resolvedFiles.map((f) => dirname(f)));
 
+    // Built once and reused by the one-shot loop and the watcher, so a rebuild can never compile
+    // with different options than the initial build. `check` builds its bag from the same mapper.
+    const compileOptions = buildCompileOptions(fileConfig, {
+      targets,
+      outDir,
+      sourceMap,
+      verbose,
+      srcDir,
+    });
+
     if (args.clean) {
       for (const target of targets) {
         rmSync(resolveTargetDir(target, outDir, targetOutDir), { recursive: true, force: true });
@@ -181,19 +188,7 @@ export default defineCommand({
       const name = basename(absPath, extname(absPath)).replace(/\.ink(\.stories)?$/, "");
       const relDir = dirname(filePath).slice(sourcePrefix.length);
 
-      const result = await compile(
-        { fileName: absPath, source },
-        {
-          targets,
-          outDir,
-          sourceMap,
-          verbose,
-          plugins: fileConfig.plugins,
-          targetOptions: fileConfig.targetOptions,
-          registry: fileConfig.registry,
-          tsconfig: fileConfig.tsconfig,
-        },
-      );
+      const result = await compile({ fileName: absPath, source }, compileOptions);
 
       for (const d of result.diagnostics) {
         if (!meetsLevel(d.severity, reportLevel)) continue;
@@ -225,8 +220,7 @@ export default defineCommand({
         outDir,
         targetOutDir,
         sourceMap,
-        verbose,
-        fileConfig,
+        compileOptions,
         sourcePrefix,
         srcDir,
         namedGroups,
@@ -290,8 +284,7 @@ function runWatch(
   outDir: string,
   targetOutDir: Partial<Record<string, string>>,
   sourceMap: "external" | "inline" | "none",
-  verbose: boolean,
-  fileConfig: Partial<import("@inkline/compiler").InklineConfig>,
+  compileOptions: Partial<import("@inkline/compiler").InklineConfig>,
   sourcePrefix: string,
   srcDir: string | undefined,
   namedGroups: readonly BarrelGroup[],
@@ -308,16 +301,7 @@ function runWatch(
       return { fileName: absPath, source: readFileSync(absPath, "utf-8") };
     });
 
-    const result = await compileIncremental(state, inputs, {
-      targets,
-      outDir,
-      sourceMap,
-      verbose,
-      plugins: fileConfig.plugins,
-      targetOptions: fileConfig.targetOptions,
-      registry: fileConfig.registry,
-      tsconfig: fileConfig.tsconfig,
-    });
+    const result = await compileIncremental(state, inputs, compileOptions);
 
     state = result.nextState;
 

--- a/tooling/cli/src/lib/compile-options.test.ts
+++ b/tooling/cli/src/lib/compile-options.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { buildCompileOptions, resolveOutDir, resolveTargets } from "./compile-options.ts";
+
+const OVERRIDES = {
+  targets: ["react"] as const,
+  outDir: "out",
+  sourceMap: "external" as const,
+  verbose: false,
+};
+
+describe("buildCompileOptions", () => {
+  it("forwards every compiler-consumed config field", () => {
+    const options = buildCompileOptions({}, OVERRIDES);
+
+    // `barrels` is CLI-only and deliberately absent. Any other InklineConfig field missing here is a
+    // silent divergence between `check` and `compile`, so the key set is asserted, not just values.
+    expect(Object.keys(options).sort()).toEqual([
+      "outDir",
+      "plugins",
+      "registry",
+      "sourceMap",
+      "srcDir",
+      "targetOptions",
+      "targetOutDir",
+      "targets",
+      "tsconfig",
+      "verbose",
+    ]);
+  });
+
+  it("takes flag-resolved values from the overrides and the rest from the config", () => {
+    const registry = { has: () => true } as never;
+    const options = buildCompileOptions(
+      {
+        srcDir: "from-config",
+        outDir: "from-config",
+        targetOutDir: { react: "out/react" },
+        sourceMap: "inline",
+        targetOptions: { react: { forwardRef: true } },
+        plugins: [],
+        verbose: true,
+        registry,
+        tsconfig: "types.tsconfig.json",
+      },
+      { ...OVERRIDES, srcDir: "from-flag" },
+    );
+
+    expect(options).toMatchObject({
+      targets: ["react"],
+      srcDir: "from-flag",
+      outDir: "out",
+      sourceMap: "external",
+      verbose: false,
+      targetOutDir: { react: "out/react" },
+      targetOptions: { react: { forwardRef: true } },
+      tsconfig: "types.tsconfig.json",
+      registry,
+    });
+  });
+
+  it("falls back to the config srcDir when no flag is given", () => {
+    expect(buildCompileOptions({ srcDir: "from-config" }, OVERRIDES).srcDir).toBe("from-config");
+  });
+});
+
+describe("resolveTargets", () => {
+  it("prefers the flag, splits on commas and trims", () => {
+    expect(resolveTargets(" react , vue ", { targets: ["svelte"] })).toEqual(["react", "vue"]);
+  });
+
+  it("falls back to the config targets", () => {
+    expect(resolveTargets(undefined, { targets: ["svelte"] })).toEqual(["svelte"]);
+  });
+
+  it("returns an empty list when neither is set, so resolveOptions can report INK0084", () => {
+    expect(resolveTargets(undefined, {})).toEqual([]);
+  });
+});
+
+describe("resolveOutDir", () => {
+  it("prefers the flag, then the config, then dist", () => {
+    expect(resolveOutDir("flag", { outDir: "config" })).toBe("flag");
+    expect(resolveOutDir(undefined, { outDir: "config" })).toBe("config");
+    expect(resolveOutDir(undefined, {})).toBe("dist");
+  });
+});

--- a/tooling/cli/src/lib/compile-options.ts
+++ b/tooling/cli/src/lib/compile-options.ts
@@ -1,0 +1,68 @@
+import type { InklineConfig, SourceMapMode, TargetName } from "@inkline/compiler";
+
+/**
+ * Values a command resolves from its own flags before the config file is consulted. Everything else
+ * in the option bag is read straight off the config, so a newly added `InklineConfig` field reaches
+ * every command at once instead of only the one whose author remembered it.
+ */
+export interface CompileOptionOverrides {
+  readonly targets: readonly TargetName[];
+  readonly outDir: string;
+  readonly sourceMap: SourceMapMode;
+  readonly verbose: boolean;
+  /** Only `compile` exposes `--src-dir`; omitted, the config value is used. */
+  readonly srcDir?: string;
+}
+
+/**
+ * Single source of truth for the config → `compile()` options mapping.
+ *
+ * `check` and `compile` must hand the compiler the same program, plugins and target options, or the
+ * command that presents itself as the correctness gate sees less than the build does — `check`
+ * passes on code `compile` rejects. That had already happened twice (`tsconfig`, `targetOptions`),
+ * so both commands now build their options here and nowhere else.
+ *
+ * The map is total over {@link InklineConfig} except `barrels`, which is CLI-only and ignored by the
+ * compiler pipeline.
+ */
+export function buildCompileOptions(
+  fileConfig: Partial<InklineConfig>,
+  overrides: CompileOptionOverrides,
+): Partial<InklineConfig> {
+  return {
+    targets: overrides.targets,
+    srcDir: overrides.srcDir ?? fileConfig.srcDir,
+    outDir: overrides.outDir,
+    targetOutDir: fileConfig.targetOutDir,
+    sourceMap: overrides.sourceMap,
+    targetOptions: fileConfig.targetOptions,
+    plugins: fileConfig.plugins,
+    verbose: overrides.verbose,
+    registry: fileConfig.registry,
+    tsconfig: fileConfig.tsconfig,
+  };
+}
+
+/**
+ * Flag > config, then parsed. An empty result is deliberately left empty rather than defaulted to a
+ * target list: `resolveOptions` turns it into INK0084, so a project with no configured targets gets
+ * the same clear diagnostic from every command instead of one command inventing a target set.
+ */
+export function resolveTargets(
+  flag: string | undefined,
+  fileConfig: Partial<InklineConfig>,
+): TargetName[] {
+  const raw = flag ?? fileConfig.targets?.join(",");
+  return (raw
+    ?.split(",")
+    .map((t) => t.trim())
+    .filter(Boolean) ?? []) as TargetName[];
+}
+
+/** Flag > config > `dist`, matching `--target` and `--source-map`. */
+export function resolveOutDir(
+  flag: string | undefined,
+  fileConfig: Partial<InklineConfig>,
+): string {
+  return flag ?? fileConfig.outDir ?? "dist";
+}


### PR DESCRIPTION
## Summary

`inkline check` presented itself as the correctness gate for `inkline compile` while quietly compiling against a different program. It now accepts the same glob patterns and builds its compiler options from the same shared mapper, so a green `check` means the build sees the same thing.

## Related issues

- Closes UXF-88 (Inkline compiler authoring-surface friction audit, finding #14 extended)

## The option diff, end to end

Done before patching, across all three call sites that build a compile-options bag (`compile` one-shot, `compile --watch`, `check`).

| `InklineConfig` field | `compile` (one-shot) | `compile --watch` | `check` (before) |
| --- | --- | --- | --- |
| `targets` | ✅ | ✅ | ⚠️ different fallback |
| `tsconfig` | ✅ | ✅ | ❌ **missing** |
| `targetOptions` | ✅ | ✅ | ❌ **missing** |
| `verbose` | ✅ | ✅ | ❌ **missing** |
| `outDir` | ✅ | ✅ | ❌ **missing** |
| `srcDir` | ❌ | ❌ | ❌ |
| `targetOutDir` | ❌ | ❌ | ❌ |
| `sourceMap` | ✅ | ✅ | hardcoded `"none"` (intentional) |
| `plugins` | ✅ | ✅ | ✅ |
| `registry` | ✅ | ✅ | ✅ |
| `barrels` | n/a — CLI-only, ignored by the pipeline | | |

The issue named two divergences (globs, `tsconfig`). Four more turned up:

1. **`targetOptions` was never passed to `check`.** `pipeline/compile.ts:197-213` walks `options.targetOptions` and emits INK0080 for unknown target option keys; `check` reported none of them. Codegen also ran with target defaults instead of the configured options, so `check` graded output the build would never produce.
2. **`verbose` was never passed.** `check` computed it for `reportConfigError`, then dropped it. `plugin/runner.ts:30,52` gates plugin error logging on `ctx.options.verbose`, so plugin failures were silent under `inkline check --verbose`.
3. **`outDir` / `srcDir` / `targetOutDir` never reached the compiler** from `check` (and `srcDir`/`targetOutDir` never reached it from `compile` either). All three are declared on `ResolvedCompilerOptions` and surfaced to plugins via `PluginContext.options`, so a plugin reading them got `undefined` from one command and a value from the other.
4. **`check` silently defaulted to `react,solid,vue,svelte`** when neither `--target` nor a config `targets` was set, where `compile` reports INK0084 and exits 2. A project with no configured targets got a passing `check` against four framework targets it may not even build.

**The `tsconfig` gap is not theoretical.** Same component, same config, only `tsconfig` toggled — `compile`'s output differs, because ambient `.d.ts` types are what let prop analysis see the prop at all:

```diff
--- without tsconfig
+++ with tsconfig
 export function C(props: TokenProps & React.HTMLAttributes<HTMLElement>)
 {
-const { ...__attrs } = props
+const { tone, ...__attrs } = props
```

`check` was running the left-hand program for every project that configures `tsconfig`.

## What changed

- `check` takes a `pattern` positional (was `file`) and routes `args._` through `expandGlobs`, matching `compile`. Zero matches print `Error: no files matched the given patterns.` and exit `EXIT_USAGE_ERROR` (2) instead of an ENOENT stack trace.
- New `lib/compile-options.ts` — `buildCompileOptions` is now the only place a config becomes a `compile()` option bag, plus `resolveTargets` / `resolveOutDir` for the flag > config > default chains both commands share. The map is total over `InklineConfig` except `barrels`.
- `compile` builds its bag once and hands the same object to the one-shot loop and the watcher, so a rebuild can no longer compile with different options than the initial build (`runWatch` no longer re-derives them from `fileConfig`).
- `sourceMap` is the single sanctioned divergence, documented in code and in `tooling/cli/AGENTS.md`: `check` writes no output, so generating maps is pure waste. It cannot affect diagnostics — `print()` consumes it and reports nothing.

### Behavior changes worth calling out

- `inkline check` with no configured targets now reports INK0084 and exits 2 rather than checking against four invented targets.
- `compile` and `check` now pass `srcDir` and `targetOutDir` to the compiler. No pipeline code reads them; the visible effect is that plugins reading `PluginContext.options` see the configured values instead of `undefined`.

## Test plan

- [x] `pnpm run build` — clean
- [x] `vp check` — no format, lint or type errors in 611 files
- [x] `pnpm run test` — 279 test files, all passing
- [x] **AC 3 (load-bearing):** `commands/check.test.ts` → *"builds identical compile options from the same config file"* stubs `compile()`, runs both commands against **one** config fixture that sets every mapped field, and asserts `checkOptions` deep-equals `{ ...compileOptions, sourceMap: "none" }`. Verified it actually fails: dropping `tsconfig` from `check`'s bag turns the test red.
- [x] **AC 1:** `inkline check 'src/**/*.ink.tsx'` compiles every match — asserted in the unit test and verified end to end against the built binary with two files in nested directories (exit 0).
- [x] **AC 2:** `inkline check 'src/**/*.nonexistent'` → `Error: no files matched the given patterns.`, exit 2, no stack trace. Verified end to end against the built binary.
- [x] Single-file `inkline check src/A.ink.tsx` still works — no regression for the old calling convention.
- [x] `lib/compile-options.test.ts` asserts the mapper's **key set**, so a field silently dropped from the map fails a test even if no command notices yet.

## Checklist

- [x] Added a changeset (`.changeset/check-compile-option-parity.md`, `@inkline/cli` patch)
- [x] Updated `tooling/cli/AGENTS.md` (command table, `lib/` table, the "one mapper" rule) and `core/compiler/README.md` (CLI section: `check <glob>`, flags, glob example)
- [x] Commit message follows the conventional format
