### PR TITLE
feat(cli): render a source frame and relative paths in diagnostics

### DIFF
--- a/.changeset/diagnostic-source-frames.md
+++ b/.changeset/diagnostic-source-frames.md
@@ -1,0 +1,37 @@
+---
+"@inkline/compiler": minor
+"@inkline/cli": minor
+---
+
+feat(cli): render a source frame and relative paths in diagnostics
+
+A diagnostic used to be a single line naming an absolute path, which put a ~140-character prefix on
+every line of output and never showed the code it was complaining about. `SourceLocation` already
+carried `offset` and `length` alongside line/column — enough to slice the source and underline the
+exact span — and nothing used them.
+
+`formatDiagnostic` now prints a `rustc`-style code frame under the header and makes the path
+relative to the invocation directory:
+
+```
+$ inkline check src/Menu.ink.tsx
+src/Menu.ink.tsx:8:7  error  INK0060  <Show> requires a 'when' prop
+  8 |       <Show>
+    |       ^^^^^^
+    help: Pass the condition as a prop: <Show when={visible()}>…</Show>. …
+    docs: https://docs.inkline.dev/diagnostics/INK0060
+```
+
+The formatter stays pure — the source text is a second argument, never an `fs` read — so the `check`
+and `compile` commands pass the text they already hold, and callers with no source (config-time
+failures) get the previous one-line output unchanged. The line number is derived from `offset` so
+the gutter can never disagree with the slice it labels; a span crossing a line boundary is clamped
+to the end of its first line; tabs are preserved in the caret padding so alignment survives any tab
+width. A path is kept absolute when climbing out of the tree with `../..` would be the longer read.
+
+Separately, the 7 catalog codes that shipped with `help: undefined` — `INK0060`, `INK0061`,
+`INK0062`, `INK0065`, `INK0066`, `INK0080`, `INK0090` — now carry help text containing a corrected
+example rather than a restatement of the title. A catalog test asserts non-empty `help` over
+`Object.keys(DIAGNOSTICS)` so the gap cannot reopen as codes are added. `INK0090` was building its
+diagnostic by hand and bypassing the catalog's `help` and interpolation; it now goes through
+`createDiagnostic` like every other code.

--- a/core/compiler/docs/adding-a-diagnostic.md
+++ b/core/compiler/docs/adding-a-diagnostic.md
@@ -1,6 +1,6 @@
 # Adding a Diagnostic
 
-Diagnostics are typed compiler messages with a stable code (`INKxxxx`), severity, location, and optional help text.
+Diagnostics are typed compiler messages with a stable code (`INKxxxx`), severity, location, and help text.
 
 ## 1. Add the code to the catalog
 
@@ -24,7 +24,7 @@ export const DIAGNOSTICS = {
 - **Code ranges**: 00xx = parse, 01xx = analyze, 05xx = lower, 06xx-08xx = options/config, 09xx = plugin, 10xx = pipeline.
 - **Severity**: `"error"` (blocks compilation), `"warning"` (informational), `"info"` (hint).
 - **Placeholders**: use `{name}` syntax in the title and/or the help text; both are interpolated. The type system extracts them from both via `DiagnosticParams<C>` and enforces callers supply them.
-- **Help text**: one sentence explaining what to do. Set to `undefined` if not applicable.
+- **Help text**: required — the catalog test asserts a non-empty `help` on every code. Give the fix, not a restatement of the title: a corrected example the author can copy.
 - **URL**: link to `https://docs.inkline.dev/diagnostics/INKxxxx`.
 
 ## 2. Push the diagnostic
@@ -49,6 +49,7 @@ Every diagnostic code must be exercised by at least one test. Source-level codes
 The catalog test in `src/core/diagnostics/codes.test.ts` verifies:
 
 - Every code has a valid severity.
+- Every code has a non-empty title, `help`, and docs URL — asserted over `Object.keys(DIAGNOSTICS)`, so a new code with no help fails the suite.
 - Every title's placeholder count matches `DiagnosticParams<C>`.
 - The placeholder list is complete.
 

--- a/core/compiler/docs/api-reference.md
+++ b/core/compiler/docs/api-reference.md
@@ -1396,7 +1396,7 @@ Constant map of all diagnostic codes to their metadata:
 | `INK0100` | error    | Parse failure in component '{name}': {message}          |
 | `INK0110` | error    | Internal compiler error: {message}                      |
 
-Each entry provides `severity`, `title`, `help` (optional), and `url` linking to full documentation. Placeholders in both `title` and `help` are interpolated when the diagnostic is created.
+Each entry provides `severity`, `title`, `help`, and `url` linking to full documentation. Every code carries help text — the catalog test asserts it over `Object.keys(DIAGNOSTICS)`. Placeholders in both `title` and `help` are interpolated when the diagnostic is created.
 
 ### `InklineConfigError`
 

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -58,6 +58,14 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
+  // Asserted over the live key set, never a hard-coded count: the catalog grew from 28 to 35 codes
+  // in a single stage, and a counted assertion would have gone stale instead of catching the gap.
+  it("every entry has a non-empty help", () => {
+    for (const code of codes) {
+      expect(DIAGNOSTICS[code].help, `${code} is missing help text`).toBeTruthy();
+    }
+  });
+
   it("every entry has a url", () => {
     for (const code of codes) {
       expect(DIAGNOSTICS[code].url).toMatch(/^https:\/\/docs\.inkline\.dev/);

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -73,19 +73,19 @@ export const DIAGNOSTICS = {
   INK0060: {
     severity: "error" as const,
     title: "<Show> requires a 'when' prop" as const,
-    help: undefined,
+    help: "Pass the condition as a prop: <Show when={visible()}>…</Show>. Without 'when' there is nothing to test, so the block and its children are dropped from the output." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0060" as const,
   },
   INK0061: {
     severity: "info" as const,
     title: "Nullish-coalescing (??) in JSX is ambiguous" as const,
-    help: undefined,
+    help: "?? falls back only on null and undefined, so count() ?? <Empty /> still renders a literal 0. State the condition instead: <Show when={count() > 0} fallback={<Empty />}>…</Show>." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0061" as const,
   },
   INK0062: {
     severity: "error" as const,
     title: "<For> requires an 'each' prop" as const,
-    help: undefined,
+    help: "Pass the collection as a prop: <For each={items()} key={(item) => item.id}>{(item) => <li>{item.name}</li>}</For>. Without 'each' there is nothing to iterate, so the block is dropped from the output." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0062" as const,
   },
   INK0063: {
@@ -104,14 +104,14 @@ export const DIAGNOSTICS = {
   INK0065: {
     severity: "error" as const,
     title: "<Transition> cannot wrap <For>; list transitions are not yet supported" as const,
-    help: undefined,
+    help: 'Move the transition inside the row so each item animates on its own: <For each={items()} key={(item) => item.id}>{(item) => <Transition name="fade"><li>{item.name}</li></Transition>}</For>. Wrapping the list needs a list-transition primitive, which does not exist yet.' as const,
     url: "https://docs.inkline.dev/diagnostics/INK0065" as const,
   },
   INK0066: {
     severity: "info" as const,
     title:
       "<Transition> for Angular: CSS classes are emitted but animation requires manual @angular/animations setup" as const,
-    help: undefined,
+    help: "The compiler emits the name-prefixed classes and nothing else. Define them in a stylesheet — .fade-enter-active, .fade-leave-active { transition: opacity 150ms } — or drive the same states from @angular/animations on the host component." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0066" as const,
   },
   INK0067: {
@@ -142,7 +142,7 @@ export const DIAGNOSTICS = {
   INK0080: {
     severity: "warning" as const,
     title: "Unknown target option: {key}" as const,
-    help: undefined,
+    help: "The option is ignored. Check it against the target's defaultOptions, then fix or remove it: targetOptions: { vue: { sfc: true } } in inkline.config.ts." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0080" as const,
   },
   INK0081: {
@@ -184,7 +184,7 @@ export const DIAGNOSTICS = {
   INK0090: {
     severity: "error" as const,
     title: "Plugin '{name}' threw: {message}" as const,
-    help: undefined,
+    help: "The hook is skipped and compilation continues without its contribution. Re-run with --verbose for the stack trace; a plugin should report recoverable problems with ctx.pushDiagnostic(diagnostic) rather than throwing." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0090" as const,
   },
   INK0100: {

--- a/core/compiler/src/core/diagnostics/collector.test.ts
+++ b/core/compiler/src/core/diagnostics/collector.test.ts
@@ -56,12 +56,12 @@ describe("DiagnosticCollector", () => {
     expect(diags[0]!.help).not.toContain("{name}");
   });
 
-  it("push() sets help to undefined when absent", () => {
+  it("push() carries the catalog help through for every code", () => {
     const c = createDiagnosticCollector();
     c.push("INK0060", loc);
     const diags = c.freeze();
 
-    expect(diags[0]!.help).toBeUndefined();
+    expect(diags[0]!.help).toContain("<Show when={visible()}>");
   });
 
   it("push() includes url", () => {

--- a/core/compiler/src/plugin/runner.ts
+++ b/core/compiler/src/plugin/runner.ts
@@ -1,19 +1,14 @@
-import { DIAGNOSTICS, type Diagnostic } from "../core/diagnostics/codes.ts";
+import type { Diagnostic } from "../core/diagnostics/codes.ts";
+import { createDiagnostic } from "../core/diagnostics/create.ts";
 import type { GeneratedFile, TargetName } from "../codegen/context.ts";
 import { UNKNOWN_LOCATION } from "../ir/types.ts";
 import type { AnalyzedModule } from "../pipeline/passes/04-analyze/index.ts";
 import type { Plugin, PluginContext } from "./types.ts";
 
+/** Built through the catalog so the plugin error carries its `help` and docs URL like any other. */
 function makeErrorDiagnostic(pluginName: string, err: unknown): Diagnostic {
-  const def = DIAGNOSTICS.INK0090;
   const message = err instanceof Error ? err.message : String(err);
-  return {
-    code: "INK0090",
-    severity: def.severity,
-    title: `Plugin '${pluginName}' threw: ${message}`,
-    url: def.url,
-    loc: UNKNOWN_LOCATION,
-  };
+  return createDiagnostic("INK0090", UNKNOWN_LOCATION, { name: pluginName, message });
 }
 
 export class PluginRunner {

--- a/tooling/cli/src/commands/check.ts
+++ b/tooling/cli/src/commands/check.ts
@@ -46,7 +46,7 @@ export default defineCommand({
       );
 
       for (const d of result.diagnostics) {
-        console.error(formatDiagnostic(d));
+        console.error(formatDiagnostic(d, { source: d.loc.file === absPath ? source : undefined }));
         if (d.severity === "error") hasError = true;
       }
     }

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -197,7 +197,7 @@ export default defineCommand({
 
       for (const d of result.diagnostics) {
         if (!meetsLevel(d.severity, reportLevel)) continue;
-        console.error(formatDiagnostic(d));
+        console.error(formatDiagnostic(d, { source: d.loc.file === absPath ? source : undefined }));
         if (d.severity === "error") hasError = true;
       }
 
@@ -321,9 +321,10 @@ function runWatch(
 
     state = result.nextState;
 
+    const sources = new Map(inputs.map((i) => [i.fileName, i.source]));
     for (const d of result.diagnostics) {
       if (!meetsLevel(d.severity, DEV_REPORT_LEVEL)) continue;
-      console.error(formatDiagnostic(d));
+      console.error(formatDiagnostic(d, { source: sources.get(d.loc.file) }));
     }
 
     const barrelEntries: BarrelMap = new Map();

--- a/tooling/cli/src/lib/diagnostics.test.ts
+++ b/tooling/cli/src/lib/diagnostics.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { join, resolve, sep } from "node:path";
 import { formatDiagnostic } from "./diagnostics.ts";
 import type { Diagnostic } from "@inkline/compiler";
 
@@ -11,6 +12,21 @@ function makeDiag(overrides: Partial<Diagnostic> = {}): Diagnostic {
     url: "",
     loc: { file: "Button.ink.tsx", line: 10, column: 5, offset: 100, length: 10 },
     ...overrides,
+  };
+}
+
+/** Builds a `loc` whose offset/line/column all point at the first occurrence of `needle`. */
+function locOf(source: string, needle: string, file = "Button.ink.tsx"): Diagnostic["loc"] {
+  const offset = source.indexOf(needle);
+  if (offset === -1) throw new Error(`fixture does not contain ${needle}`);
+  const before = source.slice(0, offset);
+  const lineStart = before.lastIndexOf("\n") + 1;
+  return {
+    file,
+    line: before.split("\n").length,
+    column: offset - lineStart + 1,
+    offset,
+    length: needle.length,
   };
 }
 
@@ -42,5 +58,139 @@ describe("formatDiagnostic", () => {
       makeDiag({ loc: { file: "", line: 0, column: 0, offset: 0, length: 0 } }),
     );
     expect(msg.startsWith("error  INK001  Something went wrong")).toBe(true);
+  });
+});
+
+describe("formatDiagnostic source frame", () => {
+  const source = [
+    'import { defineComponent, Show } from "@inkline/core";',
+    "",
+    "export default defineComponent(() => {",
+    "  return <Show>ok</Show>;",
+    "});",
+    "",
+  ].join("\n");
+
+  it("renders the offending line and a caret under the reported span", () => {
+    const msg = formatDiagnostic(makeDiag({ loc: locOf(source, "<Show>") }), { source });
+
+    expect(msg).toContain("\n  4 |   return <Show>ok</Show>;\n    |          ^^^^^^");
+  });
+
+  it("pads the gutter so the caret line aligns with a multi-digit line number", () => {
+    const padded = `${"\n".repeat(9)}  return <Show>ok</Show>;\n`;
+    const msg = formatDiagnostic(makeDiag({ loc: locOf(padded, "<Show>") }), { source: padded });
+
+    expect(msg).toContain("\n  10 |   return <Show>ok</Show>;\n     |          ^^^^^^");
+  });
+
+  it("omits the frame when no source is supplied", () => {
+    const msg = formatDiagnostic(makeDiag({ loc: locOf(source, "<Show>") }));
+
+    expect(msg).not.toContain("|");
+  });
+
+  it("omits the frame for a diagnostic with no real location", () => {
+    const msg = formatDiagnostic(
+      makeDiag({ loc: { file: "<unknown>", line: 0, column: 0, offset: 0, length: 0 } }),
+      { source },
+    );
+
+    expect(msg).not.toContain("|");
+  });
+
+  it("places the frame above help and docs", () => {
+    const msg = formatDiagnostic(
+      makeDiag({ loc: locOf(source, "<Show>"), help: "Pass a when prop", url: "https://d.ev" }),
+      { source },
+    );
+
+    expect(msg.indexOf("^^^^^^")).toBeLessThan(msg.indexOf("help:"));
+    expect(msg.indexOf("help:")).toBeLessThan(msg.indexOf("docs:"));
+  });
+
+  it("clamps a multi-line span to the end of its first line", () => {
+    const multi = ["<Transition>", "  <For each={x} />", "</Transition>", ""].join("\n");
+    const loc = { ...locOf(multi, "<Transition>"), length: multi.indexOf("</Transition>") + 13 };
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: multi });
+
+    // Only the head of the span is underlined; the caret run stops at the newline.
+    expect(msg).toContain("\n  1 | <Transition>\n    | ^^^^^^^^^^^^");
+    expect(msg).not.toContain("^^^^^^^^^^^^^");
+  });
+
+  it("renders a single caret for a zero-length span", () => {
+    const loc = { ...locOf(source, "<Show>"), length: 0 };
+    const msg = formatDiagnostic(makeDiag({ loc }), { source });
+
+    expect(msg).toContain("\n    |          ^");
+    expect(msg).not.toContain("^^");
+  });
+
+  it("points one past the last character when the span sits at end of file", () => {
+    const eof = "const a = 1;";
+    const loc = { file: "a.ts", line: 1, column: 13, offset: eof.length, length: 0 };
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: eof });
+
+    expect(msg).toContain("\n  1 | const a = 1;\n    |             ^");
+  });
+
+  it("renders an empty frame line when the file ends with a newline", () => {
+    const trailing = "const a = 1;\n";
+    const loc = { file: "a.ts", line: 2, column: 1, offset: trailing.length, length: 0 };
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: trailing });
+
+    expect(msg).toContain("\n  2 | \n    | ^");
+  });
+
+  it("skips the frame when the offset is past the end of the source", () => {
+    const loc = { file: "a.ts", line: 1, column: 1, offset: 999, length: 3 };
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: "const a = 1;" });
+
+    expect(msg).not.toContain("|");
+  });
+
+  it("keeps tabs in the caret padding so alignment survives any tab width", () => {
+    const tabbed = "\t<Show>ok</Show>\n";
+    const msg = formatDiagnostic(makeDiag({ loc: locOf(tabbed, "<Show>") }), { source: tabbed });
+
+    expect(msg).toContain("\n  1 | \t<Show>ok</Show>\n    | \t^^^^^^");
+  });
+
+  it("strips a carriage return from a CRLF source line", () => {
+    const crlf = "const a = 1;\r\nconst b = 2;\r\n";
+    const msg = formatDiagnostic(makeDiag({ loc: locOf(crlf, "const b") }), { source: crlf });
+
+    expect(msg).toContain("\n  2 | const b = 2;\n    | ^^^^^^^");
+  });
+});
+
+describe("formatDiagnostic paths", () => {
+  it("prints an absolute path relative to the invocation directory", () => {
+    const cwd = process.cwd();
+    const file = join(cwd, "src", "Button.ink.tsx");
+
+    const msg = formatDiagnostic(makeDiag({ loc: { ...makeDiag().loc, file } }), { cwd });
+
+    expect(msg.startsWith(join("src", "Button.ink.tsx"))).toBe(true);
+    expect(msg).not.toContain(cwd);
+  });
+
+  it("leaves an already-relative path alone", () => {
+    const msg = formatDiagnostic(makeDiag(), { cwd: process.cwd() });
+
+    expect(msg.startsWith("Button.ink.tsx:10:5")).toBe(true);
+  });
+
+  it("keeps the absolute path when climbing out of the tree would be longer", () => {
+    const file = resolve(sep, "a.tsx");
+    const cwd = resolve(sep, "very", "deeply", "nested", "project", "packages", "cli");
+
+    const msg = formatDiagnostic(makeDiag({ loc: { ...makeDiag().loc, file } }), { cwd });
+
+    expect(msg.startsWith(file)).toBe(true);
   });
 });

--- a/tooling/cli/src/lib/diagnostics.ts
+++ b/tooling/cli/src/lib/diagnostics.ts
@@ -1,16 +1,86 @@
+import { isAbsolute, relative } from "node:path";
 import type { Diagnostic } from "@inkline/compiler";
+
+export interface FormatDiagnosticOptions {
+  /**
+   * Full text of the file the diagnostic points at. The formatter stays pure — it never reads the
+   * file itself — so callers that have the source already pass it here to get a code frame. Omit it
+   * and the frame is skipped.
+   */
+  source?: string;
+  /** Directory the printed path is made relative to. Defaults to the invocation directory. */
+  cwd?: string;
+}
+
+/**
+ * Absolute paths put a ~140-character prefix on every line of output. Print the path relative to the
+ * invocation directory instead, unless that comes out longer (a file outside the tree climbs out
+ * through `../../..`), in which case the absolute path is the shorter read.
+ */
+function formatPath(file: string, cwd: string): string {
+  if (!isAbsolute(file)) return file;
+  const rel = relative(cwd, file);
+  return rel.length > 0 && rel.length < file.length ? rel : file;
+}
 
 /**
  * Config-time diagnostics carry no source position. Printing `<unknown>:0:0` for them is noise, so
  * the location prefix is dropped entirely when there is nothing real to point at.
  */
-function formatLocation(loc: Diagnostic["loc"]): string {
-  if (!loc.file || loc.file === "<unknown>") return "";
-  return `${loc.file}:${loc.line}:${loc.column}  `;
+function hasLocation(loc: Diagnostic["loc"]): boolean {
+  return Boolean(loc.file) && loc.file !== "<unknown>";
 }
 
-export function formatDiagnostic(d: Diagnostic): string {
-  let msg = `${formatLocation(d.loc)}${d.severity}  ${d.code}  ${d.title}`;
+function formatLocation(loc: Diagnostic["loc"], cwd: string): string {
+  if (!hasLocation(loc)) return "";
+  return `${formatPath(loc.file, cwd)}:${loc.line}:${loc.column}  `;
+}
+
+/**
+ * A `rustc`-style code frame: the offending line behind a line-number gutter, and a caret run under
+ * the reported span.
+ *
+ * ```
+ *   10 |       <Show>
+ *      |       ^^^^^^
+ * ```
+ *
+ * `offset`/`length` from {@link SourceLocation} are the authority for the span; the line number is
+ * derived from `offset` too so the gutter can never disagree with the slice it labels. A span that
+ * crosses a line boundary is clamped to the end of its first line — the head of a multi-line span is
+ * what identifies it, and printing the whole body buries the message.
+ */
+function renderFrame(loc: Diagnostic["loc"], source: string): string {
+  const { offset, length } = loc;
+  if (offset < 0 || offset > source.length) return "";
+
+  const lineStart = offset === 0 ? 0 : source.lastIndexOf("\n", offset - 1) + 1;
+  const newline = source.indexOf("\n", lineStart);
+  const lineEnd = newline === -1 ? source.length : newline;
+  const text = source.slice(lineStart, lineEnd).replace(/\r$/, "");
+
+  const line = source.slice(0, lineStart).split("\n").length;
+  const gutter = String(line);
+  const blank = " ".repeat(gutter.length);
+
+  // Copy the prefix verbatim except for its non-tab characters, so a tab-indented line keeps the
+  // caret aligned whatever the terminal's tab width is. `column` is derived from `offset` rather
+  // than trusted from `loc`, and can land one past the end of the line at EOF.
+  const column = offset - lineStart;
+  const prefix =
+    text.slice(0, column).replace(/[^\t]/g, " ") + " ".repeat(Math.max(0, column - text.length));
+  const carets = "^".repeat(Math.max(1, Math.min(length, text.length - column)));
+
+  return `\n  ${gutter} | ${text}\n  ${blank} | ${prefix}${carets}`;
+}
+
+export function formatDiagnostic(d: Diagnostic, options: FormatDiagnosticOptions = {}): string {
+  const cwd = options.cwd ?? process.cwd();
+
+  let msg = `${formatLocation(d.loc, cwd)}${d.severity}  ${d.code}  ${d.title}`;
+  if (options.source !== undefined && hasLocation(d.loc)) {
+    msg += renderFrame(d.loc, options.source);
+  }
   if (d.help) msg += `\n    help: ${d.help}`;
   if (d.url) msg += `\n    docs: ${d.url}`;
   return msg;


### PR DESCRIPTION
## Summary

`formatDiagnostic` was a one-line message with an absolute path and no sight of the code it was complaining about — a ~140-character prefix repeated on every line of output. `SourceLocation` already carried `offset` and `length` alongside line/column; nothing used them. This renders a `rustc`-style source frame with a caret under the reported span, prints paths relative to the invocation directory, and fills in the 7 catalog codes that shipped with `help: undefined`.

```
$ inkline check src/Menu.ink.tsx
src/Menu.ink.tsx:8:7  error  INK0060  <Show> requires a 'when' prop
  8 |       <Show>
    |       ^^^^^^
    help: Pass the condition as a prop: <Show when={visible()}>…</Show>. …
    docs: https://docs.inkline.dev/diagnostics/INK0060
```

## Related issues

- UXF-85 (parent: UXF-71, compiler authoring-surface friction audit, finding #9)

## Type of change

- [x] `feat` — new user-facing capability or public API

## What changed

- **`tooling/cli/src/lib/diagnostics.ts`** — `formatDiagnostic(d, options?)`. `options.source` is the file text; `options.cwd` is the base for the relative path. The formatter is pure — no `fs` read inside it. Omit `source` and the frame is skipped, so config-time diagnostics keep their previous one-line output verbatim.
- **`check.ts` / `compile.ts`** — pass the source they already read, matched on `d.loc.file` so a cross-file diagnostic never gets framed against the wrong text. The watch loop builds a `fileName → source` map from its inputs.
- **Catalog** — help text for `INK0060`, `INK0061`, `INK0062`, `INK0065`, `INK0066`, `INK0080`, `INK0090`, each containing a corrected example rather than a restatement of the title.
- **`plugin/runner.ts`** — `INK0090` was hand-building its `Diagnostic` and bypassing the catalog, so it would have silently dropped the new help text. It now goes through `createDiagnostic`.

## Rendering decisions

- The **line number is derived from `offset`**, not read from `loc.line`, so the gutter can never disagree with the slice it labels.
- A **span crossing a line boundary is clamped to the end of its first line**. The head of a multi-line span identifies it; printing the whole body buries the message.
- **Tabs are preserved in the caret padding** (prefix copied verbatim, non-tabs replaced by spaces) so alignment survives any terminal tab width.
- A path stays **absolute when `../../..` out of the tree would be the longer read**.
- Colour was optional in the scope and is not implemented — no `NO_COLOR` / TTY handling to get wrong.

## Failure modes

| What breaks | How it shows | Recovery |
| --- | --- | --- |
| `offset` out of range for the given source (stale text, wrong file) | frame silently omitted | header/help/docs still print; identical to pre-change output |
| Diagnostic has no real location (`<unknown>` or empty file) | frame and location prefix both omitted | unchanged behaviour, covered by existing tests |
| Caller passes no `source` | no frame | opt-in by design; `config.ts` and `errors.ts` deliberately do not pass one |
| A new code lands with no `help` | `codes.test.ts` fails, naming the code | assertion runs over `Object.keys(DIAGNOSTICS)`, never a count |

## Test plan

- [x] `pnpm test` in `tooling/cli` — 123 passed across `src/lib`, 15 new formatter cases: frame rendering, multi-digit gutter alignment, multi-line span clamping, zero-length span, end-of-file offset, trailing-newline line, out-of-range offset, tab padding, CRLF, and the three path cases.
- [x] `pnpm test` in `core/compiler` — `src/core/diagnostics` + `src/plugin` green. Full suite was 3272/3273 before this branch's fixup; the one failure was `collector.test.ts` asserting `INK0060` has no help, which is exactly the gap being closed, and it is rewritten.
- [x] `pnpm check` in both packages — error counts identical to `main` (205 / 29, all pre-existing unresolved-module noise from unbuilt workspace deps); nothing in the changed files.
- [x] Manual end-to-end against a built CLI, output pasted above and below.
- [ ] CI

Multi-line span clamping, verified end-to-end:

```
$ inkline check src/Anim.ink.tsx
src/Anim.ink.tsx:5:5  error  INK0065  <Transition> cannot wrap <For>; list transitions are not yet supported
  5 |     <Transition name="fade">
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
```

The `<Transition>` element spans lines 5–9; the caret run stops at the end of line 5.

## Checklist

- [x] Added a changeset (`.changeset/diagnostic-source-frames.md`, minor for `@inkline/compiler` and `@inkline/cli`).
- [x] Updated `core/compiler/docs/adding-a-diagnostic.md` and `docs/api-reference.md` — `help` is now required, and the catalog test enforces it.
- [x] Conventional commit.
