### PR TITLE
feat(compiler)!: split exports into root, /ir and /codegen subpaths

### DIFF
--- a/.changeset/narrow-compiler-export-surface.md
+++ b/.changeset/narrow-compiler-export-surface.md
@@ -1,0 +1,13 @@
+---
+"@inkline/compiler": minor
+---
+
+Split `@inkline/compiler` into three entry points so the import path states the support tier.
+
+The root exported 158 names, which buried the handful of real entry points in compiler internals. It now exports 35: compiling, configuring, diagnostics, plugin authoring, and target selection.
+
+- `@inkline/compiler` — `compile`, `compileIncremental`, `defineConfig`, `resolveOptions`, the diagnostic types and helpers, `definePlugin`, `TargetName`/`ALL_TARGETS`/`builtinRegistry`.
+- `@inkline/compiler/ir` — the render IR: node types, builders, visitors, `transform`, serialization, migration, `SymbolTable`, and the pass primitives.
+- `@inkline/compiler/codegen` — **unstable**: Code IR, the `Target` contract, the printer, and the built-in targets. Unstable for as long as `TargetName` is a closed union, since an external target cannot typecheck or run today. Marked in `package.json` under `inkline.unstableExports`.
+
+Nothing was removed — every name still ships, at the path that describes it. Two types that were previously unnameable are now exported: `SourceLocation` (the type of `Diagnostic.loc`) from the root, and `ReactivityGraph` (the value type of `AnalyzedModule.graphs`, which the `ir:post` plugin hook hands you) from `/ir`.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -581,10 +581,11 @@ interface GeneratedFile {
 
 ### Working with the IR
 
-The compiler exposes its full intermediate representation for advanced use cases:
+The compiler exposes its full intermediate representation at `@inkline/compiler/ir`:
 
 ```ts
-import { compile, walkRenderTree } from "@inkline/compiler";
+import { compile } from "@inkline/compiler";
+import { walkRenderTree } from "@inkline/compiler/ir";
 
 const result = await compile({ fileName: "Counter.ink.tsx", source }, { targets: ["react"] });
 
@@ -617,7 +618,7 @@ for (const [componentId, graph] of module.graphs) {
 ### Transforming the IR
 
 ```ts
-import { transform, transformComponent, SKIP } from "@inkline/compiler";
+import { transform, transformComponent, SKIP } from "@inkline/compiler/ir";
 
 const transformed = transformComponent(component, {
   enter(node) {
@@ -813,9 +814,10 @@ for (const file of files) {
 Register a custom target for frameworks not built in:
 
 ```ts
-import { defineTarget, createRegistry, builtinRegistry } from "@inkline/compiler";
-import type { IRComponent, CodegenContext, CodeModule } from "@inkline/compiler";
-import { cFile, cStmt, cImport, cJsxElement } from "@inkline/compiler";
+import { defineTarget, createRegistry, builtinRegistry } from "@inkline/compiler/codegen";
+import type { CodegenContext, CodeModule } from "@inkline/compiler/codegen";
+import { cFile, cStmt, cImport, cJsxElement } from "@inkline/compiler/codegen";
+import type { IRComponent } from "@inkline/compiler/ir";
 
 const myTarget = defineTarget({
   name: "react", // must be a valid TargetName

--- a/core/compiler/package.json
+++ b/core/compiler/package.json
@@ -24,6 +24,14 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
+    "./ir": {
+      "types": "./dist/ir.d.mts",
+      "default": "./dist/ir.mjs"
+    },
+    "./codegen": {
+      "types": "./dist/codegen.d.mts",
+      "default": "./dist/codegen.mjs"
+    },
     "./testing": {
       "types": "./dist/testing.d.mts",
       "default": "./dist/testing.mjs"
@@ -113,5 +121,10 @@
     "vue": {
       "optional": true
     }
+  },
+  "inkline": {
+    "unstableExports": [
+      "./codegen"
+    ]
   }
 }

--- a/core/compiler/src/codegen/index.ts
+++ b/core/compiler/src/codegen/index.ts
@@ -1,0 +1,91 @@
+/**
+ * `@inkline/compiler/codegen` — **UNSTABLE. No semver guarantee.**
+ *
+ * Code IR, the `Target` contract, the printer, and the built-in targets.
+ *
+ * Why unstable: `TargetName` is a closed string-literal union of the seven built-in targets
+ * (`./context.ts`), and `Target.name` is a `TargetName` — so an external
+ * `defineTarget({ name: "lit" })` cannot typecheck. It also cannot run: `resolveOptions` rejects
+ * any target outside `ALL_TARGETS` (diagnostic INK0085) before it consults a custom registry.
+ * These names are therefore usable today only from inside this repository. They ship at a subpath
+ * so that in-repo target work has a real import path instead of a deep relative one, and so the
+ * root entry point is not filled with an API no external author can call.
+ *
+ * Opening the extension point is a separate design decision. Until it is made, expect this
+ * surface to change in any release, including a patch. Marked in `package.json` under
+ * `inkline.unstableExports`.
+ *
+ * Selecting a target (`TargetName`, `ALL_TARGETS`, `builtinRegistry`, `GeneratedFile`) is stable
+ * and lives at `@inkline/compiler`; those four are re-exported here so a target implementation
+ * needs one import rather than two.
+ */
+
+// ============ TARGET API ============
+export type {
+  Target,
+  TargetName,
+  TargetPlan,
+  TargetConformanceSpec,
+  ControlFlowImportSpec,
+  MemberRewriteRules,
+  RewriteRules,
+  TargetRegistry,
+  CodegenContext,
+  GeneratedFile,
+  CodeModule,
+} from "./context.ts";
+export { defineTarget, createRegistry, builtinRegistry } from "./registry.ts";
+export { ALL_TARGETS } from "./context.ts";
+
+// ============ CODE IR ============
+export type {
+  Code,
+  CFile,
+  CScript,
+  CImport,
+  CStmt,
+  CExpr,
+  CRaw,
+  CJsxElement,
+  CJsxAttr,
+  CJsxText,
+  CTmplElement,
+  CTmplDirective,
+  CTmplAttr,
+  CTmplText,
+  CTmplMustache,
+  CGroup,
+  CIndent,
+  CStyle,
+} from "./code-ir/nodes.ts";
+export {
+  cFile,
+  cScript,
+  cImport,
+  cStmt,
+  cExpr,
+  cRaw,
+  cJsxElement,
+  cJsxAttr,
+  cJsxText,
+  cTmplElement,
+  cTmplDirective,
+  cTmplAttr,
+  cTmplText,
+  cTmplMustache,
+  cGroup,
+  cIndent,
+  cStyle,
+} from "./code-ir/builders.ts";
+
+// ============ PRINTER ============
+export { print, type PrintOptions, type PrintResult } from "./print/printer.ts";
+
+// ============ BUILT-IN TARGETS ============
+export { react as reactTarget } from "./targets/react/index.ts";
+export { vue as vueTarget } from "./targets/vue/index.ts";
+export { svelte as svelteTarget } from "./targets/svelte/index.ts";
+export { solid as solidTarget } from "./targets/solid/index.ts";
+export { angular as angularTarget } from "./targets/angular/index.ts";
+export { qwik as qwikTarget } from "./targets/qwik/index.ts";
+export { astro as astroTarget } from "./targets/astro/index.ts";

--- a/core/compiler/src/index.ts
+++ b/core/compiler/src/index.ts
@@ -1,3 +1,19 @@
+/**
+ * `@inkline/compiler` — the supported entry point.
+ *
+ * The package ships three entry points, and the import path states the support tier:
+ *
+ * - `@inkline/compiler` (here) — compiling, configuring, reading diagnostics, and authoring
+ *   plugins. Stable. This is what a consumer autocompletes against, so it stays small.
+ * - `@inkline/compiler/ir` — the render IR: node types, builders, visitors, transforms,
+ *   serialization, migration, and the reactivity symbol table. For plugin authors who inspect
+ *   or rewrite the IR handed to them by the `ir:post` hook.
+ * - `@inkline/compiler/codegen` — **unstable.** Code IR, the `Target` contract, the printer,
+ *   and the built-in targets. See that file's header for why it is not stable yet.
+ *
+ * Nothing was deleted in the split — every name still ships, at the path that describes it.
+ */
+
 // ============ TOP-LEVEL ENTRY POINT ============
 export { compile } from "./pipeline/compile.ts";
 export type { CompileInput, CompileResult, AnalyzedModule } from "./pipeline/compile.ts";
@@ -22,10 +38,6 @@ export { defineConfig } from "./core/config.ts";
 // config before compiling (creating or cleaning output directories) needs to fail first.
 export { resolveOptions } from "./core/options.ts";
 
-// ============ PIPELINE PRIMITIVES (advanced users) ============
-export type { Pass, PassContext } from "./pipeline/types.ts";
-export { pipe } from "./pipeline/types.ts";
-
 // ============ TARGET NAMING ============
 // The Angular element selector for a compiled component (`IBadge` → `ink-badge`). Exported for
 // tooling that instantiates compiled components by tag (e.g. the Storybook story generator).
@@ -42,156 +54,21 @@ export {
   createDiagnosticCollector,
   type DiagnosticCollector,
 } from "./core/diagnostics/collector.ts";
-
-// ============ IR — RENDER TREE TYPES ============
-export type {
-  IRNode,
-  IRElement,
-  IRComponentInstance,
-  IRText,
-  IRExprNode,
-  IRIf,
-  IRIfBranch,
-  IRFor,
-  IRSwitch,
-  IRSwitchCase,
-  IRSlotPlaceholder,
-  IRFragment,
-  IRAttribute,
-  IRAttributeBinding,
-  IRStaticValue,
-  IREventBinding,
-  IRRefBinding,
-  IRSlotContent,
-  IRProp,
-  IRSlotDeclaration,
-  IREventDeclaration,
-  IRStateDeclaration,
-  IRRefDeclaration,
-  IRMemoDeclaration,
-  IREffectDeclaration,
-  IRResourceDeclaration,
-  IRLifecycle,
-  IRSetupStatement,
-  IRRefCategory,
-  IREffectCleanup,
-  IRComponent,
-  IRRuntimeMode,
-  IRStyleBlock,
-  IRTargetOverride,
-  IRModule,
-  PrimitiveName,
-  PrimitiveUsage,
-} from "./ir/render/nodes.ts";
-export { IR_VERSION } from "./ir/render/nodes.ts";
-
-// ============ IR — MIGRATION ============
-export { migrate, registerMigration, type IRMigration } from "./ir/migration.ts";
-
-// ============ IR — SERIALIZATION ============
-export { serializeModule, deserializeModule } from "./ir/serialize.ts";
-
-// ============ IR — BUILDERS ============
-export {
-  createElement,
-  createComponentInstance,
-  createText,
-  createExpr,
-  createIf,
-  createFor,
-  createSwitch,
-  createSlotPlaceholder,
-  createFragment,
-  createAttribute,
-  createStaticValue,
-} from "./ir/render/builders.ts";
-
-// ============ IR — VISITORS ============
-export type { IRVisitor } from "./ir/render/visit.ts";
-export { walkRenderTree, walkNode } from "./ir/render/visit.ts";
-export type { IRTransformer } from "./ir/render/transform.ts";
-export { SKIP, transform, transformComponent } from "./ir/render/transform.ts";
-
-// ============ IR — REACTIVITY ============
-export type {
-  SymbolId,
-  IRReactiveKind,
-  IRReactiveSymbol,
-  IRDependency,
-  IRDependencySet,
-} from "./ir/reactivity.ts";
-export { SymbolTable } from "./ir/reactivity.ts";
+// `Diagnostic.loc` is a `SourceLocation`. Without this a consumer that holds a Diagnostic cannot
+// name the type of a field it was handed — the same leak `/ir` closes for `ReactivityGraph`.
+export type { SourceLocation } from "./ir/types.ts";
 
 // ============ PLUGIN API ============
+// Plugins are a genuinely open extension point: `config.plugins` is honoured and `Plugin.name` is
+// a free string, so plugin authoring is root-tier. The IR types a plugin inspects live at
+// `@inkline/compiler/ir`.
 export type { Plugin, PluginHooks, PluginContext } from "./plugin/types.ts";
 export { definePlugin } from "./plugin/types.ts";
 
-// ============ TARGET API ============
-export type {
-  Target,
-  TargetName,
-  TargetPlan,
-  TargetConformanceSpec,
-  ControlFlowImportSpec,
-  MemberRewriteRules,
-  RewriteRules,
-  TargetRegistry,
-  CodegenContext,
-  GeneratedFile,
-  CodeModule,
-} from "./codegen/context.ts";
-export { defineTarget, createRegistry, builtinRegistry } from "./codegen/registry.ts";
+// ============ TARGETS ============
+// Naming and selecting a target is root-tier; *implementing* one is not. `TargetName` is a closed
+// union, so the `Target` contract and the Code IR it is written against live at
+// `@inkline/compiler/codegen` and are marked unstable there.
+export type { TargetName, GeneratedFile } from "./codegen/context.ts";
 export { ALL_TARGETS } from "./codegen/context.ts";
-
-// ============ CODE IR (target/plugin authors) ============
-export type {
-  Code,
-  CFile,
-  CScript,
-  CImport,
-  CStmt,
-  CExpr,
-  CRaw,
-  CJsxElement,
-  CJsxAttr,
-  CJsxText,
-  CTmplElement,
-  CTmplDirective,
-  CTmplAttr,
-  CTmplText,
-  CTmplMustache,
-  CGroup,
-  CIndent,
-  CStyle,
-} from "./codegen/code-ir/nodes.ts";
-export {
-  cFile,
-  cScript,
-  cImport,
-  cStmt,
-  cExpr,
-  cRaw,
-  cJsxElement,
-  cJsxAttr,
-  cJsxText,
-  cTmplElement,
-  cTmplDirective,
-  cTmplAttr,
-  cTmplText,
-  cTmplMustache,
-  cGroup,
-  cIndent,
-  cStyle,
-} from "./codegen/code-ir/builders.ts";
-
-// ============ PRINTER ============
-export { print, type PrintOptions, type PrintResult } from "./codegen/print/printer.ts";
-
-// ============ BUILT-IN TARGETS ============
-export { react as reactTarget } from "./codegen/targets/react/index.ts";
-export { vue as vueTarget } from "./codegen/targets/vue/index.ts";
-export { svelte as svelteTarget } from "./codegen/targets/svelte/index.ts";
-export { solid as solidTarget } from "./codegen/targets/solid/index.ts";
-export { angular as angularTarget } from "./codegen/targets/angular/index.ts";
-export { qwik as qwikTarget } from "./codegen/targets/qwik/index.ts";
-export { astro as astroTarget } from "./codegen/targets/astro/index.ts";
+export { builtinRegistry } from "./codegen/registry.ts";

--- a/core/compiler/src/ir/index.ts
+++ b/core/compiler/src/ir/index.ts
@@ -1,0 +1,103 @@
+/**
+ * `@inkline/compiler/ir` — the render intermediate representation.
+ *
+ * For plugin authors. The `ir:post` hook hands you an `AnalyzedModule`; everything you need to
+ * read, walk, rewrite, serialize, or migrate what is inside it lives here.
+ *
+ * Stability: these names moved off the root in the same change that first published the package,
+ * so nothing here is a break. They are supported, but they track the IR — `IR_VERSION` and the
+ * migration registry exist because the IR shape does change between versions.
+ *
+ * Compiling, configuring, diagnostics, and `definePlugin` stay at `@inkline/compiler`.
+ */
+
+// ============ RENDER TREE TYPES ============
+export type {
+  IRNode,
+  IRElement,
+  IRComponentInstance,
+  IRText,
+  IRExprNode,
+  IRIf,
+  IRIfBranch,
+  IRFor,
+  IRSwitch,
+  IRSwitchCase,
+  IRSlotPlaceholder,
+  IRFragment,
+  IRAttribute,
+  IRAttributeBinding,
+  IRStaticValue,
+  IREventBinding,
+  IRRefBinding,
+  IRSlotContent,
+  IRProp,
+  IRSlotDeclaration,
+  IREventDeclaration,
+  IRStateDeclaration,
+  IRRefDeclaration,
+  IRMemoDeclaration,
+  IREffectDeclaration,
+  IRResourceDeclaration,
+  IRLifecycle,
+  IRSetupStatement,
+  IRRefCategory,
+  IREffectCleanup,
+  IRComponent,
+  IRRuntimeMode,
+  IRStyleBlock,
+  IRTargetOverride,
+  IRModule,
+  PrimitiveName,
+  PrimitiveUsage,
+} from "./render/nodes.ts";
+export { IR_VERSION } from "./render/nodes.ts";
+
+// Re-exported from the root so an IR consumer annotating `node.loc` needs one import, not two.
+export type { SourceLocation } from "./types.ts";
+
+// ============ MIGRATION ============
+export { migrate, registerMigration, type IRMigration } from "./migration.ts";
+
+// ============ SERIALIZATION ============
+export { serializeModule, deserializeModule } from "./serialize.ts";
+
+// ============ BUILDERS ============
+export {
+  createElement,
+  createComponentInstance,
+  createText,
+  createExpr,
+  createIf,
+  createFor,
+  createSwitch,
+  createSlotPlaceholder,
+  createFragment,
+  createAttribute,
+  createStaticValue,
+} from "./render/builders.ts";
+
+// ============ VISITORS ============
+export type { IRVisitor } from "./render/visit.ts";
+export { walkRenderTree, walkNode } from "./render/visit.ts";
+export type { IRTransformer } from "./render/transform.ts";
+export { SKIP, transform, transformComponent } from "./render/transform.ts";
+
+// ============ REACTIVITY ============
+export type {
+  SymbolId,
+  IRReactiveKind,
+  IRReactiveSymbol,
+  IRDependency,
+  IRDependencySet,
+} from "./reactivity.ts";
+export { SymbolTable } from "./reactivity.ts";
+// `AnalyzedModule.graphs` is a `ReadonlyMap<string, ReactivityGraph>`. Without this export a
+// plugin author cannot name the type of a field the `ir:post` hook hands them.
+export type { ReactivityGraph } from "../pipeline/passes/04-analyze/graph.ts";
+
+// ============ PIPELINE PRIMITIVES ============
+// A `Pass` is a step over the IR, so the pass primitives sit with the IR rather than on the root,
+// where they were indistinguishable from the entry points.
+export type { Pass, PassContext } from "../pipeline/types.ts";
+export { pipe } from "../pipeline/types.ts";

--- a/core/compiler/src/subpath-export.test.ts
+++ b/core/compiler/src/subpath-export.test.ts
@@ -1,0 +1,172 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+import * as root from "./index.ts";
+import * as ir from "./ir/index.ts";
+import * as codegen from "./codegen/index.ts";
+// Type-only, so it is `vp check` that enforces it rather than a runtime assertion: the `ir:post`
+// hook hands a plugin author an `AnalyzedModule` whose `graphs` is a map of these. Closing that
+// leak is the reason the `/ir` tier exists, so the import must keep resolving.
+import type { ReactivityGraph } from "./ir/index.ts";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+interface PackageManifest {
+  readonly exports: Readonly<Record<string, unknown>>;
+  readonly inkline?: { readonly unstableExports?: readonly string[] };
+}
+
+const manifest = JSON.parse(
+  readFileSync(join(packageDir, "package.json"), "utf-8"),
+) as PackageManifest;
+
+/**
+ * The root's runtime exports, exhaustively.
+ *
+ * This is the guard the split exists for. `@inkline/compiler` carried 158 names; autocomplete
+ * buried the real entry points in internals. Every IR builder, visitor and transform, every Code
+ * IR builder, and every built-in target is a *value*, so any attempt to re-widen the root with
+ * them fails here. Type-only names are invisible at runtime and are not covered — the docblock in
+ * `index.ts` is what governs those.
+ */
+const ROOT_RUNTIME_EXPORTS = [
+  "ALL_TARGETS",
+  "DIAGNOSTICS",
+  "InklineConfigError",
+  "angularSelector",
+  "builtinRegistry",
+  "compile",
+  "compileIncremental",
+  "createDiagnosticCollector",
+  "createIncrementalState",
+  "defineConfig",
+  "definePlugin",
+  "isInklineConfigError",
+  "meetsLevel",
+  "resolveOptions",
+  "seedIncrementalState",
+] as const;
+
+/** One representative value per subpath, checked through the packed tarball below. */
+const SUBPATH_PROBES = {
+  "./ir": { specifier: "@inkline/compiler/ir", name: "walkRenderTree" },
+  "./codegen": { specifier: "@inkline/compiler/codegen", name: "defineTarget" },
+} as const;
+
+function names(mod: Record<string, unknown>): string[] {
+  return Object.keys(mod)
+    .filter((k) => k !== "default")
+    .sort();
+}
+
+describe("@inkline/compiler entry points", () => {
+  it("declares /ir and /codegen in package.json exports", () => {
+    expect(manifest.exports["./ir"]).toEqual({
+      types: "./dist/ir.d.mts",
+      default: "./dist/ir.mjs",
+    });
+    expect(manifest.exports["./codegen"]).toEqual({
+      types: "./dist/codegen.d.mts",
+      default: "./dist/codegen.mjs",
+    });
+  });
+
+  // The tier is unstable for as long as `TargetName` is a closed union, and a docblock alone is
+  // not machine-readable. Delete this expectation only when the extension point actually opens.
+  it("marks /codegen unstable in package metadata", () => {
+    expect(manifest.inkline?.unstableExports).toEqual(["./codegen"]);
+  });
+
+  it("keeps the root narrow", () => {
+    expect(names(root)).toEqual([...ROOT_RUNTIME_EXPORTS].sort());
+  });
+
+  it("ships the moved names at their new paths rather than dropping them", () => {
+    expect(names(ir)).toEqual(
+      expect.arrayContaining([
+        "walkRenderTree",
+        "transform",
+        "SymbolTable",
+        "migrate",
+        "serializeModule",
+        "pipe",
+      ]),
+    );
+    expect(names(codegen)).toEqual(
+      expect.arrayContaining(["defineTarget", "createRegistry", "print", "cFile", "reactTarget"]),
+    );
+  });
+
+  it("exposes ReactivityGraph so a plugin can name what ir:post hands it", () => {
+    // `satisfies` would need a value; asserting the shape is enough to keep the type reachable.
+    const graph: ReactivityGraph = {
+      dependencies: new Map(),
+      dependents: new Map(),
+      topo: [],
+      cycles: [],
+    };
+    expect(graph.topo).toEqual([]);
+  });
+
+  // Packaging can only be checked against a build. CI always builds before testing (the `test`
+  // job downloads the `build` job's artifacts); an unbuilt local tree skips. Keyed on `dist/`
+  // itself, so a build that stops emitting these entries fails rather than skips.
+  it.skipIf(!existsSync(join(packageDir, "dist")))(
+    "resolves both subpaths under the import and require conditions from a packed tarball",
+    () => {
+      // Staged under the package's own node_modules so peer dependencies still resolve by walking
+      // up to the workspace root, as they do for a real consumer.
+      const consumerDir = join(packageDir, "node_modules", ".entry-point-smoke");
+      rmSync(consumerDir, { recursive: true, force: true });
+      mkdirSync(join(consumerDir, "node_modules", "@inkline"), { recursive: true });
+
+      try {
+        execFileSync("pnpm", ["pack", "--pack-destination", consumerDir], {
+          cwd: packageDir,
+          stdio: "pipe",
+        });
+        const tarball = readdirSync(consumerDir).find((f) => f.endsWith(".tgz"));
+        expect(tarball).toBeDefined();
+
+        execFileSync("tar", ["-xzf", join(consumerDir, tarball as string)], { cwd: consumerDir });
+        renameSync(
+          join(consumerDir, "package"),
+          join(consumerDir, "node_modules", "@inkline", "compiler"),
+        );
+
+        for (const [subpath, { specifier, name }] of Object.entries(SUBPATH_PROBES)) {
+          // Run out of process with cwd inside the consumer so bare-specifier resolution picks the
+          // real condition. `exports` declares only `default`, which both conditions land on — the
+          // point is that neither one 404s on a missing map entry.
+          const esm = execFileSync(
+            process.execPath,
+            [
+              "--input-type=module",
+              "-e",
+              `const m = await import(${JSON.stringify(specifier)}); process.stdout.write(typeof m[${JSON.stringify(name)}]);`,
+            ],
+            { cwd: consumerDir, encoding: "utf-8" },
+          );
+          expect(esm, `${subpath} under the import condition`).toBe("function");
+
+          const cjs = execFileSync(
+            process.execPath,
+            [
+              "--input-type=commonjs",
+              "-e",
+              `const m = require(${JSON.stringify(specifier)}); process.stdout.write(typeof m[${JSON.stringify(name)}]);`,
+            ],
+            { cwd: consumerDir, encoding: "utf-8" },
+          );
+          expect(cjs, `${subpath} under the require condition`).toBe("function");
+        }
+      } finally {
+        rmSync(consumerDir, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
+});

--- a/core/compiler/vite.config.ts
+++ b/core/compiler/vite.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   pack: {
     entry: {
       index: "src/index.ts",
+      ir: "src/ir/index.ts",
+      codegen: "src/codegen/index.ts",
       testing: "src/testing/index.ts",
     },
     dts: {


### PR DESCRIPTION
## Summary

`@inkline/compiler` shipped 158 names from its root entry point, burying the six real entry points in compiler internals. This splits the package into three entry points so the import path states the support tier. The root is now 35 names. Nothing was removed — every name still ships, at the path that describes it.

Implements the Operator's decision (Option B) from the RFC on UXF-91.

- **`@inkline/compiler`** — `compile`, `compileIncremental`, `defineConfig`, `resolveOptions`, the diagnostic types and helpers, `definePlugin`, `TargetName` / `ALL_TARGETS` / `builtinRegistry`.
- **`@inkline/compiler/ir`** — render IR node types, builders, visitors, `transform`, serialization, migration, `SymbolTable`, and the pass primitives.
- **`@inkline/compiler/codegen`** — **unstable**. Code IR, the `Target` contract, the printer, and the built-in targets. Unstable for as long as `TargetName` is a closed union: an external `defineTarget({ name: "lit" })` can neither typecheck nor run (`resolveOptions` rejects unknown targets with INK0085 before consulting a custom registry). Marked in the entry point's docblock and in `package.json` under `inkline.unstableExports`.

Two types that were previously unnameable are now exported, closing leaks where a consumer is handed a value whose type it cannot write down:

- `SourceLocation` — the type of `Diagnostic.loc` — from the root.
- `ReactivityGraph` — the value type of `AnalyzedModule.graphs`, which the `ir:post` plugin hook hands you — from `/ir`.

**Timing:** this is free of semver cost only because `@inkline/compiler` has never been published. It should land before the first `npm publish`.

## Related issues

- Closes UXF-143
- Refs UXF-91 (RFC and decision)

## Type of change

- [x] `feat` — new user-facing capability or public API
- [ ] `fix` — bug fix
- [x] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `chore` / `ci` — tooling, dependencies, or CI

Marked `feat!` in the commit: it is a re-export topology change with no behaviour change, but it narrows a public surface. There is no semver cost today because the package is unpublished.

## Failure-mode note

- **What breaks:** an import of a moved name from the root — `import { walkRenderTree } from "@inkline/compiler"`. There are no such importers in this monorepo and none outside it (`npm view @inkline/compiler` → 404).
- **How it is detected:** at compile time, by the importer's own typecheck. There is no runtime failure mode — the names still exist, at a different specifier.
- **How it recovers:** change the specifier to `/ir` or `/codegen`. No code change.
- **Regression guard:** `src/subpath-export.test.ts` asserts the root's runtime export list exhaustively, so re-widening the root with any IR builder, visitor, transform, Code IR builder or built-in target fails the suite. Verified to go red by removing `./ir` from the exports map.

## Test plan

- [x] `pnpm run build` — full workspace, exit 0. Compiler emits four entries with `.d.mts` for each: `index`, `ir`, `codegen`, `testing`.
- [x] `pnpm run check` — 955 files formatted, **no warnings, lint errors or type errors in 696 files**. This is the proof of zero cross-package edits: every consumer in `ui/`, `tooling/`, and `core/plugin/` typechecks unmodified.
- [x] `pnpm run test` — all packages green, 0 failures. Compiler: 220 files / 3286 tests.
- [x] New `src/subpath-export.test.ts` (6 tests) resolves `/ir` and `/codegen` from a **packed tarball** under both the `import` and `require` conditions, out of process with cwd inside a staged consumer.
- [x] Mutation-checked the new test: removing `./ir` from `exports` fails it with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- [x] `core/inkline/src/compiler.ts` (`export * from "@inkline/compiler"`) narrows automatically with no edit, as predicted. Verified nothing reaches IR or Code IR names *through* `inkline/compiler`: the only importers of that specifier are a config-file template and its test, both using `defineConfig`.

`vp run ready` could not be used as a single command in this environment — `vp run`'s process spawner fails with `Failed to spawn process: underlying os error: Invalid argument (os error 22)` on `apps/website`. Confirmed pre-existing and unrelated: it reproduces on a clean stash of `main` (2 failures at baseline vs 1 with this branch). The gate was therefore run as its three constituent steps, which is exactly what `ready` expands to (`pnpm run build && pnpm run check && pnpm run test`).

## Checklist

- [x] Added a changeset (`.changeset/narrow-compiler-export-surface.md`, `minor`).
- [x] Updated `core/compiler/README.md` — the "Working with the IR", "Transforming the IR" and "Custom Targets" examples imported moved names from the root and would no longer compile. `docs/api-reference.md` is deliberately untouched; that delta is tracked separately.
- [x] Commit message follows the conventional format.

## Not done, deliberately

- The target extension point stays closed. `TargetName` is still a closed union and `resolveOptions` still rejects unknown targets. Opening it is a separate design decision.
- No behaviour changes.

## Findings for follow-up (not fixed here)

The same "handed a value you cannot name" leak exists elsewhere. Reporting rather than widening the tiers unasked:

- `createRegistry()` returns `MutableTargetRegistry`, which is not exported from any entry point — a `/codegen` consumer cannot annotate the result.
- `RewriteRules` is exported, but its field types `ReactiveReadKind`, `SetterStyleKind` and `RefAccessKind` are not.
- `IRComponent` is exported, but `IRTransition`, `IRModelDeclaration`, `IRContextDefinition`, `IRProvideDeclaration` and `IRConsumeDeclaration` — all reachable through it — are not.
