### PR TITLE
test(cli): pin source frames at the caller->reporter seam

### DIFF
--- a/.changeset/cli-diagnostic-dedupe-and-summary.md
+++ b/.changeset/cli-diagnostic-dedupe-and-summary.md
@@ -1,0 +1,24 @@
+---
+"@inkline/cli": minor
+---
+
+feat(cli): print each advisory once per source location and close the build with a summary
+
+Build-invariant advisories are pushed once per codegen target with the component's own location, so
+compiling for both Angular and Qwik printed the byte-identical `INK0068` line twice for a single
+`hasSlot()` call site. `inkline compile` now reports a finding once per `(code, file, line, column)`:
+one thing to fix, one line of output. The same code at a different position is a different finding
+and still prints, and deduplication spans the whole build rather than a single file.
+
+Every one-shot compile now ends with a summary of what it did:
+
+```
+$ inkline compile "src/**/*.ink.tsx" --config inkline.config.ts
+…
+Compiled 67 files in 0.34s — 0 errors, 0 warnings, 12 notes
+```
+
+Exit codes are unchanged: `0` clean, `1` when the compile reported errors, `2` for unusable input
+(which produces no summary, because no build ran). The exit status is computed before filtering and
+deduplication, so neither can hide a failure. `--watch` keeps its per-rebuild reporting and its
+`warning` floor.

--- a/.changeset/cli-diagnostic-dedupe-and-summary.md
+++ b/.changeset/cli-diagnostic-dedupe-and-summary.md
@@ -6,9 +6,11 @@ feat(cli): print each advisory once per source location and close the build with
 
 Build-invariant advisories are pushed once per codegen target with the component's own location, so
 compiling for both Angular and Qwik printed the byte-identical `INK0068` line twice for a single
-`hasSlot()` call site. `inkline compile` now reports a finding once per `(code, file, line, column)`:
-one thing to fix, one line of output. The same code at a different position is a different finding
-and still prints, and deduplication spans the whole build rather than a single file.
+`hasSlot()` call site. `inkline compile` now reports a finding once per
+`(code, file, line, column, title)`: one thing to fix, one line of output. The same code at a
+different position — or saying something different at the same position, as `INK0090` and `INK0100`
+do — is a different finding and still prints. Deduplication spans the whole build rather than a
+single file.
 
 Every one-shot compile now ends with a summary of what it did:
 

--- a/tooling/cli/AGENTS.md
+++ b/tooling/cli/AGENTS.md
@@ -45,11 +45,13 @@ When adding a command:
 | [`errors.ts`](./src/lib/errors.ts)                                   | Exit-code constants and config-error reporting (see "Exit codes" below).             |
 | [`glob.ts`](./src/lib/glob.ts)                                       | Input-file globbing.                                                                 |
 | [`inkline-config-template.ts`](./src/lib/inkline-config-template.ts) | `inkline.config.ts` + example-component templates for `init --compiler`.             |
-| [`report.ts`](./src/lib/report.ts)                                   | Per-build diagnostic reporting: level filter, deduplication, counts, summary line.   |
+| [`report.ts`](./src/lib/report.ts)                                   | Per-build diagnostic policy: level filter, deduplication, counts, summary line.      |
 | [`styleframe-config.ts`](./src/lib/styleframe-config.ts)             | The `styleframe.config.ts` template seeded by `init`.                                |
 | [`writer.ts`](./src/lib/writer.ts)                                   | Atomic file writes with source-map sidecar support.                                  |
 
 These are internal — no `exports` map entry. If you find yourself importing from `lib/` outside the CLI, lift the utility into a more appropriate package first.
+
+`report.ts` decides _which_ diagnostics are printed; `diagnostics.ts` decides _how_ one is rendered. The reporter must never build a message itself — it calls `formatDiagnostic` and passes the caller's source text through, so a change to the rendering (code frames, relative paths, color) reaches every path that prints a diagnostic.
 
 ## Exit codes
 

--- a/tooling/cli/AGENTS.md
+++ b/tooling/cli/AGENTS.md
@@ -45,6 +45,7 @@ When adding a command:
 | [`errors.ts`](./src/lib/errors.ts)                                   | Exit-code constants and config-error reporting (see "Exit codes" below).             |
 | [`glob.ts`](./src/lib/glob.ts)                                       | Input-file globbing.                                                                 |
 | [`inkline-config-template.ts`](./src/lib/inkline-config-template.ts) | `inkline.config.ts` + example-component templates for `init --compiler`.             |
+| [`report.ts`](./src/lib/report.ts)                                   | Per-build diagnostic reporting: level filter, deduplication, counts, summary line.   |
 | [`styleframe-config.ts`](./src/lib/styleframe-config.ts)             | The `styleframe.config.ts` template seeded by `init`.                                |
 | [`writer.ts`](./src/lib/writer.ts)                                   | Atomic file writes with source-map sidecar support.                                  |
 
@@ -59,6 +60,8 @@ Defined once in [`lib/errors.ts`](./src/lib/errors.ts); never write a bare numbe
 | —                    | `0`  | Success.                                                                       |
 | `EXIT_COMPILE_ERROR` | `1`  | The compile ran and reported at least one `error` diagnostic.                  |
 | `EXIT_USAGE_ERROR`   | `2`  | The CLI never got that far: unusable config, or no files matched the patterns. |
+
+`EXIT_COMPILE_ERROR` is decided from every diagnostic the compile produced, before the reporting level filters any out and before [`report.ts`](./src/lib/report.ts) collapses duplicates — what a build prints may change; what it returns must not.
 
 User-input failures must never surface a stack trace. `resolveOptions` throws `InklineConfigError` carrying a catalog `Diagnostic`; commands validate up front (before `--clean` deletes anything) and hand the error to `reportConfigError`, which formats it and sets `EXIT_USAGE_ERROR`. The stack is printed only under `--verbose`. Anything `reportConfigError` returns `false` for is a real crash — rethrow it.
 

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -13,6 +13,7 @@ import { runCommand } from "citty";
 import type { GeneratedFile } from "@inkline/storybook/generator";
 import type { BarrelGroup } from "@inkline/compiler";
 import compile, { flushNamedBarrels, seedNamedBarrels, writeNamespaceBarrels } from "./compile.ts";
+import { EXIT_COMPILE_ERROR, EXIT_USAGE_ERROR } from "../lib/errors.ts";
 import type { BarrelMap, BarrelEntry } from "../lib/barrel.ts";
 
 // compile.ts is exercised in-process here (not via a subprocess like inkline.test.ts) so that the
@@ -230,6 +231,55 @@ describe("compile command (in-process)", () => {
     expect(errs).toContain("INK0045");
   });
 
+  it("prints a target-invariant advisory once when several targets raise it", async () => {
+    const out = tmpDir("dedupe");
+    // `hasSlot()` has no runtime equivalent on either Angular or Qwik, so both emitters push
+    // INK0068 at the component's location. One call site to fix, one line of output.
+    const { exitCode, errs } = await runCompile([
+      resolve(FIXTURES, "HasSlot.ink.tsx"),
+      "--target",
+      "angular,qwik",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(errs.match(/info {2}INK0068/g)?.length).toBe(1);
+    expect(errs).toContain("HasSlot.ink.tsx");
+    // Both targets still compiled — deduplication is a reporting concern, not a codegen one.
+    expect(existsSync(resolve(out, "angular", "HasSlot.component.ts"))).toBe(true);
+    expect(existsSync(resolve(out, "qwik", "HasSlot.tsx"))).toBe(true);
+  });
+
+  it("ends a clean build with a file count, elapsed time, and zero counts", async () => {
+    const out = tmpDir("summary-clean");
+    const { exitCode, logs } = await runCompile([
+      resolve(FIXTURES, "Counter.ink.tsx"),
+      "--target",
+      "react",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(logs).toMatch(/^Compiled 1 file in \d+\.\d\ds — 0 errors, 0 warnings, 0 notes$/m);
+  });
+
+  it("counts reported diagnostics in the summary, after deduplication", async () => {
+    const out = tmpDir("summary-counts");
+    const { logs, errs } = await runCompile([
+      resolve(FIXTURES, "HasSlot.ink.tsx"),
+      "--target",
+      "angular,qwik",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(errs.match(/info {2}INK0068/g)?.length).toBe(1);
+    // The summary agrees with what was printed: one note, not one per target.
+    expect(logs).toMatch(/^Compiled 1 file in \d+\.\d\ds — 0 errors, 0 warnings, 1 note$/m);
+  });
+
   it("cleans target directories before compiling", async () => {
     const out = tmpDir("clean");
     mkdirSync(resolve(out, "react"), { recursive: true });
@@ -311,6 +361,71 @@ describe("compile command (in-process)", () => {
     expect(readFileSync(resolve(reactDir, "stories.ts"), "utf-8")).toContain(
       "export * as IButtonStories from './components/button/stories/IButton.stories.ts';",
     );
+  });
+});
+
+// Deduplication and the summary line changed how diagnostics are counted, so pin the exit status of
+// every path against that: what the build *says* moved, what it *returns* did not.
+describe("compile command exit codes", () => {
+  it("exits 0 on a clean build", async () => {
+    const out = tmpDir("exit-clean");
+    const { exitCode } = await runCompile([
+      resolve(FIXTURES, "Counter.ink.tsx"),
+      "--target",
+      "react",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("exits 0 when the build only produced notes", async () => {
+    const out = tmpDir("exit-info");
+    const { exitCode, logs } = await runCompile([
+      resolve(FIXTURES, "ModelInput.ink.tsx"),
+      "--target",
+      "astro",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(logs).toContain("0 errors");
+  });
+
+  it("exits 1 when a diagnostic is an error, and the summary counts it", async () => {
+    const out = tmpDir("exit-error");
+    const { exitCode, logs } = await runCompile([
+      resolve(FIXTURES, "Diag_ShowNoWhen.ink.tsx"),
+      "--target",
+      "react",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(EXIT_COMPILE_ERROR);
+    expect(logs).toMatch(/— [1-9]\d* errors?,/);
+  });
+
+  it("exits 1 once, not per duplicate, when the same error is raised by two targets", async () => {
+    const out = tmpDir("exit-error-dedupe");
+    const { exitCode } = await runCompile([
+      resolve(FIXTURES, "Diag_ShowNoWhen.ink.tsx"),
+      "--target",
+      "angular,qwik",
+      "--out-dir",
+      out,
+    ]);
+    expect(exitCode).toBe(EXIT_COMPILE_ERROR);
+  });
+
+  it("exits 2 without a summary when the input is unusable", async () => {
+    const { exitCode, logs } = await runCompile([
+      resolve(TMP, "does-not-exist", "*.ink.tsx"),
+      "--target",
+      "react",
+    ]);
+    // The build never ran, so there is nothing to summarize.
+    expect(exitCode).toBe(EXIT_USAGE_ERROR);
+    expect(logs).not.toContain("Compiled");
   });
 });
 

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -251,6 +251,28 @@ describe("compile command (in-process)", () => {
     expect(existsSync(resolve(out, "qwik", "HasSlot.tsx"))).toBe(true);
   });
 
+  // UXF-85's source frames reach the one-shot build only if `run()` hands the reporter the source
+  // text for the file it just compiled. `report.test.ts` pins the reporter→formatter seam; this pins
+  // the caller→reporter one. Dropping the source map at the call site is what silently reverted
+  // UXF-85 during the #541 rebase, and it reverted it with every unit test still green.
+  it("prints a source frame for a diagnostic in a real one-shot build", async () => {
+    const out = tmpDir("source-frame");
+    const { exitCode, errs } = await runCompile([
+      resolve(FIXTURES, "HasSlot.ink.tsx"),
+      "--target",
+      "angular",
+      "--out-dir",
+      out,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(errs).toContain("INK0068");
+    // INK0068 is raised at the component's own location: the `defineComponent` call on line 5.
+    expect(errs).toMatch(/^\s*5 \| export default defineComponent\(/m);
+    // The caret row that underlines the frame — present only when the formatter got source text.
+    expect(errs).toMatch(/^\s*\| \^+$/m);
+  });
+
   it("ends a clean build with a file count, elapsed time, and zero counts", async () => {
     const out = tmpDir("summary-clean");
     const { exitCode, logs } = await runCompile([

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -26,6 +26,7 @@ import {
   type BarrelMap,
 } from "../lib/barrel.ts";
 import { formatDiagnostic } from "../lib/diagnostics.ts";
+import { createBuildReporter, formatBuildSummary } from "../lib/report.ts";
 import { EXIT_COMPILE_ERROR, EXIT_USAGE_ERROR, reportConfigError } from "../lib/errors.ts";
 import { writeCompileOutput, writeIfChanged, writeOutput } from "../lib/writer.ts";
 
@@ -156,8 +157,8 @@ export default defineCommand({
       return;
     }
 
-    let hasError = false;
     const reportLevel: DiagnosticSeverity = args.watch ? DEV_REPORT_LEVEL : "info";
+    const reporter = createBuildReporter(reportLevel);
     const barrelEntries: BarrelMap = new Map();
     const srcDir = args["src-dir"] ?? fileConfig.srcDir;
     const sourcePrefix = srcDir
@@ -176,6 +177,8 @@ export default defineCommand({
       srcDir,
     });
 
+    const startedAt = performance.now();
+
     if (args.clean) {
       for (const target of targets) {
         rmSync(resolveTargetDir(target, outDir, targetOutDir), { recursive: true, force: true });
@@ -190,11 +193,9 @@ export default defineCommand({
 
       const result = await compile({ fileName: absPath, source }, compileOptions);
 
-      for (const d of result.diagnostics) {
-        if (!meetsLevel(d.severity, reportLevel)) continue;
-        console.error(formatDiagnostic(d, { source: d.loc.file === absPath ? source : undefined }));
-        if (d.severity === "error") hasError = true;
-      }
+      // The reporter renders through `formatDiagnostic`, so it needs the same source text the
+      // inline loop used to hand it: a diagnostic pointing anywhere but this file gets no frame.
+      reporter.report(result.diagnostics, new Map([[absPath, source]]));
 
       writeCompileOutput(
         result,
@@ -228,7 +229,12 @@ export default defineCommand({
       );
     }
 
-    if (hasError) process.exitCode = EXIT_COMPILE_ERROR;
+    // A build closes with one line stating what it did; the watch loop reports per rebuild instead.
+    console.log(
+      formatBuildSummary(resolvedFiles.length, performance.now() - startedAt, reporter.counts),
+    );
+
+    if (reporter.hasError) process.exitCode = EXIT_COMPILE_ERROR;
   },
 });
 

--- a/tooling/cli/src/lib/report.test.ts
+++ b/tooling/cli/src/lib/report.test.ts
@@ -51,6 +51,50 @@ describe("createBuildReporter", () => {
     expect(reporter.counts.info).toBe(3);
   });
 
+  it("keeps two plugin failures, which share INK0090's unknown location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    // `runPlugins` builds INK0090 at UNKNOWN_LOCATION and puts the payload in the title, so position
+    // cannot separate one failing plugin from another.
+    const unknown = { file: "<unknown>", line: 0, column: 0, offset: 0, length: 0 };
+    reporter.report([
+      makeDiag({
+        code: "INK0090" as Diagnostic["code"],
+        severity: "error",
+        title: "Plugin 'tailwind' threw: Cannot read properties of undefined",
+        loc: unknown,
+      }),
+      makeDiag({
+        code: "INK0090" as Diagnostic["code"],
+        severity: "error",
+        title: "Plugin 'icons' threw: ENOENT: no such file or directory",
+        loc: unknown,
+      }),
+    ]);
+
+    expect(printed).toHaveLength(2);
+  });
+
+  it("keeps two targets failing differently on the same component", () => {
+    const { printed, reporter } = collectingReporter();
+
+    // The per-target emit loop pushes INK0100 at the component's own location, once per target.
+    reporter.report([
+      makeDiag({
+        code: "INK0100" as Diagnostic["code"],
+        severity: "error",
+        title: "Parse failure in component 'IInput': angular: unsupported directive",
+      }),
+      makeDiag({
+        code: "INK0100" as Diagnostic["code"],
+        severity: "error",
+        title: "Parse failure in component 'IInput': qwik: unsupported serialization",
+      }),
+    ]);
+
+    expect(printed).toHaveLength(2);
+  });
+
   it("keeps different codes at the same location", () => {
     const { printed, reporter } = collectingReporter();
 

--- a/tooling/cli/src/lib/report.test.ts
+++ b/tooling/cli/src/lib/report.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import type { Diagnostic } from "@inkline/compiler";
+import { createBuildReporter, formatBuildSummary } from "./report.ts";
+
+function makeDiag(overrides: Partial<Diagnostic> = {}): Diagnostic {
+  return {
+    code: "INK0068" as Diagnostic["code"],
+    severity: "info",
+    title: "hasSlot() always returns true",
+    url: "",
+    loc: { file: "IInput.ink.tsx", line: 39, column: 1, offset: 0, length: 0 },
+    ...overrides,
+  };
+}
+
+function collectingReporter(level: Parameters<typeof createBuildReporter>[0] = "info") {
+  const printed: string[] = [];
+  return { printed, reporter: createBuildReporter(level, (m) => void printed.push(m)) };
+}
+
+describe("createBuildReporter", () => {
+  it("prints one line for a finding raised by several targets at the same location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    // What Angular and Qwik both push for a single `hasSlot()` call site.
+    reporter.report([makeDiag(), makeDiag()]);
+
+    expect(printed).toHaveLength(1);
+    expect(reporter.counts).toEqual({ error: 0, warning: 0, info: 1 });
+  });
+
+  it("deduplicates across compiled files, not just within one", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([makeDiag()]);
+    reporter.report([makeDiag()]);
+
+    expect(printed).toHaveLength(1);
+  });
+
+  it("keeps the same code at a different location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([
+      makeDiag(),
+      makeDiag({ loc: { file: "IInput.ink.tsx", line: 52, column: 1, offset: 0, length: 0 } }),
+      makeDiag({ loc: { file: "IButton.ink.tsx", line: 39, column: 1, offset: 0, length: 0 } }),
+    ]);
+
+    expect(printed).toHaveLength(3);
+    expect(reporter.counts.info).toBe(3);
+  });
+
+  it("keeps different codes at the same location", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([makeDiag(), makeDiag({ code: "INK0045" as Diagnostic["code"] })]);
+
+    expect(printed).toHaveLength(2);
+  });
+
+  it("counts each severity separately", () => {
+    const { reporter } = collectingReporter();
+
+    reporter.report([
+      makeDiag({ severity: "error", code: "INK0001" as Diagnostic["code"] }),
+      makeDiag({ severity: "warning", code: "INK0010" as Diagnostic["code"] }),
+      makeDiag({ severity: "info", code: "INK0045" as Diagnostic["code"] }),
+    ]);
+
+    expect(reporter.counts).toEqual({ error: 1, warning: 1, info: 1 });
+  });
+
+  it("drops diagnostics below the reporting level and leaves them out of the counts", () => {
+    const { printed, reporter } = collectingReporter("warning");
+
+    reporter.report([
+      makeDiag({ severity: "info" }),
+      makeDiag({ severity: "warning", code: "INK0010" as Diagnostic["code"] }),
+    ]);
+
+    expect(printed).toHaveLength(1);
+    expect(reporter.counts).toEqual({ error: 0, warning: 1, info: 0 });
+  });
+
+  it("has no error before anything is reported", () => {
+    const { reporter } = collectingReporter();
+    expect(reporter.hasError).toBe(false);
+  });
+
+  it("flags an error even when it is a duplicate or below the reporting level", () => {
+    // Errors outrank every reporting level today, so neither branch is reachable from the CLI's own
+    // wiring — the exit status is computed before filtering precisely so it stays that way.
+    const duplicate = collectingReporter();
+    duplicate.reporter.report([makeDiag({ severity: "error" }), makeDiag({ severity: "error" })]);
+    expect(duplicate.printed).toHaveLength(1);
+    expect(duplicate.reporter.hasError).toBe(true);
+
+    const filtered = createBuildReporter("error", () => {});
+    filtered.report([makeDiag({ severity: "warning" })]);
+    expect(filtered.hasError).toBe(false);
+  });
+});
+
+describe("formatBuildSummary", () => {
+  it("reports file count, elapsed seconds, and counts by severity", () => {
+    expect(formatBuildSummary(67, 450, { error: 0, warning: 0, info: 4 })).toBe(
+      "Compiled 67 files in 0.45s — 0 errors, 0 warnings, 4 notes",
+    );
+  });
+
+  it("singularizes counts of one", () => {
+    expect(formatBuildSummary(1, 1000, { error: 1, warning: 1, info: 1 })).toBe(
+      "Compiled 1 file in 1.00s — 1 error, 1 warning, 1 note",
+    );
+  });
+});

--- a/tooling/cli/src/lib/report.test.ts
+++ b/tooling/cli/src/lib/report.test.ts
@@ -29,6 +29,29 @@ describe("createBuildReporter", () => {
     expect(reporter.counts).toEqual({ error: 0, warning: 0, info: 1 });
   });
 
+  it("renders through formatDiagnostic, so a source frame still reaches the output", () => {
+    const { printed, reporter } = collectingReporter();
+    const source = "const a = 1;\nconst b = 2;\n";
+
+    reporter.report(
+      [makeDiag({ loc: { file: "a.ink.tsx", line: 2, column: 6, offset: 19, length: 1 } })],
+      new Map([["a.ink.tsx", source]]),
+    );
+
+    // Rendering lives in `diagnostics.ts`; a reporter that formatted its own message would drop the
+    // code frame and silently revert it.
+    expect(printed[0]).toContain("2 | const b = 2;");
+    expect(printed[0]).toContain("^");
+  });
+
+  it("omits the frame when no source is supplied for the diagnostic's file", () => {
+    const { printed, reporter } = collectingReporter();
+
+    reporter.report([makeDiag()], new Map([["other.ink.tsx", "const a = 1;\n"]]));
+
+    expect(printed[0]).not.toContain("|");
+  });
+
   it("deduplicates across compiled files, not just within one", () => {
     const { printed, reporter } = collectingReporter();
 

--- a/tooling/cli/src/lib/report.ts
+++ b/tooling/cli/src/lib/report.ts
@@ -5,15 +5,20 @@ import { formatDiagnostic } from "./diagnostics.ts";
 export type SeverityCounts = Record<DiagnosticSeverity, number>;
 
 /**
- * Identity of a finding: the same code at the same source position is one thing to fix, however many
- * codegen targets noticed it. Build-invariant advisories are pushed once per target with the
- * component's own location — INK0068 from both the Angular and the Qwik emitter, for instance — so a
- * component compiled for both prints the byte-identical line twice today. The author has a single
- * call site to change, so they get a single line. The same code at a different position is a
- * different finding and still prints.
+ * Identity of a finding: the same code saying the same thing at the same source position is one thing
+ * to fix, however many codegen targets noticed it. Build-invariant advisories are pushed once per
+ * target with the component's own location — INK0068 from both the Angular and the Qwik emitter, for
+ * instance — so a component compiled for both prints the byte-identical line twice today. The author
+ * has a single call site to change, so they get a single line.
+ *
+ * The title is part of the key because some codes carry their payload there rather than in the
+ * position: INK0090 reports every plugin failure at `<unknown>:0:0`, and INK0100 reports a per-target
+ * emit failure at the component's location once per target. Two plugins crashing, or two targets
+ * failing differently on one component, are distinct findings sharing a code and a position — the
+ * title is the only thing that tells them apart.
  */
 function identity(d: Diagnostic): string {
-  return [d.code, d.loc.file, d.loc.line, d.loc.column].join("\u0000");
+  return [d.code, d.loc.file, d.loc.line, d.loc.column, d.title].join("\u0000");
 }
 
 /** Source text by absolute file name, for the code frame `formatDiagnostic` renders. */

--- a/tooling/cli/src/lib/report.ts
+++ b/tooling/cli/src/lib/report.ts
@@ -1,0 +1,97 @@
+import { meetsLevel, type Diagnostic, type DiagnosticSeverity } from "@inkline/compiler";
+import { formatDiagnostic } from "./diagnostics.ts";
+
+/** How many diagnostics were reported, per severity. */
+export type SeverityCounts = Record<DiagnosticSeverity, number>;
+
+/**
+ * Identity of a finding: the same code at the same source position is one thing to fix, however many
+ * codegen targets noticed it. Build-invariant advisories are pushed once per target with the
+ * component's own location — INK0068 from both the Angular and the Qwik emitter, for instance — so a
+ * component compiled for both prints the byte-identical line twice today. The author has a single
+ * call site to change, so they get a single line. The same code at a different position is a
+ * different finding and still prints.
+ */
+function identity(d: Diagnostic): string {
+  return [d.code, d.loc.file, d.loc.line, d.loc.column].join("\u0000");
+}
+
+/** Source text by absolute file name, for the code frame `formatDiagnostic` renders. */
+export type SourceMap = ReadonlyMap<string, string>;
+
+export interface BuildReporter {
+  /**
+   * Filter by reporting level, drop repeats of an already-reported finding, print and count the rest.
+   *
+   * Rendering belongs to `formatDiagnostic`, not to this module: `sources` is looked up by the
+   * diagnostic's file and handed straight to the formatter so it can draw its code frame. A caller
+   * with no source text for that file omits it and the frame is skipped, per the formatter's own
+   * contract.
+   */
+  report(diagnostics: readonly Diagnostic[], sources?: SourceMap): void;
+  /** True once any `error` diagnostic has been seen — including filtered and duplicate ones. */
+  readonly hasError: boolean;
+  readonly counts: SeverityCounts;
+}
+
+/**
+ * Collects a whole build's diagnostics: one reporter per compile so deduplication spans files, not
+ * just the targets of a single one.
+ */
+export function createBuildReporter(
+  level: DiagnosticSeverity,
+  print: (message: string) => void = (message) => console.error(message),
+): BuildReporter {
+  const seen = new Set<string>();
+  const counts: SeverityCounts = { error: 0, warning: 0, info: 0 };
+  let hasError = false;
+
+  return {
+    report(diagnostics, sources) {
+      for (const d of diagnostics) {
+        // Exit status is decided before filtering and deduplication: an error hidden by the
+        // reporting level, or repeated by a second target, is still a failed build.
+        if (d.severity === "error") hasError = true;
+        if (!meetsLevel(d.severity, level)) continue;
+
+        const key = identity(d);
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        counts[d.severity]++;
+        print(formatDiagnostic(d, { source: sources?.get(d.loc.file) }));
+      }
+    },
+    get hasError() {
+      return hasError;
+    },
+    get counts() {
+      return counts;
+    },
+  };
+}
+
+/** `info` is the compiler's severity; "note" is what it is called to the person reading the build. */
+const SEVERITY_NOUN: Record<DiagnosticSeverity, string> = {
+  error: "error",
+  warning: "warning",
+  info: "note",
+};
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** One closing line per build, e.g. `Compiled 67 files in 0.45s — 0 errors, 0 warnings, 4 notes`. */
+export function formatBuildSummary(
+  fileCount: number,
+  elapsedMs: number,
+  counts: SeverityCounts,
+): string {
+  const bySeverity = (["error", "warning", "info"] as const)
+    .map((severity) => pluralize(counts[severity], SEVERITY_NOUN[severity]))
+    .join(", ");
+  const elapsed = (elapsedMs / 1000).toFixed(2);
+
+  return `Compiled ${pluralize(fileCount, "file")} in ${elapsed}s — ${bySeverity}`;
+}


### PR DESCRIPTION
## Summary

Adds one regression test to `tooling/cli/src/commands/compile.test.ts`. Targets `agent/signal/6f69ff64` (#539) because the test uses the `reporter.report(diagnostics, sources)` signature that #539 introduces — it cannot land on `main` before #539 does.

`report.test.ts` (added in #539's `3b2f56bb2`) pins the **reporter → formatter** seam: revert the `source` passthrough in `report.ts:67` and exactly one test fails. Verified.

Nothing pins the seam one level up. Reverting the **caller → reporter** seam in `compile.ts:198`:

```diff
-      reporter.report(result.diagnostics, new Map([[absPath, source]]));
+      reporter.report(result.diagnostics);
```

leaves the entire CLI suite green — **210 passed (210)** — while the real build emits `advisories: 12  frames: 0`. UXF-85 fully reverted in user-facing output, with nothing red. That is byte-for-byte the failure mode that hit UXF-85 during the #541 rebase, one seam up.

## Changes

- `tooling/cli/src/commands/compile.test.ts` (+22): `"prints a source frame for a diagnostic in a real one-shot build"` — runs a real one-shot compile of the `HasSlot.ink.tsx` fixture to the `angular` target and asserts the frame's source row (`5 | export default defineComponent(`) and caret row reach stderr.

## Verification

- Passes at `3b2f56bb2`: `compile.test.ts` 26/26; full CLI suite **211 passed (211)**.
- Fails under the caller regression above: `1 failed | 25 passed`, `AssertionError: expected 'core/compiler/src/__fixtures__/HasSlo…' to match /^\s*5 \| export default defineComponent\(/m`.
- Both files restored to pristine before commit; diff is the test only.

## Notes

- No production code touched.
- No changeset — test-only.
- Asserts against line 5 of `core/compiler/src/__fixtures__/HasSlot.ink.tsx` (the `defineComponent` call, where INK0068 is raised). If that fixture is edited above line 5 the expectation needs updating; the line number is called out in a comment on the assertion.
