### PR TITLE
fix(compiler): carry defineEmits payload types through to codegen

### DIFF
--- a/.changeset/emit-payload-types.md
+++ b/.changeset/emit-payload-types.md
@@ -1,0 +1,9 @@
+---
+"@inkline/compiler": patch
+---
+
+Carry `defineEmits` payload types through to every target. The declared tuple was parsed and then discarded, so events were emitted untyped everywhere — most visibly in Angular, where `defineEmits<{ change: [value: string] }>()` produced a bare `change = output()`. That infers `OutputEmitterRef<void>`, so the generated `this.change.emit(value)` did not even type-check.
+
+`change = output<string>()` now, and the payload reaches the other targets too: React/Solid/Svelte get `onChange?: (value: string) => void` instead of `(...args: any[]) => void`, Qwik the same inside its `QRL<…>`, and Vue re-declares the shape as `defineEmits<{ change: [value: string] }>()` instead of the untyped array form. Custom events remain inert on Astro (`INK0045`), so nothing is typed there.
+
+Angular is the one target that cannot take the tuple verbatim, because an `output<T>` carries exactly one value. A single-value tuple unwraps, an empty one becomes `output<void>()`, and a multi-value tuple stays a tuple with the emit call packing its arguments to match (`emit("move", x, y)` → `this.move.emit([x, y])`) rather than silently dropping all but the first. Declaring events with the runtime array form (`defineEmits(["change"])`) still leaves them untyped, as it carries no type to begin with.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -249,6 +249,14 @@ export default defineComponent(() => {
 Qwik, a `defineEmits`/`emit` pair in Vue, a callback prop in Svelte, and `this.change.emit(x)` from an
 `@Output()` in Angular. (Custom events are inert on the static Astro target — diagnostic `INK0045`.)
 
+The declared payload tuple is the arguments `emit` takes, and it carries through to each target's event
+channel: the callback prop becomes `onChange?: (value: string) => void`, Vue re-declares the same shape
+in its own `defineEmits<…>()`. Angular is the exception, because an `output<T>` carries exactly one
+value — so a single-value tuple unwraps (`change = output<string>()`), an empty one becomes
+`output<void>()`, and a multi-value tuple stays a tuple with the emit call packing its arguments
+(`emit("move", x, y)` → `this.move.emit([x, y])`). Declaring events with the runtime array form
+(`defineEmits(["change"])`) leaves them untyped.
+
 ### Slots
 
 A component declares its slots in the options object and renders them with the `<Slot>` component

--- a/core/compiler/src/codegen/context.ts
+++ b/core/compiler/src/codegen/context.ts
@@ -141,6 +141,12 @@ export interface RewriteRules {
     readonly suffix?: string;
     /** Access prefix for a callback-prop emit (`props.` for React/Solid/Qwik, `""` for Svelte). */
     readonly propsAccess?: string;
+    /**
+     * Angular only: the names of events declaring more than one payload value. An Angular
+     * `output<T>` carries a single value, so those emits pack their arguments into an array
+     * (`emit("x", a, b)` → `this.x.emit([a, b])`) to match the tuple type argument on the output.
+     */
+    readonly packedPayloads?: ReadonlySet<string>;
   };
   /**
    * Lowers a `hasSlot("name")` call to the target's slot-presence check. Each target maps the slot

--- a/core/compiler/src/codegen/shared/event-payload.test.ts
+++ b/core/compiler/src/codegen/shared/event-payload.test.ts
@@ -1,0 +1,90 @@
+// Lowering of a declared emit payload tuple to each target's event-channel typing.
+import { describe, it, expect } from "vitest";
+import type { IREventDeclaration } from "../../ir/render/nodes.ts";
+import { loc, mockType } from "../../testing/codegen.ts";
+import {
+  angularOutputTypeArgument,
+  eventCallbackType,
+  packedPayloadEvents,
+  vueEmitsTypeArgument,
+} from "./event-payload.ts";
+
+/** An event declared as `defineEmits<{ <name>: <payload> }>()`, or untyped when `payload` is omitted. */
+function event(name: string, payload?: string): IREventDeclaration {
+  return { name, payloadType: payload === undefined ? undefined : mockType(payload), loc };
+}
+
+describe("angularOutputTypeArgument", () => {
+  it("unwraps a single-element tuple to the one value an output carries", () => {
+    expect(angularOutputTypeArgument(event("change", "[value: string]"))).toBe("<string>");
+    expect(angularOutputTypeArgument(event("change", "[string]"))).toBe("<string>");
+  });
+
+  it("types a valueless event as void", () => {
+    expect(angularOutputTypeArgument(event("submit", "[]"))).toBe("<void>");
+  });
+
+  it("keeps a multi-value payload as a tuple — an output cannot carry two values", () => {
+    expect(angularOutputTypeArgument(event("move", "[a: string, b: number]"))).toBe(
+      "<[a: string, b: number]>",
+    );
+  });
+
+  it("leaves an untyped event's output generic-free", () => {
+    expect(angularOutputTypeArgument(event("change"))).toBe("");
+  });
+});
+
+describe("eventCallbackType", () => {
+  it("takes the payload tuple as the callback's parameter list", () => {
+    expect(eventCallbackType(event("change", "[value: string]"))).toBe("(value: string) => void");
+    expect(eventCallbackType(event("move", "[a: string, b: number]"))).toBe(
+      "(a: string, b: number) => void",
+    );
+  });
+
+  it("names unlabelled tuple elements positionally", () => {
+    expect(eventCallbackType(event("change", "[string]"))).toBe("(arg0: string) => void");
+  });
+
+  it("takes no parameters for a valueless event", () => {
+    expect(eventCallbackType(event("submit", "[]"))).toBe("() => void");
+  });
+
+  it("falls back to a variadic any for an untyped event", () => {
+    expect(eventCallbackType(event("change"))).toBe("(...args: any[]) => void");
+  });
+});
+
+describe("vueEmitsTypeArgument", () => {
+  it("rebuilds the declaration Vue's macro takes", () => {
+    expect(vueEmitsTypeArgument([event("change", "[value: string]"), event("submit", "[]")])).toBe(
+      "{ change: [value: string]; submit: [] }",
+    );
+  });
+
+  it("quotes a name that is not a bare identifier", () => {
+    expect(vueEmitsTypeArgument([event("update:value", "[value: string]")])).toBe(
+      `{ "update:value": [value: string] }`,
+    );
+  });
+
+  it("falls back to the runtime array form when any event is untyped", () => {
+    expect(vueEmitsTypeArgument([event("change", "[value: string]"), event("submit")])).toBe(
+      undefined,
+    );
+    expect(vueEmitsTypeArgument([])).toBe(undefined);
+  });
+});
+
+describe("packedPayloadEvents", () => {
+  it("selects only the multi-value events", () => {
+    const packed = packedPayloadEvents([
+      event("move", "[a: string, b: number]"),
+      event("change", "[value: string]"),
+      event("submit", "[]"),
+      event("untyped"),
+    ]);
+    expect([...packed]).toEqual(["move"]);
+  });
+});

--- a/core/compiler/src/codegen/shared/event-payload.ts
+++ b/core/compiler/src/codegen/shared/event-payload.ts
@@ -1,0 +1,100 @@
+// Lowering of an event's declared payload tuple to each target's event-channel typing.
+//
+// `defineEmits<{ change: [value: string] }>()` declares `change` as carrying the *argument list*
+// `(value: string)` — the tuple mirrors what `emit("change", …)` takes, exactly like Vue's macro.
+// Targets differ in how many values their event channel can carry, so each lowers the same tuple:
+//
+//   - callback-prop targets (React/Solid/Svelte/Qwik) take the whole list: `(value: string) => void`
+//   - Vue passes the declaration through verbatim as a typed `defineEmits<{…}>()`
+//   - Angular's `output<T>` carries exactly ONE value, so the tuple is unwrapped (see below)
+//
+// An event with no `payloadType` (the runtime array form, or the options-API `events` object)
+// declares names only and stays untyped — every helper here returns `undefined` for it.
+
+import * as ts from "typescript";
+import type { IREventDeclaration } from "../../ir/render/nodes.ts";
+import { nodeText } from "./expr-rewrite.ts";
+
+/**
+ * The elements of an event's payload tuple, or `undefined` when the event is untyped or its declared
+ * type is not a tuple (e.g. `defineEmits<{ change: string }>()`, which the authoring type forbids).
+ */
+export function payloadTupleElements(
+  event: IREventDeclaration,
+): readonly ts.TypeNode[] | undefined {
+  const declared = event.payloadType;
+  if (!declared || !ts.isTupleTypeNode(declared)) return undefined;
+  return declared.elements;
+}
+
+/** The type of one tuple element, dropping the `name:` label of a named member (`count: number` → `number`). */
+function elementType(element: ts.TypeNode): string {
+  return nodeText(ts.isNamedTupleMember(element) ? element.type : element);
+}
+
+/**
+ * The callback-prop function type for an event — `[count: number]` → `(count: number) => void`,
+ * `[]` → `() => void`, `[string, number]` → `(arg0: string, arg1: number) => void`. An untyped event
+ * falls back to `(...args: any[]) => void`.
+ */
+export function eventCallbackType(event: IREventDeclaration): string {
+  const elements = payloadTupleElements(event);
+  const params = elements
+    ? elements
+        .map((el, i) => (ts.isNamedTupleMember(el) ? nodeText(el) : `arg${i}: ${nodeText(el)}`))
+        .join(", ")
+    : "...args: any[]";
+  return `(${params}) => void`;
+}
+
+/**
+ * Angular's `output<T>()` type argument, including the angle brackets, or `""` when untyped.
+ *
+ * `output<T>` carries a single value, so the payload tuple is unwrapped by arity:
+ * - `[]` → `<void>` (a valueless event; `emit()` takes no argument)
+ * - `[value: string]` → `<string>` — the common case, and the point of this whole exercise
+ * - `[a: string, b: number]` → `<[a: string, b: number]>` — Angular cannot carry two values, so a
+ *   multi-value event lowers to the tuple itself and the `emit` call packs its arguments into an
+ *   array (see {@link packedPayloadEvents}). Dropping the extras would silently lose data.
+ */
+export function angularOutputTypeArgument(event: IREventDeclaration): string {
+  const elements = payloadTupleElements(event);
+  if (!elements) return "";
+  if (elements.length === 0) return "<void>";
+  if (elements.length === 1) return `<${elementType(elements[0]!)}>`;
+  return `<[${elements.map((el) => nodeText(el)).join(", ")}]>`;
+}
+
+/**
+ * The type argument for Vue's `defineEmits<{…}>()`, rebuilt from the declared payload tuples — the
+ * closest mapping there is, since the Vue macro takes the same shape the authoring API does.
+ * `undefined` when any event is untyped, in which case the target keeps the runtime
+ * `defineEmits([...])` array form rather than emitting a half-typed declaration.
+ */
+export function vueEmitsTypeArgument(events: readonly IREventDeclaration[]): string | undefined {
+  if (events.length === 0) return undefined;
+  const members: string[] = [];
+  for (const event of events) {
+    const elements = payloadTupleElements(event);
+    if (!elements) return undefined;
+    const params = elements.map((el) => nodeText(el)).join(", ");
+    // Event names are semantic and unprefixed, but `update:value` needs quoting.
+    const key = /^[A-Za-z_$][\w$]*$/.test(event.name) ? event.name : JSON.stringify(event.name);
+    members.push(`${key}: [${params}]`);
+  }
+  return `{ ${members.join("; ")} }`;
+}
+
+/**
+ * The events whose payload is a multi-value tuple. The Angular rewriter uses this to pack
+ * `emit("x", a, b)` into `this.x.emit([a, b])`, matching the tuple type argument above. Events that
+ * are untyped or carry 0–1 values are absent and pass through unchanged.
+ */
+export function packedPayloadEvents(events: readonly IREventDeclaration[]): ReadonlySet<string> {
+  const packed = new Set<string>();
+  for (const event of events) {
+    const elements = payloadTupleElements(event);
+    if (elements && elements.length > 1) packed.add(event.name);
+  }
+  return packed;
+}

--- a/core/compiler/src/codegen/shared/expr-rewrite.ts
+++ b/core/compiler/src/codegen/shared/expr-rewrite.ts
@@ -56,7 +56,8 @@ export function callbackPropRules(
 const tsPrinter = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 const emptySF = ts.createSourceFile("_gen.tsx", "", ts.ScriptTarget.ESNext);
 
-function verbatim(node: ts.Node): string {
+/** A node's source text — verbatim when it came from a real file, printed when synthesized. */
+export function nodeText(node: ts.Node): string {
   const sf = node.getSourceFile?.();
   if (sf) return node.getText(sf);
   return tsPrinter.printNode(ts.EmitHint.Unspecified, node, emptySF);
@@ -147,8 +148,12 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
       switch (rules.emit.style) {
         case "noop":
           return "undefined";
-        case "angular-output":
-          return `${rules.selfPrefix ? "this." : ""}${eventName}.emit(${payload})`;
+        case "angular-output": {
+          // An Angular output carries one value, so a multi-value event emits its arguments packed
+          // into an array — matching the tuple type argument the declaration was given.
+          const value = rules.emit.packedPayloads?.has(eventName) ? `[${payload}]` : payload;
+          return `${rules.selfPrefix ? "this." : ""}${eventName}.emit(${value})`;
+        }
         case "callback-prop": {
           const access = rules.emit.propsAccess ?? "props.";
           return `${access}${eventToCallbackProp(eventName)}${rules.emit.suffix ?? ""}?.(${payload})`;
@@ -276,7 +281,7 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
 
   if (ts.isArrowFunction(expr)) {
     const asyncKw = hasAsyncModifier(expr) ? "async " : "";
-    const params = expr.parameters.map((p) => verbatim(p)).join(", ");
+    const params = expr.parameters.map((p) => nodeText(p)).join(", ");
     const paramStr =
       expr.parameters.length === 1 && !expr.parameters[0]!.type ? params : `(${params})`;
     // `() => batch(() => { … })` collapses to `() => { … }` (batch is a no-op grouping wrapper),
@@ -294,7 +299,7 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
 
   if (ts.isFunctionExpression(expr)) {
     const asyncKw = hasAsyncModifier(expr) ? "async " : "";
-    const params = expr.parameters.map((p) => verbatim(p)).join(", ");
+    const params = expr.parameters.map((p) => nodeText(p)).join(", ");
     const name = expr.name ? ` ${expr.name.text}` : "";
     return `${asyncKw}function${name}(${params}) ${walkBlock(expr.body, rules)}`;
   }
@@ -327,7 +332,7 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
     const parts = expr.properties.map((p) => {
       if (ts.isPropertyAssignment(p)) return `${p.name.getText()}: ${walk(p.initializer, rules)}`;
       if (ts.isSpreadAssignment(p)) return `...${walk(p.expression, rules)}`;
-      return verbatim(p);
+      return nodeText(p);
     });
     return `{ ${parts.join(", ")} }`;
   }
@@ -338,7 +343,7 @@ function walk(expr: ts.Expression, rules: RewriteRules): string {
 
   if (ts.isAsExpression(expr)) return walk(expr.expression, rules);
 
-  return verbatim(expr);
+  return nodeText(expr);
 }
 
 function walkStatement(stmt: ts.Statement, rules: RewriteRules): string {
@@ -351,7 +356,7 @@ function walkStatement(stmt: ts.Statement, rules: RewriteRules): string {
   if (ts.isVariableStatement(stmt)) {
     const kw = stmt.declarationList.flags & ts.NodeFlags.Const ? "const" : "let";
     const decls = stmt.declarationList.declarations.map((d) => {
-      const name = verbatim(d.name);
+      const name = nodeText(d.name);
       return d.initializer ? `${name} = ${walk(d.initializer, rules)}` : name;
     });
     return `${kw} ${decls.join(", ")};`;
@@ -363,9 +368,9 @@ function walkStatement(stmt: ts.Statement, rules: RewriteRules): string {
     return s;
   }
   if (ts.isForOfStatement(stmt)) {
-    return `for (${verbatim(stmt.initializer)} of ${walk(stmt.expression, rules)}) ${walkStatement(stmt.statement, rules)}`;
+    return `for (${nodeText(stmt.initializer)} of ${walk(stmt.expression, rules)}) ${walkStatement(stmt.statement, rules)}`;
   }
-  return verbatim(stmt);
+  return nodeText(stmt);
 }
 
 function walkBlock(block: ts.Block, rules: RewriteRules): string {
@@ -455,6 +460,6 @@ export function emitExprAsTemplate(expr: ts.Expression, rules: RewriteRules): st
   if (ts.isArrowFunction(inner) && !ts.isBlock(inner.body)) {
     return emitExprAsTemplate(inner.body, rules);
   }
-  if (isJsxLike(inner)) return verbatim(inner);
+  if (isJsxLike(inner)) return nodeText(inner);
   return `{${rewriteExpr(expr, rules)}}`;
 }

--- a/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -189,7 +189,7 @@ exports[`angular full output snapshots > EmitButton 1`] = `
 export class EmitButtonComponent
 {
 klass = input<string>()
-press = output()
+press = output<number>()
 }
 "
 `;

--- a/core/compiler/src/codegen/targets/angular/__tests__/models.test.ts
+++ b/core/compiler/src/codegen/targets/angular/__tests__/models.test.ts
@@ -21,9 +21,12 @@ describe("ModelInput: defineModel → model()", () => {
 });
 
 describe("EmitButton: defineEmits → output()", () => {
-  it("declares an output and emits via .emit()", async () => {
+  it("declares a payload-typed output and emits via .emit()", async () => {
     const out = await compileTo("EmitButton", "angular");
-    expect(out).toContain("press = output()");
+    // `defineEmits<{ press: [count: number] }>()` — the single-element tuple unwraps to the one
+    // value an Angular output carries. A bare `output()` is `OutputEmitterRef<void>`, which the
+    // `emit(1)` below does not even type-check against.
+    expect(out).toContain("press = output<number>()");
     expect(out).toContain(`(click)="press.emit(1)"`);
   });
 });

--- a/core/compiler/src/codegen/targets/angular/index.test.ts
+++ b/core/compiler/src/codegen/targets/angular/index.test.ts
@@ -21,6 +21,7 @@ import {
   makeComp,
   makeCtxWithExternalImport,
   mockExpr,
+  mockType,
   propsLabelDisabled,
   richComp,
   runInvariants,
@@ -506,6 +507,50 @@ describe("Angular additional branch coverage", () => {
     });
     const code = emitCode(makeComp("Page", ci));
     expect(code).toContain("(valueChange)=");
+  });
+
+  // An Angular `output<T>` carries exactly one value, so a multi-value payload tuple stays a tuple
+  // and the emit call packs its arguments to match — dropping them would lose data silently.
+  it("packs a multi-value emit into the tuple its output is typed with", () => {
+    const el = createElement({
+      tag: "button",
+      events: [
+        {
+          name: "click",
+          handler: createExpr({ expr: mockExpr(`() => emit("move", x, y)`) }),
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(
+      makeComp("Mover", el, {
+        emitName: "emit",
+        events: [{ name: "move", payloadType: mockType("[a: string, b: number]"), loc }],
+      }),
+    );
+    expect(code).toContain("move = output<[a: string, b: number]>()");
+    expect(code).toContain("move.emit([x, y])");
+  });
+
+  it("types a valueless event as output<void>() and leaves its emit argument-free", () => {
+    const el = createElement({
+      tag: "button",
+      events: [
+        {
+          name: "click",
+          handler: createExpr({ expr: mockExpr(`() => emit("submit")`) }),
+          loc,
+        },
+      ],
+    });
+    const code = emitCode(
+      makeComp("Form", el, {
+        emitName: "emit",
+        events: [{ name: "submit", payloadType: mockType("[]"), loc }],
+      }),
+    );
+    expect(code).toContain("submit = output<void>()");
+    expect(code).toContain("submit.emit()");
   });
 
   it("self-closes a void element that has no attributes", () => {

--- a/core/compiler/src/codegen/targets/angular/index.ts
+++ b/core/compiler/src/codegen/targets/angular/index.ts
@@ -18,6 +18,7 @@ import {
   reactiveReadNames,
   foldConstTest,
 } from "../../shared/expr-rewrite.ts";
+import { angularOutputTypeArgument, packedPayloadEvents } from "../../shared/event-payload.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { assertNever } from "../../../core/assert.ts";
@@ -491,7 +492,11 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
     ...component.models.map((m) => [m.setterName, m.name]),
   ]);
   const emitRule = component.emitName
-    ? ({ local: component.emitName, style: "angular-output" } as const)
+    ? ({
+        local: component.emitName,
+        style: "angular-output",
+        packedPayloads: packedPayloadEvents(component.events),
+      } as const)
     : undefined;
   // Refs bound to a DOM element (`<input ref={x}>`) must unwrap to `this.x()?.nativeElement` in
   // class-body reads (see REWRITES.refAccess); a ref on a component instance keeps the raw `viewChild`
@@ -697,11 +702,13 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
       body.push(cStmt({ body: `${m.name} = model${generic}(${opts})`, span: m.loc }));
     }
   }
-  // Custom events become `@Output()` emitters; `emit("x", …)` → `this.x.emit(…)`.
+  // Custom events become `@Output()` emitters; `emit("x", …)` → `this.x.emit(…)`. The declared
+  // payload tuple is unwrapped to the single value an `output<T>` carries — see
+  // `angularOutputTypeArgument` for the arity rules.
   if (component.events.length > 0) {
     angularImports.push("output");
     for (const ev of component.events) {
-      const generic = ev.payloadType ? `<${ev.payloadType.getText()}>` : "";
+      const generic = angularOutputTypeArgument(ev);
       body.push(cStmt({ body: `${ev.name} = output${generic}()`, span: ev.loc }));
     }
   }

--- a/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -202,7 +202,7 @@ return (
 
 exports[`qwik full output snapshots > EmitButton 1`] = `
 "import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
-export const EmitButton = component$((props: { onPress$?: QRL<(...args: any[]) => void> } & Record<string, any>) =>
+export const EmitButton = component$((props: { onPress$?: QRL<(count: number) => void> } & Record<string, any>) =>
 {
 const { onPress$, ...__attrs } = props
 return (

--- a/core/compiler/src/codegen/targets/qwik/__tests__/models.test.ts
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/models.test.ts
@@ -25,6 +25,6 @@ describe("EmitButton: defineEmits → QRL callback prop", () => {
   it("rewrites emit(name, …) to props.on<Name>$?.()", async () => {
     const out = await compileTo("EmitButton", "qwik");
     expect(out).toContain("onClick$={$(() => props.onPress$?.(1))}");
-    expect(out).toContain("onPress$?: QRL<(...args: any[]) => void>");
+    expect(out).toContain("onPress$?: QRL<(count: number) => void>");
   });
 });

--- a/core/compiler/src/codegen/targets/qwik/index.ts
+++ b/core/compiler/src/codegen/targets/qwik/index.ts
@@ -22,6 +22,7 @@ import {
   reactiveReadNames,
   foldConstTest,
 } from "../../shared/expr-rewrite.ts";
+import { eventCallbackType } from "../../shared/event-payload.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
@@ -416,7 +417,7 @@ function qwikModelEventTypeFields(component: IRComponent): string[] {
     fields.push(`${eventToCallbackProp(`update:${m.propName}`)}$?: QRL<(value: ${t}) => void>`);
   }
   for (const ev of component.events) {
-    fields.push(`${eventToCallbackProp(ev.name)}$?: QRL<(...args: any[]) => void>`);
+    fields.push(`${eventToCallbackProp(ev.name)}$?: QRL<${eventCallbackType(ev)}>`);
   }
   return fields;
 }

--- a/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -199,7 +199,7 @@ return (
 `;
 
 exports[`react full output snapshots > EmitButton 1`] = `
-"export function EmitButton(props: { onPress?: (...args: any[]) => void } & React.HTMLAttributes<HTMLElement>)
+"export function EmitButton(props: { onPress?: (count: number) => void } & React.HTMLAttributes<HTMLElement>)
 {
 const { onPress, ...__attrs } = props
 return (

--- a/core/compiler/src/codegen/targets/react/__tests__/models.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/models.test.ts
@@ -24,6 +24,6 @@ describe("EmitButton: defineEmits → callback prop", () => {
   it("rewrites emit(name, …) to props.on<Name>?.()", async () => {
     const out = await compileTo("EmitButton", "react");
     expect(out).toContain("props.onPress?.(1)");
-    expect(out).toContain("onPress?: (...args: any[]) => void");
+    expect(out).toContain("onPress?: (count: number) => void");
   });
 });

--- a/core/compiler/src/codegen/targets/react/index.ts
+++ b/core/compiler/src/codegen/targets/react/index.ts
@@ -24,6 +24,7 @@ import {
   callbackPropRules,
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
+import { eventCallbackType } from "../../shared/event-payload.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
@@ -443,7 +444,7 @@ function buildPropsType(component: IRComponent): string {
     emissionFields.push(`${eventToCallbackProp(`update:${m.propName}`)}?: (value: ${t}) => void`);
   }
   for (const ev of component.events) {
-    emissionFields.push(`${eventToCallbackProp(ev.name)}?: (...args: any[]) => void`);
+    emissionFields.push(`${eventToCallbackProp(ev.name)}?: ${eventCallbackType(ev)}`);
   }
   if (emissionFields.length > 0) {
     parts.push(`{ ${emissionFields.join("; ")} }`);

--- a/core/compiler/src/codegen/targets/solid/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/solid/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -219,7 +219,7 @@ return (
 exports[`solid full output snapshots > EmitButton 1`] = `
 "import { splitProps } from "solid-js";
 import type { JSX } from "solid-js";
-export default function EmitButton(props: { onPress?: (...args: any[]) => void } & JSX.HTMLAttributes<HTMLElement>)
+export default function EmitButton(props: { onPress?: (count: number) => void } & JSX.HTMLAttributes<HTMLElement>)
 {
 const [, __attrs] = splitProps(props, ["onPress"])
 return (

--- a/core/compiler/src/codegen/targets/solid/index.ts
+++ b/core/compiler/src/codegen/targets/solid/index.ts
@@ -22,6 +22,7 @@ import {
   callbackPropRules,
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
+import { eventCallbackType } from "../../shared/event-payload.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
@@ -503,7 +504,7 @@ function modelEventTypeFields(component: IRComponent): string[] {
     fields.push(`${eventToCallbackProp(`update:${m.propName}`)}?: (value: ${t}) => void`);
   }
   for (const ev of component.events) {
-    fields.push(`${eventToCallbackProp(ev.name)}?: (...args: any[]) => void`);
+    fields.push(`${eventToCallbackProp(ev.name)}?: ${eventCallbackType(ev)}`);
   }
   return fields;
 }

--- a/core/compiler/src/codegen/targets/svelte/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/svelte/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -123,7 +123,7 @@ exports[`svelte full output snapshots > ElementRef 1`] = `
 
 exports[`svelte full output snapshots > EmitButton 1`] = `
 "<script lang="ts">
-  interface Props { onPress?: (...args: any[]) => void }
+  interface Props { onPress?: (count: number) => void }
   let { onPress, ...__attrs }: Props & Record<string, any> = $props()
 </script>
 <button {...__attrs} class={__attrs.class} onclick={() => onPress?.(1)}>Go</button>

--- a/core/compiler/src/codegen/targets/svelte/__tests__/models.test.ts
+++ b/core/compiler/src/codegen/targets/svelte/__tests__/models.test.ts
@@ -25,6 +25,6 @@ describe("EmitButton: defineEmits → callback prop", () => {
   it("rewrites emit(name, …) to a bare on<Name>?.() callback", async () => {
     const out = await compileTo("EmitButton", "svelte");
     expect(out).toContain("onclick={() => onPress?.(1)}");
-    expect(out).toContain("onPress?: (...args: any[]) => void");
+    expect(out).toContain("onPress?: (count: number) => void");
   });
 });

--- a/core/compiler/src/codegen/targets/svelte/index.ts
+++ b/core/compiler/src/codegen/targets/svelte/index.ts
@@ -26,6 +26,7 @@ import {
   eventToCallbackProp,
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
+import { eventCallbackType } from "../../shared/event-payload.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
@@ -467,7 +468,7 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   // event contributes a callback prop.
   const emissionTypeFields = [
     ...component.models.map((m) => `${m.propName}?: ${m.typeNode?.getText() ?? "unknown"}`),
-    ...component.events.map((ev) => `${eventToCallbackProp(ev.name)}?: (...args: any[]) => void`),
+    ...component.events.map((ev) => `${eventToCallbackProp(ev.name)}?: ${eventCallbackType(ev)}`),
   ];
   const extraTypeFields = [...emissionTypeFields, ...slotPropFields];
   const hasExtra = extraTypeFields.length > 0;

--- a/core/compiler/src/codegen/targets/vue/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/vue/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -184,7 +184,7 @@ exports[`vue full output snapshots > ElementRef 1`] = `
 
 exports[`vue full output snapshots > EmitButton 1`] = `
 "<script setup lang="ts">
-  const emit = defineEmits(["press"])
+  const emit = defineEmits<{ press: [count: number] }>()
 </script>
 <template>
 <button @click='() => emit("press", 1)'>Go</button>

--- a/core/compiler/src/codegen/targets/vue/__tests__/models.test.ts
+++ b/core/compiler/src/codegen/targets/vue/__tests__/models.test.ts
@@ -20,9 +20,10 @@ describe("ModelInput: defineModel macro", () => {
 });
 
 describe("EmitButton: defineEmits", () => {
-  it("declares defineEmits and keeps the emit call", async () => {
+  it("declares a payload-typed defineEmits and keeps the emit call", async () => {
     const out = await compileTo("EmitButton", "vue");
-    expect(out).toContain('const emit = defineEmits(["press"])');
+    // Vue's macro takes the same shape the authoring API does, so the declaration carries over.
+    expect(out).toContain("const emit = defineEmits<{ press: [count: number] }>()");
     expect(out).toContain(`emit("press", 1)`);
   });
 });

--- a/core/compiler/src/codegen/targets/vue/index.ts
+++ b/core/compiler/src/codegen/targets/vue/index.ts
@@ -23,6 +23,7 @@ import {
   extractKeyBody,
   reactiveReadNames,
 } from "../../shared/expr-rewrite.ts";
+import { vueEmitsTypeArgument } from "../../shared/event-payload.ts";
 import { emitComponentImports } from "../../shared/component-imports.ts";
 import { setupLocalEmits } from "../../shared/setup-locals.ts";
 import { childrenArePhrasing } from "../../shared/phrasing.ts";
@@ -440,9 +441,13 @@ function emit(component: IRComponent, ctx: CodegenContext): CodeModule {
   }
 
   // `defineEmits` (a Vue macro) declares the component's custom events; `emit(…)` calls pass through.
+  // Declared payload tuples carry over as the macro's type argument (Vue takes the same shape the
+  // authoring API does); the runtime array form is the fallback when any event is untyped.
   if (component.emitName) {
+    const typeArg = vueEmitsTypeArgument(component.events);
     const names = component.events.map((e) => JSON.stringify(e.name)).join(", ");
-    scriptBody.unshift(cStmt({ body: `const ${component.emitName} = defineEmits([${names}])` }));
+    const macro = typeArg ? `defineEmits<${typeArg}>()` : `defineEmits([${names}])`;
+    scriptBody.unshift(cStmt({ body: `const ${component.emitName} = ${macro}` }));
   }
 
   // ── Module-level context definitions (non-setup <script>) ─────────

--- a/core/compiler/src/ir/render/nodes.ts
+++ b/core/compiler/src/ir/render/nodes.ts
@@ -247,6 +247,12 @@ export interface IRSlotDeclaration {
 
 export interface IREventDeclaration {
   readonly name: string;
+  /**
+   * The declared payload as an argument **tuple** — `defineEmits<{ change: [value: string] }>()`
+   * stores the `[value: string]` node, mirroring the arguments `emit("change", …)` takes. Absent for
+   * the runtime array form (`defineEmits(["change"])`) and for the options-API `events` object,
+   * which declare names only. Targets lower it themselves (see `payloadTupleElements`).
+   */
   readonly payloadType?: ts.TypeNode;
   readonly loc: SourceLocation;
 }

--- a/core/compiler/src/pipeline/passes/02-parse/model-emit.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/model-emit.test.ts
@@ -93,6 +93,36 @@ describe("defineEmits parsing", () => {
     expect(comp.events.some((e) => e.name === "press")).toBe(true);
   });
 
+  // `payloadType` is what every target types its event channel from. It was written nowhere for a
+  // release, which left Angular emitting a bare `output()`; assert the propagation so a silent
+  // regression fails here rather than in the emitted output.
+  it("carries the declared payload tuple onto the event", async () => {
+    const comp = (
+      await parse(`
+        import { defineComponent, defineEmits } from "@inkline/core";
+        export default defineComponent(() => {
+          const emit = defineEmits<{ press: [count: number]; submit: [] }>();
+          return <button onClick={() => emit("press", 1)}>Go</button>;
+        });
+      `)
+    ).components[0]!;
+    const payloads = Object.fromEntries(comp.events.map((e) => [e.name, e.payloadType?.getText()]));
+    expect(payloads).toEqual({ press: "[count: number]", submit: "[]" });
+  });
+
+  it("leaves the array form's events untyped", async () => {
+    const comp = (
+      await parse(`
+        import { defineComponent, defineEmits } from "@inkline/core";
+        export default defineComponent(() => {
+          const emit = defineEmits(["change"]);
+          return <button onClick={() => emit("change")}>Go</button>;
+        });
+      `)
+    ).components[0]!;
+    expect(comp.events[0]!.payloadType).toBeUndefined();
+  });
+
   it("records events from the array form", async () => {
     const comp = (
       await parse(`

--- a/core/compiler/src/pipeline/passes/02-parse/setup.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/setup.ts
@@ -38,24 +38,31 @@ function isCallTo(expr: ts.Expression, name: string | undefined): expr is ts.Cal
   );
 }
 
-/** Event names declared by `defineEmits(["a","b"])` or `defineEmits<{ a: [...]; b: [...] }>()`. */
-function declaredEmitNames(call: ts.CallExpression): string[] {
-  const names: string[] = [];
+/**
+ * Events declared by `defineEmits(["a","b"])` or `defineEmits<{ a: [...]; b: [...] }>()`.
+ *
+ * The type-argument form also carries each event's payload: the member type is the tuple of the
+ * arguments `emit(name, …)` takes, so it is kept verbatim as {@link IREventDeclaration.payloadType}
+ * for targets to lower. The runtime array form declares names only and stays untyped.
+ */
+function declaredEmits(call: ts.CallExpression): { name: string; payloadType?: ts.TypeNode }[] {
+  const declared: { name: string; payloadType?: ts.TypeNode }[] = [];
   const arg = call.arguments[0];
   if (arg && ts.isArrayLiteralExpression(arg)) {
     for (const el of arg.elements) {
-      if (ts.isStringLiteral(el)) names.push(el.text);
+      if (ts.isStringLiteral(el)) declared.push({ name: el.text });
     }
   }
   const typeArg = call.typeArguments?.[0];
   if (typeArg && ts.isTypeLiteralNode(typeArg)) {
     for (const member of typeArg.members) {
       if (member.name && (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name))) {
-        names.push(member.name.text);
+        const payloadType = ts.isPropertySignature(member) ? member.type : undefined;
+        declared.push({ name: member.name.text, payloadType });
       }
     }
   }
-  return names;
+  return declared;
 }
 
 function makeExprNode(expr: ts.Expression, sf: ts.SourceFile): IRExprNode {
@@ -294,8 +301,8 @@ export function parseSetup(
         if (isCallTo(init, emitsLocal)) {
           // const emit = defineEmits(["change"]) / defineEmits<{ change: [v: string] }>()
           if (ts.isIdentifier(decl.name)) emitName = decl.name.text;
-          for (const name of declaredEmitNames(init)) {
-            events.push({ name, loc: toLoc(decl, sourceFile) });
+          for (const { name, payloadType } of declaredEmits(init)) {
+            events.push({ name, payloadType, loc: toLoc(decl, sourceFile) });
           }
           continue;
         }

--- a/core/compiler/src/testing/codegen.ts
+++ b/core/compiler/src/testing/codegen.ts
@@ -138,6 +138,12 @@ export function mockExpr(code: string): ts.Expression {
   return (sf.statements[0] as ts.ExpressionStatement).expression;
 }
 
+/** Parse a snippet of TS into a type node — for building IR declarations that carry one inline. */
+export function mockType(code: string): ts.TypeNode {
+  const sf = ts.createSourceFile(`t.ts`, `type T = ${code};`, ts.ScriptTarget.Latest, true);
+  return (sf.statements[0] as ts.TypeAliasDeclaration).type;
+}
+
 /** A minimal component (no state/memos/effects) with overridable fields. */
 export function makeComp(
   name: string,

--- a/ui/components/src/components/radio/headless/__snapshots__/IRadioFieldBase.ink.test.ts.snap
+++ b/ui/components/src/components/radio/headless/__snapshots__/IRadioFieldBase.ink.test.ts.snap
@@ -34,7 +34,7 @@ checked = input<boolean>()
 disabled = input<boolean>()
 required = input<boolean>()
 readonly = input<boolean>()
-change = output()
+change = output<string>()
 }
 @Component({ standalone: true, selector: 'input[ink-radio-field-base]', host: { '[class]': "'radio-field' + (klass() ? ' ' + klass() : '')", 'type': 'radio', '[attr.id]': "(id()) ?? null", '[attr.name]': "(name()) ?? null", '[value]': "value() ?? ''", '[checked]': "checked()", '[disabled]': "disabled()", '[required]': "required()", '(click)': "readonly() && $event.preventDefault()", '(change)': "!readonly() && change.emit(value() ?? '')" }, template: \`\` })
 export class IRadioFieldBaseHostComponent
@@ -47,7 +47,7 @@ checked = input<boolean>()
 disabled = input<boolean>()
 required = input<boolean>()
 readonly = input<boolean>()
-change = output()
+change = output<string>()
 }
 ",
   "astro/IRadioFieldBase.astro": "---
@@ -98,7 +98,7 @@ export interface RadioFieldBaseProps {
    */
   readonly?: boolean;
 }
-export const IRadioFieldBase = component$((props: RadioFieldBaseProps & { onChange$?: QRL<(...args: any[]) => void> } & Record<string, any>) =>
+export const IRadioFieldBase = component$((props: RadioFieldBaseProps & { onChange$?: QRL<(value: string) => void> } & Record<string, any>) =>
 {
 const { id, name, value, checked, disabled, required, readonly, onChange$, ...__attrs } = props
 return (
@@ -126,7 +126,7 @@ return (
    */
   readonly?: boolean;
 }
-export function IRadioFieldBase(props: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & React.HTMLAttributes<HTMLElement>)
+export function IRadioFieldBase(props: RadioFieldBaseProps & { onChange?: (value: string) => void } & React.HTMLAttributes<HTMLElement>)
 {
 const { id, name, value, checked, disabled, required, readonly, onChange, ...__attrs } = props
 return (
@@ -156,7 +156,7 @@ export interface RadioFieldBaseProps {
    */
   readonly?: boolean;
 }
-export default function IRadioFieldBase(props: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & JSX.HTMLAttributes<HTMLElement>)
+export default function IRadioFieldBase(props: RadioFieldBaseProps & { onChange?: (value: string) => void } & JSX.HTMLAttributes<HTMLElement>)
 {
 const [, __attrs] = splitProps(props, ["id", "name", "value", "checked", "disabled", "required", "readonly", "onChange"])
 return (
@@ -185,7 +185,7 @@ return (
      */
     readonly?: boolean;
   }
-  let { id, name, value, checked, disabled, required, readonly, onChange, ...__attrs }: RadioFieldBaseProps & { onChange?: (...args: any[]) => void } & Record<string, any> = $props()
+  let { id, name, value, checked, disabled, required, readonly, onChange, ...__attrs }: RadioFieldBaseProps & { onChange?: (value: string) => void } & Record<string, any> = $props()
 </script>
 <input {...__attrs} class={["radio-field", __attrs.class].filter(Boolean).join(" ")} type="radio" id={id} name={name} value={value ?? ""} checked={checked} disabled={disabled} required={required} onclick={(e: { preventDefault: () => void }) => readonly && e.preventDefault()} onchange={() => !readonly && onChange?.(value ?? "")} />
 ",
@@ -210,7 +210,7 @@ return (
      */
     readonly?: boolean;
   }
-  const emit = defineEmits(["change"])
+  const emit = defineEmits<{ change: [value: string] }>()
   const props = defineProps<RadioFieldBaseProps>()
 </script>
 <template>


### PR DESCRIPTION
## Summary

`defineEmits<{ change: [value: string] }>()` declared a payload type that the compiler parsed and then threw away — `IREventDeclaration.payloadType` was written nowhere and read in exactly one place. Angular consequently emitted a bare `change = output()`, which infers `OutputEmitterRef<void>`, so the `this.change.emit(value)` the compiler generated alongside it did not even type-check. This carries the declared tuple through parse into the IR and lowers it in every target.

## Related issues

- Relates to UXF-167 (Multica), part of the UXF-90 stage-4 work.

## Type of change

- [x] `fix` — bug fix

## What each target emits now

| Target | Before | After |
| --- | --- | --- |
| Angular | `press = output()` | `press = output<number>()` |
| React / Solid / Svelte | `onPress?: (...args: any[]) => void` | `onPress?: (count: number) => void` |
| Qwik | `onPress$?: QRL<(...args: any[]) => void>` | `onPress$?: QRL<(count: number) => void>` |
| Vue | `defineEmits(["press"])` | `defineEmits<{ press: [count: number] }>()` |
| Astro | — | — (custom events are inert there, `INK0045`) |

## The multi-element tuple decision

The declared payload is an **argument tuple** — it mirrors what `emit(name, …)` takes, the same shape Vue's macro uses. Callback-prop targets take the whole list, so they need no decision. Angular does: an `output<T>` carries exactly one value. Lowering by arity:

- `[]` → `output<void>()`, `emit()` stays argument-free
- `[value: string]` → `output<string>()` — the tuple unwraps; this is the case the issue is about
- `[a: string, b: number]` → `output<[a: string, b: number]>()`, **and** the emit call packs: `emit("move", x, y)` → `this.move.emit([x, y])`

Packing is the only self-consistent option. Dropping the extra values is what happens today and it loses data silently; leaving `emit(x, y)` against any single-value `output<T>` does not compile. No multi-argument `emit(…)` exists anywhere in the repo, so this defines previously-undefined behaviour rather than changing existing output.

Vue is all-or-nothing: if any event on a component is untyped (the runtime `defineEmits(["a"])` form, or the options-API `events` object), the target keeps the array form rather than emitting a half-typed declaration.

## Snapshot diffs

Seven snapshot lines changed, all of them the intended new output — reviewed individually, not re-baselined to go green:

- `EmitButton` in six target snapshots (astro unchanged — events are inert there), one line each, exactly the table above.
- `IRadioFieldBase` in `ui/components`, which authors `defineEmits<{ change: [value: string] }>()` — this is the issue's acceptance case on a real component: `change = output<string>()`, `onChange?: (value: string) => void`, `defineEmits<{ change: [value: string] }>()`.

Unrelated `(...args: any[])` occurrences (scoped-slot render props) are untouched.

## Test plan

- [x] `pnpm run ready` (build + check + full monorepo test suite) passes locally — `core/compiler` 223 files / 3424 tests, `ui/components` 25 files / 212 tests, all packages green
- [x] IR-level test asserting `payloadType` propagation in `02-parse/model-emit.test.ts`, so the field cannot go dead again without a failure at the source
- [x] Unit coverage for the four lowering helpers in `codegen/shared/event-payload.test.ts` (label handling, `[]`, single, multi, untyped fallbacks, Vue key quoting)
- [x] Angular target tests for the multi-value packing and the `output<void>()` case, built from hand-written IR
- [x] Per-target `models.test.ts` expectations updated to the typed output

## Checklist

- [x] Added a changeset (`.changeset/emit-payload-types.md`)
- [x] `core/compiler/README.md` documents the payload lowering and the Angular arity rules
- [x] Commit message follows the conventional format
