### PR TITLE
fix(cli): let the config file's sourceMap reach the resolution chain

### DIFF
--- a/.changeset/cli-source-map-config-precedence.md
+++ b/.changeset/cli-source-map-config-precedence.md
@@ -1,0 +1,21 @@
+---
+"@inkline/cli": patch
+---
+
+fix(cli): let the config file's `sourceMap` take effect, and `--no-verbose` override a config `verbose`
+
+A config file's `sourceMap` was silently ignored. `--source-map` carried a citty `default: "external"`,
+which made `args["source-map"]` permanently defined, so the `flag ?? config ?? "external"` chain could
+never reach the config branch — the same defect that was fixed for `--out-dir`, one line down. Removing
+the citty default lets the chain work as written: `--source-map` still wins, a config `sourceMap` now
+applies when the flag is omitted, and `external` remains the documented fallback.
+
+`--verbose` on both `compile` and `check` had the boolean form of the same problem. With `default: false`,
+an omitted flag and an explicit `--no-verbose` both arrived as `false`, so a config `verbose: true` could
+not be switched off from the command line. The flag now declares no default and resolves
+`flag ?? config ?? false`.
+
+Behaviour change: a project whose config sets `sourceMap` was previously getting `external` regardless;
+it now gets what the config asks for. Projects that relied on the ignored value being overridden should
+pass `--source-map external` explicitly. `--clean` and `--watch` keep their citty defaults — they have no
+config counterpart, so the default is the whole resolution rather than a shadow over one.

--- a/tooling/cli/src/commands/check.test.ts
+++ b/tooling/cli/src/commands/check.test.ts
@@ -145,6 +145,26 @@ describe("check / compile option parity", () => {
     expect(checkOptions?.targetOptions).toEqual({ react: { forwardRef: true } });
   });
 
+  // The assertion above only ever exercises an omitted `--verbose`, and that is exactly the input
+  // where `||` and `??` agree — so it cannot see `check` losing the `??` half of the resolution.
+  // Passing the flag is what separates them: under `||` a config `verbose: true` survives
+  // `--no-verbose`, which is the defect this pair of commands was just fixed for.
+  it("lets --no-verbose override a config verbose: true, matching compile", async () => {
+    const dir = resolve(TMP, "verbose-parity");
+    const configPath = writeFixture(dir);
+    process.chdir(dir);
+
+    await run(compileCommand, ["src/A.ink.tsx", "--config", configPath, "--no-verbose"]);
+    const compileOptions = compileCalls.at(-1);
+    compileCalls.length = 0;
+
+    await run(checkCommand, ["src/A.ink.tsx", "--config", configPath, "--no-verbose"]);
+    const checkOptions = compileCalls.at(-1);
+
+    expect(compileOptions?.verbose).toBe(false);
+    expect(checkOptions?.verbose).toBe(false);
+  });
+
   it("reports missing targets as a diagnostic rather than inventing a target set", async () => {
     const dir = resolve(TMP, "no-targets");
     mkdirSync(dir, { recursive: true });

--- a/tooling/cli/src/commands/check.ts
+++ b/tooling/cli/src/commands/check.ts
@@ -14,15 +14,16 @@ export default defineCommand({
     pattern: { type: "positional", description: "Glob pattern for .ink.tsx files", required: true },
     target: { type: "string", description: "Comma-separated targets" },
     config: { type: "string", description: "Path to config file" },
+    /** Chain arg (config `verbose`); no default — see the args note in `compile.ts` for why. */
     verbose: {
       type: "boolean",
       description: "Include the stack trace in error output",
-      default: false,
     },
   },
   async run({ args }) {
     const fileConfig = await loadInklineConfig(args.config);
-    const verbose = args.verbose || fileConfig.verbose === true;
+    // Same chain as `compile`: `??` so an omitted flag defers to the config and `--no-verbose` wins.
+    const verbose = args.verbose ?? fileConfig.verbose === true;
     const targets = resolveTargets(args.target, fileConfig);
 
     try {

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -371,6 +371,117 @@ describe("compile command --out-dir precedence", () => {
   });
 });
 
+describe("compile command --source-map precedence", () => {
+  const SOURCE = () => resolve(FIXTURES, "Counter.ink.tsx");
+  const INLINE_MARKER = "//# sourceMappingURL=data:application/json;base64,";
+
+  /**
+   * Compile into a fresh output directory and report the two observable outcomes: an inline map is
+   * appended to the emitted file, an external one is written beside it as `.map`, and `none` leaves
+   * neither. Reading the artifacts keeps this a black-box check of what the user actually gets.
+   */
+  async function compileWith(
+    name: string,
+    extraArgs: string[],
+    configSourceMap?: string,
+  ): Promise<{ contents: string; hasExternalMap: boolean }> {
+    const base = tmpDir(name);
+    const outDir = resolve(base, "out");
+    const args = [SOURCE(), "--target", "react", "--out-dir", outDir, ...extraArgs];
+
+    if (configSourceMap !== undefined) {
+      const configPath = resolve(base, "inkline.config.mjs");
+      writeFileSync(
+        configPath,
+        `export default { sourceMap: ${JSON.stringify(configSourceMap)} };\n`,
+      );
+      args.push("--config", configPath);
+    }
+
+    const { exitCode } = await runCompile(args);
+    expect(exitCode).toBe(0);
+
+    const outFile = resolve(outDir, "react", "Counter.tsx");
+    return {
+      contents: readFileSync(outFile, "utf-8"),
+      hasExternalMap: existsSync(`${outFile}.map`),
+    };
+  }
+
+  // The citty `default: "external"` used to make `args["source-map"]` permanently defined, so this
+  // branch of the chain was unreachable and a config `sourceMap` was silently ignored.
+  it("uses the config file's sourceMap when no flag is passed", async () => {
+    const { contents, hasExternalMap } = await compileWith("source-map-config", [], "inline");
+    expect(contents).toContain(INLINE_MARKER);
+    expect(hasExternalMap).toBe(false);
+  });
+
+  it("prefers --source-map over the config file's sourceMap", async () => {
+    const { contents, hasExternalMap } = await compileWith(
+      "source-map-flag",
+      ["--source-map", "none"],
+      "inline",
+    );
+    expect(contents).not.toContain(INLINE_MARKER);
+    expect(hasExternalMap).toBe(false);
+  });
+
+  it("falls back to external when neither the flag nor the config sets sourceMap", async () => {
+    const { contents, hasExternalMap } = await compileWith("source-map-default", []);
+    expect(hasExternalMap).toBe(true);
+    expect(contents).not.toContain(INLINE_MARKER);
+  });
+
+  it("honours --source-map when the config is silent", async () => {
+    const { contents } = await compileWith("source-map-flag-only", ["--source-map", "inline"]);
+    expect(contents).toContain(INLINE_MARKER);
+  });
+});
+
+describe("compile command --verbose precedence", () => {
+  const SOURCE = () => resolve(FIXTURES, "Counter.ink.tsx");
+  /** `reportConfigError` prints the error stack only when `verbose` resolved true. */
+  const STACK_FRAME = "\n    at ";
+
+  /**
+   * Resolve `verbose` observably: a misspelled `--target` routes through `reportConfigError`, which
+   * appends the stack trace only under verbose. A config `verbose: true` is present in every case so
+   * the flag's ability to override it is what is under test.
+   */
+  async function stackShown(name: string, extraArgs: string[]): Promise<boolean> {
+    const base = tmpDir(name);
+    const configPath = resolve(base, "inkline.config.mjs");
+    writeFileSync(configPath, `export default { verbose: true };\n`);
+
+    const { exitCode, errs } = await runCompile([
+      SOURCE(),
+      "--target",
+      "reakt",
+      "--config",
+      configPath,
+      ...extraArgs,
+    ]);
+
+    expect(exitCode).toBe(2);
+    expect(errs).toContain("INK0085");
+    return errs.includes(STACK_FRAME);
+  }
+
+  it("uses the config file's verbose when no flag is passed", async () => {
+    expect(await stackShown("verbose-config", [])).toBe(true);
+  });
+
+  // With the old citty `default: false`, `--no-verbose` was indistinguishable from an omitted flag,
+  // so a config `verbose: true` could never be switched off from the command line.
+  it("lets --no-verbose override a config verbose: true", async () => {
+    expect(await stackShown("verbose-no-flag", ["--no-verbose"])).toBe(false);
+  });
+
+  it("honours --verbose", async () => {
+    expect(await stackShown("verbose-flag", ["--verbose"])).toBe(true);
+  });
+});
+
 describe("compile command watch mode", () => {
   it("rebuilds on a component change and regenerates stories on a story change", async () => {
     const configDir = tmpDir("watch");

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -104,26 +104,44 @@ export function writeNamespaceBarrels(
 
 export default defineCommand({
   meta: { name: "compile", description: "Compile .ink.tsx files and generate stories" },
+  /**
+   * A citty `default` makes an arg permanently defined, which destroys the flag > config > default
+   * chain in `run` below: for a string the config branch becomes unreachable, and for a boolean
+   * `--no-x` becomes indistinguishable from omitting the flag. So any arg with a config counterpart
+   * declares no `default` and puts its fallback in the chain instead. A citty `default` is correct
+   * only where there is no config counterpart and the default *is* the whole resolution. Each arg
+   * below states which of the two it is; do not add a `default` without re-reading this.
+   */
   args: {
+    /** No config counterpart: the positional inputs are the invocation itself. */
     pattern: { type: "positional", description: "Glob pattern for .ink.tsx files", required: true },
+    /** Chain arg (config `targets`); no default — `resolveTargets` deliberately leaves it empty. */
     target: { type: "string", description: "Comma-separated targets" },
+    /** Chain arg (config `srcDir`); no default — falls back to the sources' common prefix. */
     "src-dir": { type: "string", description: "Source root directory to strip from output paths" },
-    // No citty `default` here: it would make `args["out-dir"]` always defined, so the resolution
-    // chain below could never fall through to the config file. The `"dist"` fallback lives there.
+    /** Chain arg (config `outDir`); no default — the `"dist"` fallback lives in the chain. */
     "out-dir": { type: "string", description: "Default output directory (default: dist)" },
-    "source-map": { type: "string", description: "external | inline | none", default: "external" },
+    /** Chain arg (config `sourceMap`); no default — the `"external"` fallback lives in the chain. */
+    "source-map": { type: "string", description: "external | inline | none (default: external)" },
+    /** No config counterpart by construction: this flag names the config file the chain reads. */
     config: { type: "string", description: "Path to config file" },
-    verbose: { type: "boolean", description: "Verbose plugin error logs", default: false },
+    /** Chain arg (config `verbose`); no default — so `--no-verbose` can beat a config `true`. */
+    verbose: { type: "boolean", description: "Verbose plugin error logs" },
+    /** Deliberate default: no config counterpart, so this is the whole resolution. `--no-clean` opts out. */
     clean: {
       type: "boolean",
       description: "Clean output directories before compilation",
       default: true,
     },
+    /** Deliberate default: no config counterpart — watching is a per-invocation mode, not a setting. */
     watch: { type: "boolean", description: "Watch and recompile on change", default: false },
   },
   async run({ args }) {
     const fileConfig = await loadInklineConfig(args.config);
-    const verbose = args.verbose || fileConfig.verbose === true;
+    // `??`, not `||`: with the citty default gone, an omitted `--verbose` is `undefined` and only
+    // then does the config apply. `||` would let a config `true` survive an explicit `--no-verbose`.
+    // The `=== true` keeps a non-boolean config value (reported by the schema, not rewritten) falsy.
+    const verbose = args.verbose ?? fileConfig.verbose === true;
 
     const targets = resolveTargets(args.target, fileConfig);
 


### PR DESCRIPTION
## Summary

A config file's `sourceMap` was silently ignored. `--source-map` declared a citty `default: "external"`, which makes the arg permanently defined, so the resolution chain `args["source-map"] ?? fileConfig.sourceMap ?? "external"` could never reach its config branch. This is the same defect #529 removed for `--out-dir` — one line down in the same args block, directly under the comment explaining it.

Removing the citty default lets the chain work as written. Sweeping the rest of the block turned up the boolean form of the same problem on `--verbose`.

## Related issues

- Closes UXF-109.

## Type of change

- [x] `fix` — bug fix

## Changes

Verified citty's behaviour first, since the fix depends on it (probe against `citty@0.2.2`):

| declaration | omitted | `--x` | `--no-x` |
| --- | --- | --- | --- |
| `{ type: "string", default: "external" }` | `"external"` | value | — |
| `{ type: "string" }` | `undefined` | value | — |
| `{ type: "boolean", default: false }` | `false` | `true` | `false` |
| `{ type: "boolean" }` | `undefined` | `true` | `false` |

A `default` therefore erases "not passed" — for a string the config branch dies, and for a boolean `--no-x` becomes indistinguishable from omitting the flag.

**`--source-map`** — dropped `default: "external"`. The chain was already the right shape, so this line alone restores flag > config > `external`.

**`--verbose`** (`compile` and `check`) — dropped `default: false` and changed `||` to `??`. Previously a config `verbose: true` could not be switched off from the command line, because `--no-verbose` and an omitted flag both arrived as `false`. Both halves are required together: removing the default without moving to `??` would leave config reachable but the flag unable to override; moving to `??` without removing the default would make config unreachable. `check` is included because it carries the identical two lines, and this repo already documents that `check` and `compile` must not drift on config handling.

**Args-block sweep** — every arg now carries a one-line finding, under a block note explaining the mechanism once:

| arg | config counterpart | citty `default` | finding |
| --- | --- | --- | --- |
| `pattern` | — | none | N/A — positional inputs are the invocation |
| `target` | `targets` | none | already correct |
| `src-dir` | `srcDir` | none | already correct |
| `out-dir` | `outDir` | none | already correct (fixed in #529) |
| `source-map` | `sourceMap` | **`"external"`** | **fixed** — default removed |
| `config` | — | none | N/A — names the config file the chain reads |
| `verbose` | `verbose` | **`false`** | **fixed** — default removed, `\|\|` → `??` |
| `clean` | — | `true` | deliberate — no config counterpart, `--no-clean` opts out |
| `watch` | — | `false` | deliberate — a per-invocation mode, not a setting |

`clean` and `watch` are the only two keeping a citty default, and both are correct: with no config counterpart the default *is* the whole resolution rather than a shadow over one.

## Test plan

- [x] `vp test` in `tooling/cli` — 195 passed (18 files)
- [x] `vp check` — no lint, type, or formatting errors
- [x] New tests confirmed **red against the pre-fix source** (stashed the two command files and re-ran): `uses the config file's sourceMap when no flag is passed` and `lets --no-verbose override a config verbose: true` both fail. The other new cases pass before and after, which is expected — those paths were already working and are there to pin them.
- [x] Assertions are black-box on observable artifacts: `inline` appends `//# sourceMappingURL=data:application/json;base64,` to the emitted file, `external` writes a `.map` sidecar, `none` leaves neither. `verbose` is read through `reportConfigError`, which prints the stack only when it resolved true.

Covering the acceptance criteria: config `sourceMap: "inline"` with no flag produces inline maps; `--source-map none` overrides it; neither set yields `external`; plus `--source-map` honoured when the config is silent, and the three `verbose` precedence cases.

## Notes

Behaviour change, called out in the changeset: a project whose config sets `sourceMap` was previously getting `external` regardless and will now get what the config asks for. Passing `--source-map external` explicitly restores the old output.

No docs change needed — `core/compiler/README.md` already documents `--source-map` as defaulting to `external` and states "CLI flags override config file values". Both were aspirational for this flag before this PR and are now true.

Out of scope, noted while here: `--source-map`'s value is cast to the union without validation, so `--source-map bogus` is accepted and silently behaves as `none`. Separate from the precedence defect; happy to file it if wanted.

## Checklist

- [x] Added a changeset (`.changeset/cli-source-map-config-precedence.md`)
- [x] Public API/conventions docs reviewed — no update required (see Notes)
- [x] Commit message follows the conventional format

