### PR TITLE
fix(compiler): resolve declared types and object defaults in the object prop form

### DIFF
--- a/.changeset/full-prop-shape-type-key.md
+++ b/.changeset/full-prop-shape-type-key.md
@@ -13,3 +13,12 @@ untyped everywhere but Angular. `type:` now resolves against the same constructo
 and wins over the type inferred from `default`, whichever order the keys appear in. A constructor outside
 that set is reported as the new `error` diagnostic `INK0042`, whose help lists the accepted set read from
 the table itself, so the message cannot drift from what the parser accepts.
+
+The same routing dropped object defaults. `parsePropsFromObject` sent _every_ object literal into the full
+shape, so `cfg: { a: 1 }` lost its type and its default while `tags: ["x"]` in the same position kept both.
+An object literal is now read as a shape only when every key is one the shape reads (`type`, `required`,
+`default`); anything else is a default value, matching `PropDefaultValue` in `@inkline/core`.
+
+Vue additionally emits object and array defaults as factories — `withDefaults(…, { cfg: () => ({ a: 1 }) })`.
+A `withDefaults` value is shared by every instance, so a bare literal aliased one mutable object between
+them. Array defaults were already affected on main; no fixture reached that path before.

--- a/.changeset/full-prop-shape-type-key.md
+++ b/.changeset/full-prop-shape-type-key.md
@@ -1,0 +1,15 @@
+---
+"@inkline/compiler": minor
+---
+
+Resolve the `type:` key in the full object prop shape, and report an unsupported constructor as `INK0042`.
+
+`defineComponent({ props: { size: { type: Number } } }, …)` read `type:` through `ts.isTypeNode`, which a
+constructor `Identifier` never satisfies — so the key was dropped and the prop emitted untyped on every
+target (`props: { size? }` in React, `unknown` in Qwik and Astro). The `required` and `default` keys
+alongside it did not rescue the type either: `{ type: Number, required: true, default: 0 }` was equally
+untyped everywhere but Angular. `type:` now resolves against the same constructor table the bare form
+(`size: Number`) uses — `String`, `Number`, `Boolean`, `Object`, `Array`, `Function`, `Symbol`, `Date` —
+and wins over the type inferred from `default`, whichever order the keys appear in. A constructor outside
+that set is reported as the new `error` diagnostic `INK0042`, whose help lists the accepted set read from
+the table itself, so the message cannot drift from what the parser accepts.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -186,6 +186,12 @@ export default defineComponent(
 > `TS2339: Property 'color' does not exist on type '{}'`. Until the authoring types catch up, use
 > the typed-parameter form above.
 
+The full shape's `type` key takes a **constructor reference**, one of `String`, `Number`, `Boolean`,
+`Object`, `Array`, `Function`, `Symbol`, or `Date` — the same set the bare form (`size: Number`)
+accepts. Anything else is reported as `INK0042` rather than dropped; for a type that table cannot
+express, use the typed-parameter form above. When `type` is omitted, the type is inferred from
+`default`; when both are present, `type` wins.
+
 Everything that is _not_ a prop also goes in the options object — `slots`, `events`, `runtime`,
 `name`, and `meta`. Those keys are declared on `ComponentOptions` and type-check today, so they can
 be combined with a typed setup parameter:

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -192,6 +192,11 @@ accepts. Anything else is reported as `INK0042` rather than dropped; for a type 
 express, use the typed-parameter form above. When `type` is omitted, the type is inferred from
 `default`; when both are present, `type` wins.
 
+An object literal is read as that full shape only when **every** key is one the shape reads (`type`,
+`required`, `default`). Anything else is an object _default value_, exactly like an array or string
+literal in the same position — `cfg: { a: 1 }` declares an optional `Record<string, any>` defaulting
+to `{ a: 1 }`. Write `cfg: { default: { a: 1 } }` to be explicit.
+
 Everything that is _not_ a prop also goes in the options object — `slots`, `events`, `runtime`,
 `name`, and `meta`. Those keys are declared on `ComponentOptions` and type-check today, so they can
 be combined with a typed setup parameter:

--- a/core/compiler/docs/adding-a-diagnostic.md
+++ b/core/compiler/docs/adding-a-diagnostic.md
@@ -64,6 +64,7 @@ The catalog test in `src/core/diagnostics/codes.test.ts` verifies:
 | INK0030 | error    | analyze  | createMemo cycle detected                               |
 | INK0040 | error    | parse    | defineComponent must have a setup function              |
 | INK0041 | error    | parse    | defineComponent options must be a static object literal |
+| INK0042 | error    | parse    | Prop declares an unsupported `type:` constructor        |
 | INK0050 | warning  | lower    | Missing key in iteration                                |
 | INK0060 | error    | lower    | `<Show>` requires a 'when' prop                         |
 | INK0061 | info     | lower    | Nullish-coalescing (??) in JSX is ambiguous             |

--- a/core/compiler/docs/api-reference.md
+++ b/core/compiler/docs/api-reference.md
@@ -1379,6 +1379,7 @@ Constant map of all diagnostic codes to their metadata:
 | `INK0030` | error    | createMemo cycle detected: {cycle}                      |
 | `INK0040` | error    | defineComponent must have a setup function              |
 | `INK0041` | error    | defineComponent options must be a static object literal |
+| `INK0042` | error    | Prop '{name}' declares an unsupported type '{value}'    |
 | `INK0050` | warning  | Missing key in iteration                                |
 | `INK0060` | error    | `<Show>` requires a 'when' prop                         |
 | `INK0061` | info     | Nullish-coalescing (??) in JSX is ambiguous             |

--- a/core/compiler/src/__fixtures__/Diag_PropTypeUnsupported.ink.tsx
+++ b/core/compiler/src/__fixtures__/Diag_PropTypeUnsupported.ink.tsx
@@ -1,0 +1,4 @@
+import { defineComponent } from "@inkline/core";
+export default defineComponent({ props: { entries: { type: Map } } }, (props) => {
+  return <div>{props.entries}</div>;
+});

--- a/core/compiler/src/__fixtures__/PropTypeShapes.ink.tsx
+++ b/core/compiler/src/__fixtures__/PropTypeShapes.ink.tsx
@@ -1,0 +1,20 @@
+import { defineComponent } from "@inkline/core";
+export default defineComponent(
+  {
+    props: {
+      size: { type: Number },
+      label: { type: String, required: true },
+      when: { type: Date },
+      count: { type: Number, required: true, default: 0 },
+    },
+  },
+  (props) => {
+    return (
+      <div>
+        {props.label}
+        {props.size}
+        {props.count}
+      </div>
+    );
+  },
+);

--- a/core/compiler/src/__fixtures__/PropTypeShapes.ink.tsx
+++ b/core/compiler/src/__fixtures__/PropTypeShapes.ink.tsx
@@ -6,6 +6,8 @@ export default defineComponent(
       label: { type: String, required: true },
       when: { type: Date },
       count: { type: Number, required: true, default: 0 },
+      // Not a shape — an object literal used as a default, alongside the shapes above.
+      cfg: { a: 1 },
     },
   },
   (props) => {

--- a/core/compiler/src/__fixtures__/scenarios.ts
+++ b/core/compiler/src/__fixtures__/scenarios.ts
@@ -137,6 +137,9 @@ export const scenarios: Readonly<Record<string, readonly Scenario[]>> = {
   Diag_NamespaceImport: [
     { name: "triggers INK0001", asserts: { expectedDiagnostics: ["INK0001"] } },
   ],
+  Diag_PropTypeUnsupported: [
+    { name: "triggers INK0042", asserts: { expectedDiagnostics: ["INK0042"] } },
+  ],
   Diag_EmptyEffect: [{ name: "triggers INK0010", asserts: { expectedDiagnostics: ["INK0010"] } }],
   Diag_EmptyMemo: [{ name: "triggers INK0011", asserts: { expectedDiagnostics: ["INK0011"] } }],
   Diag_Cycle: [{ name: "triggers INK0030", asserts: { expectedDiagnostics: ["INK0030"] } }],

--- a/core/compiler/src/codegen/targets/angular/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/props.test.ts
@@ -4,7 +4,19 @@
 // shapes become Angular output (signal inputs, call-form reads, ng-content projection).
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every input below emitted untyped.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("Angular: signal inputs carry the constructor-declared type parameter", async () => {
+    const out = await compileToChecked("PropTypeShapes", "angular");
+    expect(out).toContain("size = input<number>()");
+    expect(out).toContain("label = input.required<string>()");
+    expect(out).toContain("when = input<Date>()");
+    expect(out).toContain("count = input<number>(0)");
+  });
+});
 
 describe("IButton: typed props (label/optional disabled)", () => {
   it("Angular: props are signal inputs; [disabled] reads the input in call form", async () => {

--- a/core/compiler/src/codegen/targets/angular/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/props.test.ts
@@ -7,14 +7,17 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every input below emitted untyped.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("Angular: signal inputs carry the constructor-declared type parameter", async () => {
+// `Identifier` never satisfies — so the key was dropped and every input below emitted untyped. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("Angular: signal inputs carry the declared type parameter and the object default as the initial value", async () => {
     const out = await compileToChecked("PropTypeShapes", "angular");
     expect(out).toContain("size = input<number>()");
     expect(out).toContain("label = input.required<string>()");
     expect(out).toContain("when = input<Date>()");
     expect(out).toContain("count = input<number>(0)");
+    expect(out).toContain("cfg = input<Record<string, any>>({ a: 1 })");
   });
 });
 

--- a/core/compiler/src/codegen/targets/astro/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/astro/__tests__/props.test.ts
@@ -6,14 +6,18 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every prop below emitted `unknown`.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("Astro: the frontmatter Props type carries the constructor-declared types", async () => {
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted `unknown`. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("Astro: the frontmatter Props type carries the declared types and applies the object default", async () => {
     const out = await compileToChecked("PropTypeShapes", "astro");
     expect(out).toContain(
-      "type Props = { size?: number; label: string; when?: Date; count: number } & Record<string, any>",
+      "type Props = { size?: number; label: string; when?: Date; count: number; cfg?: Record<string, any> } & Record<string, any>",
     );
-    expect(out).toContain("const { size, label, when, count = 0, ...__attrs } = props;");
+    expect(out).toContain(
+      "const { size, label, when, count = 0, cfg = { a: 1 }, ...__attrs } = props;",
+    );
   });
 });
 

--- a/core/compiler/src/codegen/targets/astro/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/astro/__tests__/props.test.ts
@@ -3,7 +3,19 @@
 // roots, and text siblings around an element.
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted `unknown`.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("Astro: the frontmatter Props type carries the constructor-declared types", async () => {
+    const out = await compileToChecked("PropTypeShapes", "astro");
+    expect(out).toContain(
+      "type Props = { size?: number; label: string; when?: Date; count: number } & Record<string, any>",
+    );
+    expect(out).toContain("const { size, label, when, count = 0, ...__attrs } = props;");
+  });
+});
 
 describe("PropDefaults: object form `{ props: { color: 'blue', size: Number } }`", () => {
   // The author used the object/options form, which conveys a DEFAULT ("blue") for color and a

--- a/core/compiler/src/codegen/targets/qwik/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/props.test.ts
@@ -5,12 +5,17 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every prop below emitted `unknown`.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("Qwik: the props parameter carries the constructor-declared types instead of `unknown`", async () => {
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted `unknown`. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("Qwik: the props parameter carries the declared types instead of `unknown`, and the object default is destructured", async () => {
     const out = await compileToChecked("PropTypeShapes", "qwik");
     expect(out).toContain(
-      "component$((props: { size?: number; label: string; when?: Date; count: number } & Record<string, any>)",
+      "component$((props: { size?: number; label: string; when?: Date; count: number; cfg?: Record<string, any> } & Record<string, any>)",
+    );
+    expect(out).toContain(
+      "const { size, label, when, count = 0, cfg = { a: 1 }, ...__attrs } = props",
     );
     expect(out).not.toContain("unknown");
   });

--- a/core/compiler/src/codegen/targets/qwik/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/props.test.ts
@@ -1,8 +1,20 @@
-// Qwik codegen assertions for the "props" feature area: here, fragment roots (`<>...</>`).
-// Exercises the FULL pipeline (parse -> lower -> analyze -> codegen).
+// Qwik codegen assertions for the "props" feature area: the full object form and fragment roots
+// (`<>...</>`). Exercises the FULL pipeline (parse -> lower -> analyze -> codegen).
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted `unknown`.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("Qwik: the props parameter carries the constructor-declared types instead of `unknown`", async () => {
+    const out = await compileToChecked("PropTypeShapes", "qwik");
+    expect(out).toContain(
+      "component$((props: { size?: number; label: string; when?: Date; count: number } & Record<string, any>)",
+    );
+    expect(out).not.toContain("unknown");
+  });
+});
 
 describe("FragmentRoot: `<>...</>` root with no props", () => {
   it("Qwik: fragment root emits a real `<>...</>` fragment", async () => {

--- a/core/compiler/src/codegen/targets/react/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/props.test.ts
@@ -4,7 +4,19 @@
 // and root shapes become React output.
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("React: constructor `type:` resolves, and the default only supplies the type when `type:` is absent", async () => {
+    const out = await compileToChecked("PropTypeShapes", "react");
+    expect(out).toContain(
+      "export function PropTypeShapes(props: { size?: number; label: string; when?: Date; count: number } & React.HTMLAttributes<HTMLElement>)",
+    );
+    expect(out).toContain("const { size, label, when, count = 0, ...__attrs } = props");
+  });
+});
 
 describe("IButton: typed props (label/optional disabled)", () => {
   it("React: destructures into __attrs, keeps an intersection type, binds disabled via props.x", async () => {

--- a/core/compiler/src/codegen/targets/react/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/props.test.ts
@@ -7,14 +7,18 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("React: constructor `type:` resolves, and the default only supplies the type when `type:` is absent", async () => {
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("React: `type:` resolves, `default:` supplies the type only when `type:` is absent, and `cfg` stays a default", async () => {
     const out = await compileToChecked("PropTypeShapes", "react");
     expect(out).toContain(
-      "export function PropTypeShapes(props: { size?: number; label: string; when?: Date; count: number } & React.HTMLAttributes<HTMLElement>)",
+      "export function PropTypeShapes(props: { size?: number; label: string; when?: Date; count: number; cfg?: Record<string, any> } & React.HTMLAttributes<HTMLElement>)",
     );
-    expect(out).toContain("const { size, label, when, count = 0, ...__attrs } = props");
+    expect(out).toContain(
+      "const { size, label, when, count = 0, cfg = { a: 1 }, ...__attrs } = props",
+    );
   });
 });
 

--- a/core/compiler/src/codegen/targets/solid/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/solid/__tests__/props.test.ts
@@ -4,7 +4,19 @@
 // shapes become Solid output.
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("Solid: the props parameter carries the constructor-declared types", async () => {
+    const out = await compileToChecked("PropTypeShapes", "solid");
+    expect(out).toContain(
+      "function PropTypeShapes(_props: { size?: number; label: string; when?: Date; count: number } & JSX.HTMLAttributes<HTMLElement>)",
+    );
+    expect(out).toContain("const props = mergeProps({ count: 0 }, _props)");
+  });
+});
 
 describe("IButton: typed props (label/optional disabled)", () => {
   it("Solid: splitProps lists the declared prop keys so __attrs is the remainder", async () => {

--- a/core/compiler/src/codegen/targets/solid/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/solid/__tests__/props.test.ts
@@ -7,14 +7,16 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("Solid: the props parameter carries the constructor-declared types", async () => {
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("Solid: the props parameter carries the declared types and mergeProps seeds the object default", async () => {
     const out = await compileToChecked("PropTypeShapes", "solid");
     expect(out).toContain(
-      "function PropTypeShapes(_props: { size?: number; label: string; when?: Date; count: number } & JSX.HTMLAttributes<HTMLElement>)",
+      "function PropTypeShapes(_props: { size?: number; label: string; when?: Date; count: number; cfg?: Record<string, any> } & JSX.HTMLAttributes<HTMLElement>)",
     );
-    expect(out).toContain("const props = mergeProps({ count: 0 }, _props)");
+    expect(out).toContain("const props = mergeProps({ count: 0, cfg: { a: 1 } }, _props)");
   });
 });
 

--- a/core/compiler/src/codegen/targets/svelte/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/svelte/__tests__/props.test.ts
@@ -6,14 +6,16 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("Svelte: the Props interface carries the constructor-declared types", async () => {
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("Svelte: the Props interface carries the declared types and the object default lands in the destructure", async () => {
     const out = await compileToChecked("PropTypeShapes", "svelte");
     expect(out).toContain(
-      "interface Props { size?: number; label: string; when?: Date; count: number }",
+      "interface Props { size?: number; label: string; when?: Date; count: number; cfg?: Record<string, any> }",
     );
-    expect(out).toContain("let { size, label, when, count = 0, ...__attrs }");
+    expect(out).toContain("let { size, label, when, count = 0, cfg = { a: 1 }, ...__attrs }");
   });
 });
 

--- a/core/compiler/src/codegen/targets/svelte/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/svelte/__tests__/props.test.ts
@@ -3,7 +3,19 @@
 // output. These exercise the FULL pipeline (parse -> lower -> analyze -> codegen).
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("Svelte: the Props interface carries the constructor-declared types", async () => {
+    const out = await compileToChecked("PropTypeShapes", "svelte");
+    expect(out).toContain(
+      "interface Props { size?: number; label: string; when?: Date; count: number }",
+    );
+    expect(out).toContain("let { size, label, when, count = 0, ...__attrs }");
+  });
+});
 
 describe("IButton: typed props (label/optional disabled)", () => {
   it("Svelte: $props() destructure + bare identifier access (no props. prefix)", async () => {

--- a/core/compiler/src/codegen/targets/vue/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/vue/__tests__/props.test.ts
@@ -4,7 +4,18 @@
 // in how authored props and root shapes become Vue SFC output.
 
 import { describe, it, expect } from "vitest";
-import { compileTo } from "../../../../testing/codegen.ts";
+import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
+
+// The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
+describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
+  it("Vue: the defineProps generic carries the constructor-declared types", async () => {
+    const out = await compileToChecked("PropTypeShapes", "vue");
+    expect(out).toContain(
+      "const props = withDefaults(defineProps<{ size?: number; label: string; when?: Date; count: number }>(), { count: 0 })",
+    );
+  });
+});
 
 describe("IButton: typed props (label/optional disabled)", () => {
   it("Vue: defineProps generic + template reads the destructured prop name (not props.x)", async () => {

--- a/core/compiler/src/codegen/targets/vue/__tests__/props.test.ts
+++ b/core/compiler/src/codegen/targets/vue/__tests__/props.test.ts
@@ -7,13 +7,18 @@ import { describe, it, expect } from "vitest";
 import { compileTo, compileToChecked } from "../../../../testing/codegen.ts";
 
 // The full object form used to read `type:` through `ts.isTypeNode`, which a constructor
-// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped.
-describe("PropTypeShapes: full object form `{ type: X, required, default }`", () => {
-  it("Vue: the defineProps generic carries the constructor-declared types", async () => {
+// `Identifier` never satisfies — so the key was dropped and every prop below emitted untyped. `cfg`
+// covers the other half: an object literal is only a shape when every key is one the shape reads,
+// otherwise it is a default value, and routing it into the shape dropped its type AND its default.
+describe("PropTypeShapes: full object form vs. an object literal default", () => {
+  it("Vue: the defineProps generic carries the declared types and withDefaults seeds the object default", async () => {
     const out = await compileToChecked("PropTypeShapes", "vue");
     expect(out).toContain(
-      "const props = withDefaults(defineProps<{ size?: number; label: string; when?: Date; count: number }>(), { count: 0 })",
+      "const props = withDefaults(defineProps<{ size?: number; label: string; when?: Date; count: number; cfg?: Record<string, any> }>(), { count: 0, cfg: () => ({ a: 1 }) })",
     );
+    // Vue shares one `withDefaults` value across every instance, so a bare object literal would
+    // alias the same mutable object everywhere — the default has to be a factory.
+    expect(out).not.toContain("cfg: { a: 1 }");
   });
 });
 

--- a/core/compiler/src/codegen/targets/vue/index.ts
+++ b/core/compiler/src/codegen/targets/vue/index.ts
@@ -431,7 +431,15 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     // that declared one, keeping the `const props` binding the <script> reads via `props.x`.
     const defaults = component.props
       .filter((p) => p.defaultValue)
-      .map((p) => `${p.name}: ${rewriteExpr(p.defaultValue!.expr, rules)}`);
+      .map((p) => {
+        const expr = p.defaultValue!.expr;
+        const value = rewriteExpr(expr, rules);
+        // Vue shares a `withDefaults` value across every instance, so object and array defaults must
+        // be factories or all instances alias one mutable object (`vue/require-valid-default-prop`).
+        if (ts.isObjectLiteralExpression(expr)) return `${p.name}: () => (${value})`;
+        if (ts.isArrayLiteralExpression(expr)) return `${p.name}: () => ${value}`;
+        return `${p.name}: ${value}`;
+      });
     const body =
       defaults.length > 0
         ? `const props = withDefaults(defineProps<{ ${defs} }>(), { ${defaults.join(", ")} })`

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -13,6 +13,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0030",
       "INK0040",
       "INK0041",
+      "INK0042",
       "INK0043",
       "INK0044",
       "INK0045",
@@ -82,10 +83,11 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
-  it("codes with title placeholders: INK0030, INK0044, INK0080, INK0081, INK0082, INK0083, INK0085, INK0086, INK0090, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
+  it("codes with title placeholders: INK0030, INK0042, INK0044, INK0080, INK0081, INK0082, INK0083, INK0085, INK0086, INK0090, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
     const withPlaceholders = codes.filter((c) => /\{\w+\}/.test(DIAGNOSTICS[c].title));
     expect(withPlaceholders.sort()).toEqual([
       "INK0030",
+      "INK0042",
       "INK0044",
       "INK0080",
       "INK0081",

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -21,6 +21,12 @@ export const DIAGNOSTICS = {
     help: "Move dynamic options into the setup body" as const,
     url: "https://docs.inkline.dev/diagnostics/INK0041" as const,
   },
+  INK0042: {
+    severity: "error" as const,
+    title: "Prop '{name}' declares an unsupported type '{value}'" as const,
+    help: "The object form's `type` key takes a constructor reference — one of: {supported}. Use `type: Number`. For a type none of those express, drop the object form and annotate the setup parameter instead: defineComponent((props: MyProps) => …)." as const,
+    url: "https://docs.inkline.dev/diagnostics/INK0042" as const,
+  },
   INK0043: {
     severity: "error" as const,
     title: "defineModel must be a [getter, setter] tuple with a static name" as const,

--- a/core/compiler/src/pipeline/passes/02-parse/options.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.test.ts
@@ -100,6 +100,26 @@ describe("parseOptions", () => {
       expect(result.props![1]!.typeText).toBe("number");
     });
 
+    // Every object literal used to be read as a full shape, so `cfg: { a: 1 }` lost its type AND
+    // its default while `tags: [1]` in the same position kept both.
+    it("reads an object literal as a default value unless every key belongs to the shape", () => {
+      const { obj, sf } = getObjectLiteral(
+        `{ props: { cfg: { a: 1 }, empty: {}, mixed: { a: 1, type: Number }, shape: { type: Number } } }`,
+      );
+      const ctx = makeCtx();
+      const props = parseOptions(obj, "test#X", sf, ctx).props!;
+
+      for (const p of props.slice(0, 3)) {
+        expect(p.typeText).toBe("Record<string, any>");
+        expect(p.required).toBe(false);
+        expect(p.defaultValue, `${p.name} should keep its object default`).toBeDefined();
+      }
+      // Only the all-shape-keys object is read as a declaration rather than a value.
+      expect(props[3]!.typeText).toBe("number");
+      expect(props[3]!.defaultValue).toBeUndefined();
+      expect(ctx.diagnostics.freeze()).toHaveLength(0);
+    });
+
     it("parses default-value prop as not required", () => {
       const { obj, sf } = getObjectLiteral(`{ props: { label: "hello" } }`);
       const ctx = makeCtx();

--- a/core/compiler/src/pipeline/passes/02-parse/options.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.test.ts
@@ -52,6 +52,52 @@ describe("parseOptions", () => {
       expect(prop.name).toBe("count");
       expect(prop.required).toBe(true);
       expect(prop.defaultValue).toBeDefined();
+      expect(prop.typeText).toBe("number");
+    });
+
+    // The accepted set is the compiler's `CONSTRUCTOR_TYPES` table, which `PropConstructor` in
+    // `@inkline/core` mirrors. Pinned here so the two cannot drift apart unnoticed.
+    it.each([
+      ["String", "string"],
+      ["Number", "number"],
+      ["Boolean", "boolean"],
+      ["Object", "Record<string, any>"],
+      ["Array", "any[]"],
+      ["Function", "(...args: any[]) => any"],
+      ["Symbol", "symbol"],
+      ["Date", "Date"],
+    ])("resolves `type: %s` to `%s` with no default", (ctor, expected) => {
+      const { obj, sf } = getObjectLiteral(`{ props: { value: { type: ${ctor} } } }`);
+      const ctx = makeCtx();
+      const result = parseOptions(obj, "test#X", sf, ctx);
+      expect(result.props![0]!.typeText).toBe(expected);
+      expect(ctx.diagnostics.freeze()).toHaveLength(0);
+    });
+
+    it("reports INK0042 for an unrecognised `type:` instead of dropping it", () => {
+      const { obj, sf } = getObjectLiteral(`{ props: { entries: { type: Map } } }`);
+      const ctx = makeCtx();
+      const result = parseOptions(obj, "test#X", sf, ctx);
+      expect(result.props![0]!.typeText).toBeUndefined();
+
+      const diags = ctx.diagnostics.freeze();
+      expect(diags).toHaveLength(1);
+      expect(diags[0]!.code).toBe("INK0042");
+      expect(diags[0]!.severity).toBe("error");
+      expect(diags[0]!.title).toBe("Prop 'entries' declares an unsupported type 'Map'");
+      // The help lists the accepted set from the table itself, not from a hand-written copy.
+      expect(diags[0]!.help).toContain("String, Number, Boolean, Object, Array, Function, Symbol");
+    });
+
+    it("prefers `type:` over the default's inferred type, whatever order the keys appear in", () => {
+      // Deliberately contradictory: `type: String` must win over the numeric default's `number`.
+      const { obj, sf } = getObjectLiteral(
+        `{ props: { a: { default: 0, type: String }, b: { default: 0 } } }`,
+      );
+      const ctx = makeCtx();
+      const result = parseOptions(obj, "test#X", sf, ctx);
+      expect(result.props![0]!.typeText).toBe("string");
+      expect(result.props![1]!.typeText).toBe("number");
     });
 
     it("parses default-value prop as not required", () => {

--- a/core/compiler/src/pipeline/passes/02-parse/options.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.ts
@@ -137,7 +137,7 @@ function parsePropsFromObject(
     const init = member.initializer;
     const loc = toLoc(member, sourceFile);
 
-    if (ts.isObjectLiteralExpression(init)) {
+    if (ts.isObjectLiteralExpression(init) && isFullPropShape(init)) {
       const parsed = parseFullPropShape(name, init, componentId, sourceFile, ctx);
       props.push({ ...parsed, loc });
     } else {
@@ -159,6 +159,24 @@ function parsePropsFromObject(
   }
 
   return props;
+}
+
+/** The only keys the full prop shape reads. */
+const FULL_SHAPE_KEYS: ReadonlySet<string> = new Set(["type", "required", "default"]);
+
+/**
+ * Distinguish a full prop shape (`{ type: Number, default: 0 }`) from an object literal used as a
+ * *default value* (`cfg: { a: 1 }`), which `PropDefaultValue` in `@inkline/core` accepts. Both are
+ * object literals in the same position, so the shape only wins when every key is one it reads —
+ * otherwise the object is a default, like an array or string literal in the same position. Reading
+ * every object as a shape is what dropped `cfg`'s type *and* its default silently.
+ */
+function isFullPropShape(obj: ts.ObjectLiteralExpression): boolean {
+  if (obj.properties.length === 0) return false;
+  return obj.properties.every(
+    (p) =>
+      ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && FULL_SHAPE_KEYS.has(p.name.text),
+  );
 }
 
 function parseFullPropShape(

--- a/core/compiler/src/pipeline/passes/02-parse/options.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.ts
@@ -170,8 +170,8 @@ function parseFullPropShape(
 ): IRProp {
   const loc = toLoc(obj, sourceFile);
   const id = ctx.symbols.mint({ componentId, kind: "prop", name, loc });
-  let typeNode: ts.TypeNode | undefined;
-  let defaultValue: IRExprNode | undefined;
+  let declaredType: string | undefined;
+  let defaultInit: ts.Expression | undefined;
   let required = false;
 
   for (const prop of obj.properties) {
@@ -179,29 +179,57 @@ function parseFullPropShape(
 
     switch (prop.name.text) {
       case "type":
-        if (ts.isTypeNode(prop.initializer)) {
-          typeNode = prop.initializer;
-        }
+        declaredType = resolveDeclaredType(name, prop.initializer, sourceFile, ctx);
         break;
       case "required":
         required = prop.initializer.kind === ts.SyntaxKind.TrueKeyword;
         break;
       case "default":
-        defaultValue = makeExprNode(prop.initializer, sourceFile);
+        defaultInit = prop.initializer;
         break;
     }
   }
 
-  return { name, typeNode, defaultValue, required, symbolId: id, loc };
+  // `type:` wins over the default's inferred type, and is read whichever order the keys appear in.
+  const typeText = declaredType ?? (defaultInit ? inferPropType(defaultInit) : undefined);
+  const defaultValue = defaultInit ? makeExprNode(defaultInit, sourceFile) : undefined;
+
+  return { name, typeText, defaultValue, required, symbolId: id, loc };
 }
 
+/**
+ * Resolve the object form's `type:` key, which the author writes as a constructor reference
+ * (`{ type: Number }` → `number`). The accepted set is {@link CONSTRUCTOR_TYPES} — the same table
+ * `PropConstructor` in `@inkline/core` mirrors — and an unrecognised value is reported rather than
+ * dropped, which is what happened before: the prop emitted untyped with no warning.
+ */
+function resolveDeclaredType(
+  propName: string,
+  init: ts.Expression,
+  sourceFile: ts.SourceFile,
+  ctx: PassContext,
+): string | undefined {
+  if (ts.isIdentifier(init) && init.text in CONSTRUCTOR_TYPES) return CONSTRUCTOR_TYPES[init.text];
+
+  ctx.diagnostics.push("INK0042", toLoc(init, sourceFile), {
+    name: propName,
+    value: init.getText(sourceFile),
+    supported: Object.keys(CONSTRUCTOR_TYPES).join(", "),
+  });
+  return undefined;
+}
+
+/**
+ * A bare constructor reference as a prop value declares a *required* prop: `{ size: Number }`.
+ * `Date` is deliberately absent — `{ when: Date }` reads as an optional `Date`, matching what the
+ * targets emit and what `PropConstructorRef` in `@inkline/core` accepts.
+ */
 function isConstructorRef(node: ts.Expression): boolean {
   if (!ts.isIdentifier(node)) return false;
-  return ["String", "Number", "Boolean", "Object", "Array", "Function", "Symbol"].includes(
-    node.text,
-  );
+  return node.text !== "Date" && node.text in CONSTRUCTOR_TYPES;
 }
 
+/** The constructor-to-type table shared by the bare form, the `type:` key, and `@inkline/core`. */
 const CONSTRUCTOR_TYPES: Readonly<Record<string, string>> = {
   String: "string",
   Number: "number",


### PR DESCRIPTION
## Summary

Two symptoms, one root cause in `parsePropsFromObject`/`parseFullPropShape`: the object prop form dropped declared types and object defaults silently. `type:` now resolves against the compiler's constructor table, an unrecognised constructor raises a new `INK0042` error diagnostic, and an object literal is only read as a prop *shape* when every key is one the shape reads.

## Related issues

- UXF-112 (silent type/default drop in the object prop form; regression surface of UXF-97 / #537)

## Type of change

- [x] `fix` — bug fix

## What was broken

**1. `type:` was never read.** `parseFullPropShape` matched it with `ts.isTypeNode`, which a constructor `Identifier` never satisfies — dead branch. `parseFullPropShape` also never called `inferPropType`, so `required`/`default` alongside it did not rescue the type either.

For `{ size: { type: Number }, label: { type: String, required: true }, when: { type: Date }, count: { type: Number, required: true, default: 0 } }`:

| Target | Before | After |
| --- | --- | --- |
| React | `props: { size?; label; when?; count }` | `{ size?: number; label: string; when?: Date; count: number }` |
| Solid | `_props: { size?; label; when?; count }` | same, typed; `mergeProps({ count: 0 }, _props)` |
| Vue | `defineProps<{ size?; label; when?; count }>` | `withDefaults(defineProps<{ … }>(), { count: 0 })` |
| Svelte | `interface Props { size?; label; when?; count }` | typed interface, `count = 0` in the destructure |
| Qwik | `unknown` | typed |
| Astro | `unknown` | typed |
| Angular | untyped `input()` | `input<number>()` / `input.required<string>()` / `input<Date>()` / `input<number>(0)` |

**2. Object literals used as defaults were routed into the shape.** `parsePropsFromObject` sent *every* object literal to `parseFullPropShape`, which reads only `type`/`required`/`default` — so `cfg: { a: 1 }` lost its type *and* its default, while `tags: ["x"]` in the same position kept both. Verified pre-fix on all seven targets: `cfg` emitted untyped with no default applied.

**3. Fixing (2) surfaced a live Vue bug.** `withDefaults` shares one value across every component instance, so an object or array default must be a factory. Emitting the bare literal aliased a single mutable object between instances (`vue/require-valid-default-prop`, caught by the emitted-output lint suite). Array defaults were already affected on `main` — no fixture reached that path. Vue now emits `cfg: () => ({ a: 1 })` and `tags: () => ["x"]`.

## Design notes

**The shape/default predicate.** An object literal is a shape iff it has at least one key and *every* key is `type`, `required`, or `default`. Consequences worth knowing:

- `{}` → a default value (`Record<string, any>` defaulting to `{}`), not an empty shape.
- `{ a: 1, type: Number }` → a default value, because `a` is not a shape key.
- `{ type: "dark" }` → read as a shape, and `"dark"` is not a constructor, so it raises `INK0042`. Ambiguous by construction; a diagnostic naming the file and line beats guessing. `{ default: { type: "dark" } }` is the explicit spelling.

**No second constructor list.** Net effect is the opposite of adding one — `isConstructorRef` was already carrying its own hand-written duplicate array, now deleted. The bare form, the `type:` key, `INK0042`'s help text (`Object.keys(CONSTRUCTOR_TYPES)`), and `PropConstructorValue` in `@inkline/core` (#537) all read one table. Adding a constructor is a one-line table edit.

**`INK0042` is `error`, not `warning`.** The #537 authoring type already rejects the same input at `tsc` time; a warning would disagree with the type. Error diagnostics do not halt emit in this pipeline, so the prop still emits untyped — the difference is that the author is told.

## Failure-mode note

- **What breaks:** an unsupported constructor (`{ type: Map }`) is now an `error` diagnostic rather than silence. Emit is unaffected.
- **Detection:** `INK0042` in `compile()`'s diagnostics; fixture `Diag_PropTypeUnsupported.ink.tsx` asserts it through the conformance matrix.
- **Recovery:** revert is a two-file revert (`02-parse/options.ts`, `vue/index.ts`); `INK0042` is additive and unreferenced elsewhere.
- **Compat:** `type:` now wins over `default:`, in either key order. `type:` was previously inert, so nothing that compiled before changes type unless the author wrote a `type:` contradicting their `default:` — already a bug in their source. The one behavioural change to previously-working code is Vue array defaults becoming factories, which is a fix.

## Test plan

- [x] `vp test` in `core/compiler` — 219 files, 3321 passed, 2 skipped, 0 failed
- [x] Per-target suites assert **emitted types and defaults**, not just that compilation succeeds — every symptom here compiled clean while emitting wrong output. The `PropTypeShapes` fixture carries shapes and an object default in one props object, so each of the seven `props.test.ts` blocks pins the exact emitted type string via `compileToChecked`
- [x] `options.test.ts`: `it.each` over all eight constructors; the shape-vs-default predicate across `{ a: 1 }` / `{}` / `{ a: 1, type: Number }` / `{ type: Number }`; an `INK0042` assertion (code / severity / title / help); key-order independence
- [x] `src/testing/lint.test.ts` lints the emitted Vue SFC — this is what caught the `withDefaults` aliasing bug
- [x] `codes.test.ts` catalog updated for the new code and its placeholders
- [x] `vp check` — formatting clean; typecheck error count unchanged against a stashed baseline, all in pre-existing `src/__fixtures__/*.ink.tsx` noise from an unbuilt `@inkline/core`

## Checklist

- [x] Added a changeset (`.changeset/full-prop-shape-type-key.md`)
- [x] Docs updated — `docs/api-reference.md` and `docs/adding-a-diagnostic.md` diagnostic tables, plus `README.md` on the accepted constructor set, `type` winning over `default`, and the shape-vs-default rule
- [x] Conventional commits
