### PR TITLE
fix(cli): mark a clamped multi-line span with a continuation line

### DIFF
--- a/.changeset/diagnostic-span-continuation-marker.md
+++ b/.changeset/diagnostic-span-continuation-marker.md
@@ -1,0 +1,28 @@
+---
+"@inkline/cli": patch
+---
+
+fix(cli): mark a clamped multi-line span with a `...` continuation line
+
+A source frame clamps a span crossing a line boundary to the end of its first line, so the caret run
+stops at the newline. Nothing distinguished that from a span that genuinely ends where the carets
+stop: an `INK0065` whose span ran to line 13 underlined to column 68 and read exactly like a span
+ending at column 68. The reader was not misled — the message names the construct — only
+under-informed.
+
+The frame now prints a `...` continuation line under the carets, following `rustc`'s convention for
+an elided span body:
+
+```
+$ inkline check src/Menu.ink.tsx
+src/Menu.ink.tsx:3:5  error  INK0065  <Transition> expects exactly one child
+  3 |     <Transition>
+    |     ^^^^^^^^^^^^
+    |     ...
+```
+
+The clamp itself is unchanged; printing the whole span body was deliberately rejected because it
+buries the message. The marker is driven by the raw span end (`offset + length > lineEnd`), not by
+the caret count, so a span ending exactly at the line boundary emits nothing, and one marker covers
+any number of elided lines. A length overrunning the last line of the file has no next line to
+continue into and is left unmarked.

--- a/tooling/cli/src/lib/diagnostics.test.ts
+++ b/tooling/cli/src/lib/diagnostics.test.ts
@@ -120,6 +120,46 @@ describe("formatDiagnostic source frame", () => {
     expect(msg).not.toContain("^^^^^^^^^^^^^");
   });
 
+  it("marks the clamp with a continuation line when the span ends on the next line", () => {
+    const multi = ["<Show>", "</Show>", ""].join("\n");
+    const loc = { ...locOf(multi, "<Show>"), length: multi.indexOf("</Show>") + 7 };
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: multi });
+
+    expect(msg).toContain("\n  1 | <Show>\n    | ^^^^^^\n    | ...");
+  });
+
+  it("marks the clamp with a single continuation line when the span crosses several lines", () => {
+    const multi = ["  <Transition>", "    <For each={x} />", "    <Show />", "  </Transition>", ""];
+    const source = multi.join("\n");
+    const loc = { ...locOf(source, "<Transition>"), length: source.trimEnd().length - 2 };
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source });
+
+    // One marker, aligned with the caret run — not one per elided line.
+    expect(msg).toContain("\n  1 |   <Transition>\n    |   ^^^^^^^^^^^^\n    |   ...");
+    expect(msg.match(/\.\.\./g)).toHaveLength(1);
+  });
+
+  it("omits the continuation line for a span ending exactly at the line boundary", () => {
+    const multi = ["<Transition>", "  <For each={x} />", ""].join("\n");
+    const loc = locOf(multi, "<Transition>");
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: multi });
+
+    expect(msg).toContain("\n  1 | <Transition>\n    | ^^^^^^^^^^^^");
+    expect(msg).not.toContain("...");
+  });
+
+  it("omits the continuation line when an overlong span has no next line to continue into", () => {
+    const eof = "const a = 1;";
+    const loc = { file: "a.ts", line: 1, column: 1, offset: 0, length: 999 };
+
+    const msg = formatDiagnostic(makeDiag({ loc }), { source: eof });
+
+    expect(msg).not.toContain("...");
+  });
+
   it("renders a single caret for a zero-length span", () => {
     const loc = { ...locOf(source, "<Show>"), length: 0 };
     const msg = formatDiagnostic(makeDiag({ loc }), { source });

--- a/tooling/cli/src/lib/diagnostics.ts
+++ b/tooling/cli/src/lib/diagnostics.ts
@@ -48,7 +48,15 @@ function formatLocation(loc: Diagnostic["loc"], cwd: string): string {
  * `offset`/`length` from {@link SourceLocation} are the authority for the span; the line number is
  * derived from `offset` too so the gutter can never disagree with the slice it labels. A span that
  * crosses a line boundary is clamped to the end of its first line — the head of a multi-line span is
- * what identifies it, and printing the whole body buries the message.
+ * what identifies it, and printing the whole body buries the message. Such a span gets a `...`
+ * continuation marker under the carets, following `rustc`, so a clamped run is never mistaken for a
+ * span that genuinely ends where the carets stop:
+ *
+ * ```
+ *   10 |       <Show>
+ *      |       ^^^^^^
+ *      |       ...
+ * ```
  */
 function renderFrame(loc: Diagnostic["loc"], source: string): string {
   const { offset, length } = loc;
@@ -71,7 +79,14 @@ function renderFrame(loc: Diagnostic["loc"], source: string): string {
     text.slice(0, column).replace(/[^\t]/g, " ") + " ".repeat(Math.max(0, column - text.length));
   const carets = "^".repeat(Math.max(1, Math.min(length, text.length - column)));
 
-  return `\n  ${gutter} | ${text}\n  ${blank} | ${prefix}${carets}`;
+  const frame = `\n  ${gutter} | ${text}\n  ${blank} | ${prefix}${carets}`;
+
+  // The span was clamped only if it reaches past this line's newline. A span ending exactly at the
+  // boundary is complete, and a length overrunning the last line of the file has nothing to continue
+  // into, so neither gets a marker.
+  const clamped = newline !== -1 && offset + length > lineEnd;
+
+  return clamped ? `${frame}\n  ${blank} | ${prefix}...` : frame;
 }
 
 export function formatDiagnostic(d: Diagnostic, options: FormatDiagnosticOptions = {}): string {


### PR DESCRIPTION
## Summary

A source frame clamps a span crossing a line boundary to the end of its first line, and nothing distinguished that truncated caret run from a span that genuinely ends where the carets stop. The frame now prints a `...` continuation line under the carets, following `rustc`'s convention for an elided span body.

```
$ inkline check src/Menu.ink.tsx
src/Menu.ink.tsx:3:5  error  INK0065  <Transition> expects exactly one child
  3 |     <Transition>
    |     ^^^^^^^^^^^^
    |     ...
```

Follow-up to the QA of #541. Cosmetic (P3) — the diagnostic message already names the construct, so the reader was under-informed rather than misled.

## Related issues

- Refs UXF-120

## Type of change

- [ ] `feat` — new user-facing capability or public API
- [x] `fix` — bug fix
- [ ] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `chore` / `ci` — tooling, dependencies, or CI

## Changes

`tooling/cli/src/lib/diagnostics.ts` — `renderFrame` appends `\n  {blank} | {prefix}...` when the span was clamped. The marker is aligned with the caret run rather than flush in the gutter, keeping the frame's existing rule that everything under the gutter aligns to the source column.

The clamp itself is unchanged; printing the whole span body was deliberately rejected in the original work because it buries the message.

The predicate is the raw span end, not the caret count:

```ts
const clamped = newline !== -1 && offset + length > lineEnd;
```

Three consequences fall out of that shape:

- A span ending exactly at the line boundary is complete and emits nothing.
- One marker covers any number of elided lines — the condition is not per-line.
- A `length` overrunning the last line of the file has no next line to continue into and is left unmarked, so a bogus length cannot invent a continuation.

CRLF is handled by construction: `lineEnd` is the index of the `\n`, so a span ending at the `\r` is a boundary-ending span, not a crossing one.

## Test plan

Four cases added to `tooling/cli/src/lib/diagnostics.test.ts`, three of them the acceptance gate:

- [x] span ending on the next line → marker
- [x] span crossing several lines → exactly one marker (asserted via match count, not just presence)
- [x] span ending exactly at the line boundary → no marker
- [x] overlong span on the last line of the file → no marker

Verification:

- [x] `pnpm --filter @inkline/cli run test` — 192 passed (18 files)
- [x] `pnpm --filter @inkline/cli run check` — no format, lint, or type errors in 40 files
- [x] `pnpm run build` — all 18 packages build

Note for anyone reproducing: `@inkline/cli` tests and `vp check` both need `@inkline/compiler` built first, otherwise the `@inkline/compiler` type import fails to resolve and four test files fail to load. That is pre-existing and unrelated to this change.

## Notes

Changeset: `.changeset/diagnostic-span-continuation-marker.md`, `patch` on `@inkline/cli` — output-shape only, no API or type surface moves.

The second QA nit on #541 (the relative/absolute path heuristic flipping form under a container `WORKDIR` of `/app` or `/repo`) is explicitly out of scope and closed, not deferred.

## Checklist

- [x] Added a changeset for the behavior change.
- [x] No public API, build flow, convention, or repo structure change — no `AGENTS.md` or `docs/*.md` update needed. The `renderFrame` TSDoc, which documents the frame shape, is updated in place.
- [x] Commit message follows the conventional format.
