### PR TITLE
ci(codecov): exclude build scripts from coverage attribution

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,5 +15,17 @@
 # failing on unreachable compile-source lines. The real coverage threshold still
 # applies to normal `.ts`/`.tsx` source and to the local `vp test --coverage`
 # run.
+# Build/codegen scripts are developer tooling, not shipped source, and they enter the report
+# backwards: a script is only measured once a test imports it, so it is precisely the scripts whose
+# logic *is* unit-tested that drag their untestable `main()` argv dispatch and module-entry guard
+# into the denominator. `core/compiler/scripts/gen-aria-attributes.ts` is the live case — its
+# derivation logic is exported and covered, but the file still reports 60% (18/30 statements)
+# because `main()` cannot be meaningfully unit-tested, and that alone moved `codecov/patch` on
+# PR #562 from passing to 88% against a 94.98% target. `core/core` and `core/plugin` already get
+# this for free via `coverage.include: ["src/**/*.ts"]` in their vite configs; excluding here rather
+# than adding that include to `core/compiler` keeps the carve-out to build tooling, because setting
+# `include` there also pulls three uncovered *shipped* source files into the report and would hide a
+# real gap behind a config change (see UXF-136).
 ignore:
   - "**/*.ink.tsx"
+  - "**/scripts/**"


### PR DESCRIPTION
## Summary

Excludes `**/scripts/**` from Codecov attribution. Build and codegen scripts enter the report backwards: a script is only measured once a test imports it, so it is precisely the scripts whose logic *is* unit-tested that drag their untestable `main()` argv dispatch and module-entry guard into the denominator.

This is the follow-up to the `codecov/patch` miss on #562, which merged with the check red.

## Related issues

- Refs UXF-136 (#562)

## Type of change

- [x] `chore` / `ci` — tooling, dependencies, or CI

## The live case

`core/compiler/scripts/gen-aria-attributes.ts` derives the ARIA attribute set INK0072 checks against. Its logic — `extractAriaAttributes`, `render`, `generate`, `check` — is exported and covered. The file still reports **60% (18/30 statements)**, because the uncovered lines are `main()`'s argv dispatch and the `process.argv[1]` module-entry guard, neither of which a unit test can meaningfully reach.

That one file alone put `codecov/patch` on #562 at **88.00% against a 94.98% target**, while the new logic the check was actually gating measured 97.67% (`attribute-checks.ts`) and 98.33% (`two-way-binding.ts`).

## Measured, not assumed

Ran the full `core/compiler` suite with coverage on `main` (`3405 passed | 3 skipped`, matching the numbers reported on #562):

| | statements | lines |
|---|---|---|
| as-is | 93.73% | 95.25% |
| excluding `scripts/` | **93.96%** | **95.47%** |

`scripts/` contributes exactly one measured file. `bench.ts`, `gen-diagnostics.ts` and `generate-jsx.mjs` are not imported by any test, so they were never in the report and this changes nothing for them.

Pattern scope checked against the tracked file list: the four paths it matches are all tooling. No shipped source in this repo lives under a `scripts/` directory.

Config validated against Codecov's own validator — `Valid!`, compiling to `(?s:.*/scripts/.*)\Z`.

## Why here and not in the vite config

`core/core` and `core/plugin` already get this for free via `coverage.include: ["src/**/*.ts"]`. `core/compiler` is the only package without a coverage block, so the obvious fix was to match its siblings.

**I tried that first and measured it. It is worse.** Setting `include` there drops the 30 script statements but pulls in **57 statements of uncovered shipped source** that no test currently imports:

- `src/testing/bench.ts` — 0/31
- `src/testing/equivalence.ts` — 0/25
- `src/plugin/types.ts` — 0/1

Net denominator +26, and the package falls to **92.80%** statements. It would have traded a tooling artifact for a hidden real gap — and `src/testing/` is a published `pack` entry, so that gap is on shipped surface.

Excluding at the Codecov layer keeps the carve-out scoped to build tooling and leaves that gap visible. It is filed separately rather than papered over here.

## Test plan

- [x] Full `core/compiler` suite with coverage, twice (baseline and with the rejected alternative): `3405 passed | 3 skipped` both times, no test behavior change
- [x] `codecov.yml` accepted by `https://codecov.io/validate`, compiled pattern inspected
- [x] Ignore pattern audited against `git ls-files` — matches 4 tooling files, 0 shipped source
- [x] Pre-commit `vp check --fix` clean
- [ ] Confirm `codecov/patch` and `codecov/project` recover on this PR's own run

## Checklist

- [x] Added a changeset — n/a, CI config only, no published package behavior, API, or types change
- [x] Docs updated — the rationale lives as a comment in `codecov.yml` alongside the existing `.ink.tsx` carve-out, matching that file's established convention
- [x] Commit message follows the conventional format
