### PR TITLE
feat(cli): default the report level to warning in one-shot builds

### DIFF
--- a/.changeset/cli-default-report-level-warning.md
+++ b/.changeset/cli-default-report-level-warning.md
@@ -1,0 +1,26 @@
+---
+"@inkline/cli": minor
+---
+
+feat(cli): default the report level to `warning` in one-shot builds
+
+`inkline compile` reported from `info` unless `--watch` was passed, so every build printed every
+`info` notice. On this repo's own `ui/components` that is 12 notes on a build with 0 errors and 0
+warnings. Notes of that kind are target-invariant advisories — `INK0045` tells you a fact about the
+Astro target, not about the edit you just made — so a CI log filled with them trains people to skip
+the compiler's output, which is where errors and warnings also live.
+
+Both modes now default to `warning`. `--report-level info` (or `reportLevel: "info"` in
+`inkline.config.ts`) reports exactly what a one-shot build printed before, byte for byte.
+
+Nothing else changes. Errors and warnings print as they always did, and the exit code is decided
+before the level applies, so a quieter build never becomes a passing one:
+
+```
+$ inkline compile "src/**/*.ink.tsx"
+Compiled 67 files in 0.28s — 0 errors, 0 warnings, 0 notes (12 notes withheld at --report-level warning; re-run with --report-level info to list)
+```
+
+If you verify a build by reading its notices — checking for the expected `INK0045`/`INK0068` on a new
+component, for instance — add `--report-level info`. Without it a quiet build no longer proves the
+notices you got are the ones you expected.

--- a/.claude/skills/create-component/reference/verification.md
+++ b/.claude/skills/create-component/reference/verification.md
@@ -21,12 +21,13 @@ The toolchain is **Vite+ (`vp`)** — OXLint for lint, Oxfmt for format, Vitest 
 
 - **`vp check` reports ~290 pre-existing `TS17004` errors on `.ink.tsx` fixtures.** This is a standing baseline, not something your change introduced. **Trust `vp test`** for whether the component is correct; don't try to "fix" these.
 - **Expected compiler notices** for components using two-way binding or `hasSlot` gating: `INK0045` (Astro two-way, one per binding) and `INK0068` (Qwik + Angular `hasSlot`, exactly 2). Tests assert these explicitly. Anything else in `result.diagnostics` is a real problem.
+  - Both are `info`, and `inkline compile` reports from the `warning` floor, so **`pnpm build` does not print them** — the summary line only names the count (`… 0 notes (12 notes withheld at --report-level warning; …)`). Add `--report-level info` when you need to read them. `vp test` reads `result.diagnostics` directly and is unaffected.
 - **Compiler-internal edits** (changing codegen in `core/compiler`) require `vp pack` in `core/compiler` before `inkline compile` / Storybook reflect them. **Not relevant when only authoring a component** — only if you also touched the compiler.
 - **Angular SSR sorts recipe class keys alphabetically**, so real-DOM test regexes must expect the sorted order (e.g. `class="input input--color-light input--size-md"`).
 
 ## What "verified" means per phase
 
-- **implement**: `pnpm build` emits all 7 targets with only the expected notices (`INK0045`/`INK0068`); no `INK0120`/`INK0060`/`INK0050` etc.
+- **implement**: `pnpm build --report-level info` emits all 7 targets with only the expected notices (`INK0045`/`INK0068`); no `INK0120`/`INK0060`/`INK0050` etc. Without the flag the notices are withheld, so a quiet build proves nothing about which ones you got.
 - **stories**: `pnpm build` regenerates CSF3 without error; `pnpm run storybook` renders the component across targets.
 - **test**: `vp test` green; `vp test --coverage` shows ~100% line+branch on the component's own executable code.
 - **final gate**: `vp run ready` green (build + check + test). Remember the `TS17004` fixture baseline when reading `check` output.

--- a/.claude/skills/implement-component/SKILL.md
+++ b/.claude/skills/implement-component/SKILL.md
@@ -151,8 +151,10 @@ export { default as IBadgeBase } from "./badge/headless/IBadgeBase.ink.tsx";
 
 ### 6. Verify
 
-`cd ui/components && pnpm build`. The component must compile to **all 7 targets** with only the expected notices: `INK0045` (Astro two-way, if any) and `INK0068` (Qwik + Angular, if `hasSlot` is used). Anything else (`INK0120` fallthrough, `INK0060`, `INK0050`, conformance failures) is a real defect — fix it. See `.../reference/verification.md` for the noise baseline.
+`cd ui/components && pnpm build --report-level info`. The component must compile to **all 7 targets** with only the expected notices: `INK0045` (Astro two-way, if any) and `INK0068` (Qwik + Angular, if `hasSlot` is used). Anything else (`INK0120` fallthrough, `INK0060`, `INK0050`, conformance failures) is a real defect — fix it. See `.../reference/verification.md` for the noise baseline.
+
+`--report-level info` is not optional here: `compile` reports from the `warning` floor by default, so both expected notices are **withheld** and the summary line only names the count (`… 0 notes (12 notes withheld at --report-level warning; …)`). A quiet `pnpm build` therefore does not tell you the notices you got are the expected ones.
 
 ## Exit criteria
 
-`pnpm build` is clean (only expected notices), the export is registered, every prop has TSDoc, and the source mirrors the exemplar's structure. Hand off to `stories-component` and `test-component`.
+`pnpm build --report-level info` is clean (only expected notices), the export is registered, every prop has TSDoc, and the source mirrors the exemplar's structure. Hand off to `stories-component` and `test-component`.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -433,20 +433,20 @@ export default defineConfig({
 
 ### Options
 
-| Option          | Type                                          | Default      | Description                                                                                                                                                                                                                                                                                                |
-| --------------- | --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `targets`       | `TargetName[]`                                | (required)   | Targets to compile for.                                                                                                                                                                                                                                                                                    |
-| `srcDir`        | `string`                                      | —            | Source root to strip from output paths (e.g. `"src"`). When set, directory structure below `srcDir` is preserved in the output. Without it, the deepest common prefix is used. Also available as `--src-dir` on the CLI.                                                                                   |
-| `outDir`        | `string`                                      | `"dist"`     | Output directory. Files are written to `<outDir>/<target>/`.                                                                                                                                                                                                                                               |
-| `targetOutDir`  | `Partial<Record<TargetName, string>>`         | `{}`         | Per-target output directory override, replacing `<outDir>/<target>/` for the targets it names.                                                                                                                                                                                                             |
-| `tsconfig`      | `string`                                      | —            | Path to a `tsconfig.json` whose ambient declarations (e.g. generated `*.d.ts` for virtual modules) are loaded into the per-file program, so `import type` from those modules resolves during prop analysis.                                                                                                |
-| `barrels`       | `BarrelGroup[]`                               | (see note)   | Per-category re-export barrels written for each target. Read by `@inkline/cli` only — the compiler pipeline ignores it. Omitted, the CLI writes one `index.ts` per target containing every non-story component.                                                                                            |
-| `sourceMap`     | `"external" \| "inline" \| "none"`            | `"external"` | Source map generation mode.                                                                                                                                                                                                                                                                                |
-| `reportLevel`   | `"error" \| "warning" \| "info"`              | (see note)   | Lowest diagnostic severity reported. Read by `@inkline/cli` only — the compiler pipeline ignores it and always produces every diagnostic it finds. A level reports itself and everything above it, so `"warning"` withholds notes. Omitted, the CLI reports from `"info"`, or `"warning"` under `--watch`. |
-| `targetOptions` | `Record<TargetName, Record<string, unknown>>` | `{}`         | Per-target options. Unknown keys produce INK0080 warnings.                                                                                                                                                                                                                                                 |
-| `plugins`       | `Plugin[]`                                    | `[]`         | Compiler plugins.                                                                                                                                                                                                                                                                                          |
-| `verbose`       | `boolean`                                     | `false`      | Log detailed plugin errors.                                                                                                                                                                                                                                                                                |
-| `registry`      | `TargetRegistry`                              | built-in     | Custom target registry (advanced).                                                                                                                                                                                                                                                                         |
+| Option          | Type                                          | Default      | Description                                                                                                                                                                                                                                                                 |
+| --------------- | --------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targets`       | `TargetName[]`                                | (required)   | Targets to compile for.                                                                                                                                                                                                                                                     |
+| `srcDir`        | `string`                                      | —            | Source root to strip from output paths (e.g. `"src"`). When set, directory structure below `srcDir` is preserved in the output. Without it, the deepest common prefix is used. Also available as `--src-dir` on the CLI.                                                    |
+| `outDir`        | `string`                                      | `"dist"`     | Output directory. Files are written to `<outDir>/<target>/`.                                                                                                                                                                                                                |
+| `targetOutDir`  | `Partial<Record<TargetName, string>>`         | `{}`         | Per-target output directory override, replacing `<outDir>/<target>/` for the targets it names.                                                                                                                                                                              |
+| `tsconfig`      | `string`                                      | —            | Path to a `tsconfig.json` whose ambient declarations (e.g. generated `*.d.ts` for virtual modules) are loaded into the per-file program, so `import type` from those modules resolves during prop analysis.                                                                 |
+| `barrels`       | `BarrelGroup[]`                               | (see note)   | Per-category re-export barrels written for each target. Read by `@inkline/cli` only — the compiler pipeline ignores it. Omitted, the CLI writes one `index.ts` per target containing every non-story component.                                                             |
+| `sourceMap`     | `"external" \| "inline" \| "none"`            | `"external"` | Source map generation mode.                                                                                                                                                                                                                                                 |
+| `reportLevel`   | `"error" \| "warning" \| "info"`              | `"warning"`  | Lowest diagnostic severity reported. Read by `@inkline/cli` only — the compiler pipeline ignores it and always produces every diagnostic it finds. A level reports itself and everything above it, so the default `"warning"` withholds notes; `"info"` reports everything. |
+| `targetOptions` | `Record<TargetName, Record<string, unknown>>` | `{}`         | Per-target options. Unknown keys produce INK0080 warnings.                                                                                                                                                                                                                  |
+| `plugins`       | `Plugin[]`                                    | `[]`         | Compiler plugins.                                                                                                                                                                                                                                                           |
+| `verbose`       | `boolean`                                     | `false`      | Log detailed plugin errors.                                                                                                                                                                                                                                                 |
+| `registry`      | `TargetRegistry`                              | built-in     | Custom target registry (advanced).                                                                                                                                                                                                                                          |
 
 `@inkline/cli` validates the loaded config against a zod schema. Keys outside this set are ignored
 and reported as INK0081 / INK0082 warnings (with a suggested spelling when the key is close to a
@@ -501,18 +501,23 @@ inkline compile src/IButton.ink.tsx --target react --source-map inline
 # Watch and recompile on change
 inkline compile "src/**/*.ink.tsx" --config inkline.config.ts --watch
 
-# Report warnings and errors only, withholding info notices
-inkline compile "src/**/*.ink.tsx" --target react --report-level warning
+# Also report info notices, which the default `warning` floor withholds
+inkline compile "src/**/*.ink.tsx" --target react --report-level info
 ```
 
-Flags: `--target`, `--src-dir`, `--out-dir` (default `dist`), `--source-map` (`external` | `inline` | `none`, default `external`), `--report-level` (`error` | `warning` | `info`, default `info`, or `warning` under `--watch`), `--config`, `--clean` (default `true`), `--watch`, `--verbose`. `--target` is required unless the config file sets `targets`. CLI flags override config file values.
+Flags: `--target`, `--src-dir`, `--out-dir` (default `dist`), `--source-map` (`external` | `inline` | `none`, default `external`), `--report-level` (`error` | `warning` | `info`, default `warning`), `--config`, `--clean` (default `true`), `--watch`, `--verbose`. `--target` is required unless the config file sets `targets`. CLI flags override config file values.
 
-A build closes with a summary of what it did. When `--report-level` withheld anything, the summary
-says so rather than reporting a bare `0 notes`, which cannot be told apart from "there were none":
+A build closes with a summary of what it did. Because the default level withholds notes, the summary
+says how many rather than reporting a bare `0 notes`, which cannot be told apart from "there were
+none":
 
 ```
 Compiled 67 files in 0.45s — 0 errors, 0 warnings, 0 notes (12 notes withheld at --report-level warning; re-run with --report-level info to list)
 ```
+
+Notes are target-invariant advisories — `INK0045` tells you a fact about the Astro target, not about
+the edit you just made — so they are withheld by default in both modes. `--report-level info` lists
+them.
 
 ### Check
 

--- a/tooling/cli/src/commands/compile.test.ts
+++ b/tooling/cli/src/commands/compile.test.ts
@@ -219,12 +219,16 @@ describe("compile command (in-process)", () => {
 
   it("reports the info-level INK0045 notice on a one-shot astro build", async () => {
     const out = tmpDir("astro-info");
+    // `--report-level info` because the default floor is `warning`; the precedence suite below owns
+    // that default. What this pins is the severity's *consequence*, which the level cannot change.
     const { exitCode, errs } = await runCompile([
       resolve(FIXTURES, "ModelInput.ink.tsx"),
       "--target",
       "astro",
       "--out-dir",
       out,
+      "--report-level",
+      "info",
     ]);
     // INK0045 is info, not error — it prints but does not fail the build.
     expect(exitCode).toBe(0);
@@ -241,6 +245,9 @@ describe("compile command (in-process)", () => {
       "angular,qwik",
       "--out-dir",
       out,
+      // Dedup happens below the reporting level, so the note has to be let through to be counted.
+      "--report-level",
+      "info",
     ]);
 
     expect(exitCode).toBe(0);
@@ -263,6 +270,10 @@ describe("compile command (in-process)", () => {
       "angular",
       "--out-dir",
       out,
+      // The only diagnostic this fixture raises is info, so it needs the floor lowered to print a
+      // frame at all. Source frames themselves are severity-independent.
+      "--report-level",
+      "info",
     ]);
 
     expect(exitCode).toBe(0);
@@ -295,6 +306,8 @@ describe("compile command (in-process)", () => {
       "angular,qwik",
       "--out-dir",
       out,
+      "--report-level",
+      "info",
     ]);
 
     expect(errs.match(/info {2}INK0068/g)?.length).toBe(1);
@@ -674,10 +687,26 @@ describe("compile command --report-level precedence", () => {
     expect(errs).toContain("INK0045");
   });
 
-  it("reports from info when neither the flag nor the config sets a level", async () => {
+  it("reports from warning when neither the flag nor the config sets a level", async () => {
     const { exitCode, errs, logs } = await compileWith("report-level-default", []);
 
-    // Pre-change one-shot behaviour, summary line included: adding the flag changed no default.
+    // One floor for both modes: a one-shot build no longer prints notes either. The summary still
+    // accounts for the note, so the default hides output without hiding the fact that it did.
+    expect(exitCode).toBe(0);
+    expect(errs).not.toContain("INK0045");
+    expect(logs).toMatch(
+      /^Compiled 1 file in \d+\.\d\ds — 0 errors, 0 warnings, 0 notes \(1 note withheld at --report-level warning; re-run with --report-level info to list\)$/m,
+    );
+  });
+
+  // The escape hatch the default is only acceptable because of: what the build printed before this
+  // became the default is still one flag away, byte for byte.
+  it("restores the pre-default output under --report-level info", async () => {
+    const { exitCode, errs, logs } = await compileWith("report-level-default-opt-in", [
+      "--report-level",
+      "info",
+    ]);
+
     expect(exitCode).toBe(0);
     expect(errs).toContain("INK0045");
     expect(logs).toMatch(/^Compiled 1 file in \d+\.\d\ds — 0 errors, 0 warnings, 1 note$/m);
@@ -850,10 +879,10 @@ describe("compile command watch mode: incremental seeding and rebuild reporting"
   });
 });
 
-describe("compile command watch mode: dev reporting level", () => {
+describe("compile command watch mode: reporting level", () => {
   // Compiled to astro this emits both the info-level INK0045 notice (two-way binding) and a
-  // warning-level INK0010 (the effect has no reactive deps). The watch loop reports only warning+,
-  // so on the initial compile and every rebuild it must drop INK0045 but keep INK0010.
+  // warning-level INK0010 (the effect has no reactive deps). The default floor is `warning`, so on
+  // the initial compile and every rebuild the loop must drop INK0045 but keep INK0010.
   const MODEL = (tag: string) =>
     `import { defineComponent, defineModel, createEffect } from "@inkline/core";
 export default defineComponent(() => {
@@ -930,7 +959,7 @@ export default defineComponent(() => {
 
   // The watcher used to read the `warning` constant directly, which made `--report-level` a
   // one-shot-only flag: raising the level had no effect on the loop that reports on every save.
-  it("lets --report-level info surface the notice the watch default withholds", async () => {
+  it("lets --report-level info surface the notice the default withholds", async () => {
     const { watcher, logs, errs, componentFile } = await startWatch("watch-astro-info", [
       "--report-level",
       "info",

--- a/tooling/cli/src/commands/compile.ts
+++ b/tooling/cli/src/commands/compile.ts
@@ -43,15 +43,16 @@ import { writeCompileOutput, writeIfChanged, writeOutput } from "../lib/writer.t
 const DEFAULT_BARRELS: readonly BarrelGroup[] = [{ file: "index.ts", match: "" }];
 
 /**
- * Fallbacks for the reporting level, reached only when neither `--report-level` nor the config sets
- * one. Both are *defaults*, not ceilings: either can be overridden in either direction.
+ * Fallback reporting level, reached only when neither `--report-level` nor the config sets one. A
+ * *default*, not a ceiling — `--report-level info` reports everything, in either mode.
  *
- * `--watch` is always a dev loop, so it reports only `warning` and above by default: `info` notices
- * like INK0045 (Astro two-way binding) are build-time advisories that would be noise on every
- * rebuild. A one-shot compile (a build) keeps the `info` floor and reports everything.
+ * `info` notices are target-invariant advisories: INK0045 (Astro two-way binding) tells you a fact
+ * about the Astro target, not about the edit you just made. On this repo's own `ui/components` build
+ * that is 12 distinct notes on a build with 0 errors and 0 warnings — in `--watch` they repeat on
+ * every save, and in CI they fill a log nobody reads line by line. Neither reading is the one that
+ * makes a note useful, so both modes take the same floor and neither pays for the other's noise.
  */
-const DEV_REPORT_LEVEL = "warning" as const;
-const BUILD_REPORT_LEVEL = "info" as const;
+const DEFAULT_REPORT_LEVEL = "warning" as const;
 
 /** Ensure every configured named barrel exists for each target that produced output (empty if unmatched). */
 export function seedNamedBarrels(
@@ -134,14 +135,11 @@ export default defineCommand({
     "out-dir": { type: "string", description: "Default output directory (default: dist)" },
     /** Chain arg (config `sourceMap`); no default — the `"external"` fallback lives in the chain. */
     "source-map": { type: "string", description: "external | inline | none (default: external)" },
-    /**
-     * Chain arg (config `reportLevel`); no default — and it could not have one even if the chain
-     * allowed it, because the fallback depends on `--watch`. See `DEV_REPORT_LEVEL`.
-     */
+    /** Chain arg (config `reportLevel`); no default — the `warning` fallback lives in the chain. */
     "report-level": {
       type: "string",
       description:
-        "Lowest diagnostic severity to report: error | warning | info (default: info, warning under --watch)",
+        "Lowest diagnostic severity to report: error | warning | info (default: warning)",
     },
     /** No config counterpart by construction: this flag names the config file the chain reads. */
     config: { type: "string", description: "Path to config file" },
@@ -172,11 +170,7 @@ export default defineCommand({
     let reportLevel: DiagnosticSeverity;
     try {
       resolveOptions({ targets, registry: fileConfig.registry });
-      reportLevel = resolveReportLevel(
-        args["report-level"],
-        fileConfig,
-        args.watch ? DEV_REPORT_LEVEL : BUILD_REPORT_LEVEL,
-      );
+      reportLevel = resolveReportLevel(args["report-level"], fileConfig, DEFAULT_REPORT_LEVEL);
     } catch (err) {
       if (reportConfigError(err, verbose)) return;
       throw err;
@@ -359,9 +353,9 @@ function runWatch(
   // Seeded from the initial pass in `run`, not created empty here: an empty state makes the first
   // save after startup a full rebuild of every file, which is the work the caller just finished.
   initialState: IncrementalState,
-  // Passed in rather than re-derived from `DEV_REPORT_LEVEL`: the watcher used to read that constant
-  // directly, which made `--report-level` a one-shot-only flag and left two filter sites that could
-  // disagree. There is one resolved level per invocation and both paths read it.
+  // Passed in rather than re-derived: the watcher used to read a `warning` constant directly, which
+  // made `--report-level` a one-shot-only flag and left two filter sites that could disagree. There
+  // is one resolved level per invocation and both paths read it.
   reportLevel: DiagnosticSeverity,
 ): FSWatcher {
   console.log(`Watching ${files.length} file(s) for changes...\n`);

--- a/tooling/cli/src/lib/report.ts
+++ b/tooling/cli/src/lib/report.ts
@@ -37,8 +37,8 @@ function isReportLevel(value: string): value is DiagnosticSeverity {
 
 /**
  * Flag > config > default, matching `--target`, `--src-dir` and `--out-dir`. The default is the
- * caller's, not this function's: a one-shot build reports from `info` and `--watch` from `warning`
- * (`info` notices like INK0045 are build-time advisories, not something to re-read on every save).
+ * caller's, not this function's: an omitted level is a question about what the command should do by
+ * default, which belongs where that decision is documented rather than here.
  *
  * An unusable value throws {@link InklineConfigError} carrying INK0087, so a mistyped level lands on
  * the same path as a mistyped `--target` — a formatted diagnostic with help and a docs URL, not a


### PR DESCRIPTION
## Summary

`inkline compile` reported from `info` unless `--watch` was passed, so every build printed every
`info` notice — 12 of them on this repo's own `ui/components`, on a build with 0 errors and 0
warnings. Both modes now take the same `warning` floor, and `--report-level info` reports exactly
what a one-shot build printed before.

> **Stacked on #556** (`agent/signal/c6957548`), not `main` — this needs `--report-level` to exist
> before it can be the way back. Rebase onto `main` and retarget once #556 lands; review #556 first.

## Related issues

- Closes UXF-117
- Depends on #556 (UXF-115)

## Type of change

- [x] `feat` — new user-facing capability or public API
- [ ] `fix` — bug fix
- [ ] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `chore` / `ci` — tooling, dependencies, or CI

## What changed

`DEV_REPORT_LEVEL` / `BUILD_REPORT_LEVEL` and the `args.watch` ternary that chose between them
collapse into one `DEFAULT_REPORT_LEVEL = "warning"`. Nothing else in the resolution chain moves —
`resolveReportLevel(flag, config, default)` is unchanged, so `--report-level` and `reportLevel` still
override in either direction.

The reasoning, recorded in the constant's docblock: an `info` note is a target-invariant advisory.
`INK0045` tells you a fact about the Astro target, not about the edit you just made. Repeated on
every save in `--watch` or every run in CI, that trains people to skip the compiler's output — which
is where errors and warnings also live.

## Failure-mode note

**What breaks if this is wrong:** a build gets quieter than intended and someone stops seeing a
diagnostic they were relying on.

**Why it is bounded:**

- **Exit codes are untouched.** `hasError` is computed before filtering and dedup (#539), so raising
  the floor cannot turn a failing build into a passing one. `report.test.ts` pins this directly
  (`flags an error even when it is a duplicate or below the reporting level`), and the e2e
  `exits 1 and reports the diagnostic when compilation errors` runs on the new default.
- **The summary discloses what it hid.** `0 notes` would be indistinguishable from "there were
  none", so the withheld count and the flag that reveals it are printed instead.
- **One flag back.** `--report-level info` restores the previous output; pinned as its own test.
- **Independently revertible.** One commit, and reverting it restores the `info` default without
  touching the flag.

**Known consumer:** two agent skills verify a new component by reading `INK0045`/`INK0068` out of
`pnpm build`. Those notices are now withheld, so a quiet build would have passed for the wrong
reason. Both now require `--report-level info` and say why.

## Test plan

- [x] `pnpm run build && pnpm run check && pnpm run test` — format/lint/typecheck clean (962 files,
      698 checked), 0 failures
- [x] Default withholds and discloses, against `ui/components` (67 files):
      `Compiled 67 files in 0.28s — 0 errors, 0 warnings, 0 notes (12 notes withheld at --report-level warning; re-run with --report-level info to list)`
- [x] `pnpm build --report-level info` forwards through the package script and restores the notes:
      `Compiled 67 files in 0.26s — 0 errors, 0 warnings, 12 notes`
- [x] `--watch` unchanged — it already defaulted to `warning`

Test changes: four existing tests read `info` diagnostics to assert something else (dedup, source
frames, summary counts) and now pass `--report-level info` explicitly instead of leaning on the
default. The default's own test asserts the new floor plus the disclosure suffix, with a companion
pinning that the flag restores the previous output.

## Checklist

- [x] Added a changeset
- [x] Docs updated — `core/compiler/README.md` (`reportLevel` default, flags line, sample flipped to
      `--report-level info`), plus the two agent skills above
- [x] Commit messages follow the conventional format
