### PR TITLE
fix(compiler): dedupe merged event declarations at 02-parse

### DIFF
--- a/.changeset/dedupe-merged-event-declarations.md
+++ b/.changeset/dedupe-merged-event-declarations.md
@@ -1,0 +1,9 @@
+---
+"@inkline/compiler": patch
+---
+
+Dedupe event declarations when a component declares the same event twice. The parse pass concatenated the options `events` object with the `defineEmits` declarations, so a name present in both produced two entries in the IR and a duplicated channel in every target — `defineEmits(["change", "change"])` in Vue, two `onChange` callback props elsewhere.
+
+The two declarations now collapse into one. Precedence is **last declaration wins**, which makes `defineEmits` beat the options object: the options `events` map declares names only, while `defineEmits<{ change: [value: string] }>()` also carries the payload tuple, so that is the only direction that does not silently drop type information. The winner keeps the first declaration's position, so emitted event order still follows the options object's reading order — `{ events: { change: {}, close: {} } }` plus `defineEmits<{ change: [value: string] }>()` emits `change` (typed) then `close`, not the other way round.
+
+The redundant declaration is reported as `INK0046`, a warning that names the event and points at the declaration to delete. Deduping keeps the output correct on its own; the diagnostic exists because declaring an event in both places is an authoring mistake worth surfacing rather than quietly repairing. Components that declare events from a single source are unaffected.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -257,6 +257,13 @@ value — so a single-value tuple unwraps (`change = output<string>()`), an empt
 (`emit("move", x, y)` → `this.move.emit([x, y])`). Declaring events with the runtime array form
 (`defineEmits(["change"])`) leaves them untyped.
 
+Events can also be declared in the options object (`events: { change: {} }`), which names them without
+a payload. Declaring the same name in both places is redundant, not additive: the two declarations
+collapse into a single event channel, **the `defineEmits` declaration wins** — it is the only one that
+can carry a payload tuple — and the redundant options entry is reported as `INK0046` (a warning). The
+surviving declaration keeps the position of the first one, so emitted event order still follows the
+options object. Declare each event in one place or the other, never both.
+
 ### Slots
 
 A component declares its slots in the options object and renders them with the `<Slot>` component

--- a/core/compiler/src/__fixtures__/DuplicateEvent.ink.tsx
+++ b/core/compiler/src/__fixtures__/DuplicateEvent.ink.tsx
@@ -1,0 +1,14 @@
+import { defineComponent, defineEmits } from "@inkline/core";
+
+// `change` is declared twice — once in the options `events` object and once via `defineEmits`.
+// The two declarations must collapse into a single event channel (last wins, so the typed
+// `defineEmits` payload survives) and the redundant options entry must report INK0046.
+// `close` is declared only in the options object and must be left untouched.
+export default defineComponent({ events: { change: {}, close: {} } }, () => {
+  const emit = defineEmits<{ change: [value: string] }>();
+  return (
+    <button id="change" onClick={() => emit("change", "next")}>
+      Change
+    </button>
+  );
+});

--- a/core/compiler/src/__fixtures__/scenarios.ts
+++ b/core/compiler/src/__fixtures__/scenarios.ts
@@ -180,6 +180,12 @@ export const scenarios: Readonly<Record<string, readonly Scenario[]>> = {
   DefineSlotBasic: [{ name: "renders structure", asserts: {} }],
   SlotInConditional: [{ name: "renders with conditional", asserts: {} }],
 
+  // ── Events ──
+  // Declared in both the options `events` object and `defineEmits`; INK0046 is a warning, so the
+  // fixture still compiles and keeps its conformance and per-target snapshot coverage — the
+  // diagnostic itself is asserted in `02-parse/index.test.ts`.
+  DuplicateEvent: [{ name: "collapses the duplicated event channel", asserts: {} }],
+
   // ── Scoped CSS ──
   ScopedStyle: [{ name: "renders with style", asserts: { textOf: { h1: "Hello" } } }],
 

--- a/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/angular/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -139,6 +139,18 @@ klass = input<string>()
 "
 `;
 
+exports[`angular full output snapshots > DuplicateEvent 1`] = `
+"import { Component, signal, computed, effect, input, output } from "@angular/core";
+@Component({ standalone: true, selector: 'ink-duplicate-event', host: { style: 'display: contents' }, template: \`<button id="change" [class]="klass()" (click)="change.emit('next')">Change</button>\` })
+export class DuplicateEventComponent
+{
+klass = input<string>()
+change = output<string>()
+close = output()
+}
+"
+`;
+
 exports[`angular full output snapshots > DynamicList 1`] = `
 "import { Component, signal, computed, effect, input } from "@angular/core";
 @Component({ standalone: true, selector: 'ink-dynamic-list', host: { style: 'display: contents' }, template: \`<div [class]="klass()">

--- a/core/compiler/src/codegen/targets/astro/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/astro/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -109,6 +109,16 @@ const { ...__attrs } = props;
 "
 `;
 
+exports[`astro full output snapshots > DuplicateEvent 1`] = `
+"---
+type Props = Record<string, any>
+const props = Astro.props as Props;
+const { ...__attrs } = props;
+---
+<button {...__attrs} id="change" onClick={() => undefined} class={__attrs.class}>Change</button>
+"
+`;
+
 exports[`astro full output snapshots > DynamicList 1`] = `
 "---
 type Props = Record<string, any>

--- a/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/qwik/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -152,6 +152,18 @@ return (
 "
 `;
 
+exports[`qwik full output snapshots > DuplicateEvent 1`] = `
+"import { component$, useSignal, useComputed$, useVisibleTask$, $, QRL } from "@qwik.dev/core";
+export const DuplicateEvent = component$((props: { onChange$?: QRL<(value: string) => void>; onClose$?: QRL<(...args: any[]) => void> } & Record<string, any>) =>
+{
+const { onChange$, onClose$, ...__attrs } = props
+return (
+<button {...__attrs} id="change" class={props.class} onClick$={$(() => props.onChange$?.("next"))}>Change</button>
+)
+});
+"
+`;
+
 exports[`qwik full output snapshots > DynamicList 1`] = `
 "import { component$, useSignal, useComputed$, useVisibleTask$, $ } from "@qwik.dev/core";
 export const DynamicList = component$((props) =>

--- a/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/react/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -150,6 +150,17 @@ return (
 "
 `;
 
+exports[`react full output snapshots > DuplicateEvent 1`] = `
+"export function DuplicateEvent(props: { onChange?: (value: string) => void; onClose?: (...args: any[]) => void } & React.HTMLAttributes<HTMLElement>)
+{
+const { onChange, onClose, ...__attrs } = props
+return (
+<button {...__attrs} id="change" className={props.className} onClick={() => props.onChange?.("next")}>Change</button>
+)
+}
+"
+`;
+
 exports[`react full output snapshots > DynamicList 1`] = `
 "import { useState, Fragment } from "react";
 export function DynamicList(props: React.HTMLAttributes<HTMLElement>)

--- a/core/compiler/src/codegen/targets/react/__tests__/events.test.ts
+++ b/core/compiler/src/codegen/targets/react/__tests__/events.test.ts
@@ -31,3 +31,19 @@ describe("TypedEvent: onMouseMove reading e.clientX / e.clientY into a signal", 
     expect(out).toContain("{pos.x}");
   });
 });
+
+// ---------------------------------------------------------------------------
+// DuplicateEvent: `change` declared in both the options `events` object and `defineEmits`.
+// Focus: the merge keeps ONE callback prop per name, and the surviving declaration is the
+// `defineEmits` one — the only source that can carry a payload tuple. `close`, declared in the
+// options object alone, keeps the untyped fallback signature.
+// ---------------------------------------------------------------------------
+describe("DuplicateEvent: the same event declared in options and defineEmits", () => {
+  it("React: one callback prop per name; the defineEmits payload type wins", async () => {
+    const out = await compileTo("DuplicateEvent", "react");
+    expect(out).toContain(
+      "props: { onChange?: (value: string) => void; onClose?: (...args: any[]) => void }",
+    );
+    expect(out).toContain("const { onChange, onClose, ...__attrs } = props");
+  });
+});

--- a/core/compiler/src/codegen/targets/solid/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/solid/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -163,6 +163,19 @@ return (
 "
 `;
 
+exports[`solid full output snapshots > DuplicateEvent 1`] = `
+"import { splitProps } from "solid-js";
+import type { JSX } from "solid-js";
+export default function DuplicateEvent(props: { onChange?: (value: string) => void; onClose?: (...args: any[]) => void } & JSX.HTMLAttributes<HTMLElement>)
+{
+const [, __attrs] = splitProps(props, ["onChange", "onClose"])
+return (
+<button {...__attrs} id="change" class={props.class} onclick={() => props.onChange?.("next")}>Change</button>
+)
+}
+"
+`;
+
 exports[`solid full output snapshots > DynamicList 1`] = `
 "import { createSignal, splitProps, For } from "solid-js";
 import type { JSX } from "solid-js";

--- a/core/compiler/src/codegen/targets/svelte/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/svelte/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -91,6 +91,15 @@ exports[`svelte full output snapshots > DefineSlotBasic 1`] = `
 "
 `;
 
+exports[`svelte full output snapshots > DuplicateEvent 1`] = `
+"<script lang="ts">
+  interface Props { onChange?: (value: string) => void; onClose?: (...args: any[]) => void }
+  let { onChange, onClose, ...__attrs }: Props & Record<string, any> = $props()
+</script>
+<button {...__attrs} id="change" class={__attrs.class} onclick={() => onChange?.("next")}>Change</button>
+"
+`;
+
 exports[`svelte full output snapshots > DynamicList 1`] = `
 "<script lang="ts">
   let { ...__attrs }: Record<string, any> = $props()

--- a/core/compiler/src/codegen/targets/vue/__tests__/__snapshots__/output-snapshots.test.ts.snap
+++ b/core/compiler/src/codegen/targets/vue/__tests__/__snapshots__/output-snapshots.test.ts.snap
@@ -138,6 +138,16 @@ exports[`vue full output snapshots > DefineSlotBasic 1`] = `
 "
 `;
 
+exports[`vue full output snapshots > DuplicateEvent 1`] = `
+"<script setup lang="ts">
+  const emit = defineEmits(["change", "close"])
+</script>
+<template>
+<button id="change" @click='() => emit("change", "next")'>Change</button>
+</template>
+"
+`;
+
 exports[`vue full output snapshots > DynamicList 1`] = `
 "<script setup lang="ts">
   import { ref } from "vue";

--- a/core/compiler/src/codegen/targets/vue/__tests__/events.test.ts
+++ b/core/compiler/src/codegen/targets/vue/__tests__/events.test.ts
@@ -37,3 +37,16 @@ describe("TypedEvent: onMouseMove reading e.clientX / e.clientY into a signal", 
     expect(out).toContain("{{ pos.x }}");
   });
 });
+
+// ---------------------------------------------------------------------------
+// DuplicateEvent: `change` declared in both the options `events` object and `defineEmits`.
+// Focus: the two declarations collapse into one channel. Vue is where the defect was visible —
+// the un-deduped merge emitted `defineEmits(["change", "change"])`, declaring the same emit twice.
+// ---------------------------------------------------------------------------
+describe("DuplicateEvent: the same event declared in options and defineEmits", () => {
+  it("Vue: emits one channel per name, in options-declaration order", async () => {
+    const out = await compileTo("DuplicateEvent", "vue");
+    expect(out).toContain('const emit = defineEmits(["change", "close"])');
+    expect(out).not.toContain('"change", "change"');
+  });
+});

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -16,6 +16,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0043",
       "INK0044",
       "INK0045",
+      "INK0046",
       "INK0050",
       "INK0060",
       "INK0061",
@@ -85,11 +86,12 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
-  it("codes with title placeholders: INK0030, INK0044, INK0072, INK0073, INK0080, INK0081, INK0082, INK0083, INK0085, INK0086, INK0087, INK0090, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
+  it("codes with title placeholders: INK0030, INK0044, INK0046, INK0072, INK0073, INK0080, INK0081, INK0082, INK0083, INK0085, INK0086, INK0087, INK0090, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
     const withPlaceholders = codes.filter((c) => /\{\w+\}/.test(DIAGNOSTICS[c].title));
     expect(withPlaceholders.sort()).toEqual([
       "INK0030",
       "INK0044",
+      "INK0046",
       "INK0072",
       "INK0073",
       "INK0080",

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -40,6 +40,12 @@ export const DIAGNOSTICS = {
     help: "An .astro component renders once on the server; the model value is read-only and emitted events never fire. Use a framework island for interactivity." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0045" as const,
   },
+  INK0046: {
+    severity: "warning" as const,
+    title: "Event '{name}' is declared twice" as const,
+    help: "Declare each event once. The defineEmits declaration wins, since it is the only one that can carry a payload type; remove the redundant declaration reported here." as const,
+    url: "https://docs.inkline.dev/diagnostics/INK0046" as const,
+  },
   INK0010: {
     severity: "warning" as const,
     title: "Effect has no reactive dependencies; it runs once" as const,

--- a/core/compiler/src/pipeline/passes/02-parse/index.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/index.test.ts
@@ -291,4 +291,71 @@ describe("parsePass", () => {
   it("has name 'parse'", () => {
     expect(parsePass.name).toBe("parse");
   });
+
+  // An event declared in the options `events` object AND via `defineEmits` used to be concatenated,
+  // which emitted the name twice downstream (`defineEmits(["change", "change"])` on Vue).
+  describe("event declaration merge", () => {
+    async function parse(source: string) {
+      const ctx = makeCtx();
+      const artifact = await programPass.run({ fileName: "Events.ink.tsx", source }, ctx);
+      const module = parsePass.run(artifact, ctx);
+      const resolved = module instanceof Promise ? await module : module;
+      return { component: resolved.components[0]!, diagnostics: ctx.diagnostics.freeze() };
+    }
+
+    const collision = `
+      import { defineComponent, defineEmits } from "@inkline/core";
+      export default defineComponent({ events: { change: {}, close: {} } }, () => {
+        const emit = defineEmits<{ change: [value: string] }>();
+        return <button onClick={() => emit("change", "next")}>Go</button>;
+      });
+    `;
+
+    it("collapses a name declared in both options and defineEmits into one event", async () => {
+      const { component } = await parse(collision);
+      expect(component.events.map((e) => e.name)).toEqual(["change", "close"]);
+    });
+
+    it("keeps the defineEmits payload type for the collapsed event", async () => {
+      const { component } = await parse(collision);
+      // The options `events` map declares names only, so the setup declaration has to win or the
+      // payload tuple is lost.
+      expect(component.events.find((e) => e.name === "change")!.payloadType).toBeDefined();
+      expect(component.events.find((e) => e.name === "close")!.payloadType).toBeUndefined();
+    });
+
+    it("reports INK0046 at the losing declaration", async () => {
+      const { diagnostics } = await parse(collision);
+      const duplicate = diagnostics.filter((d) => d.code === "INK0046");
+      expect(duplicate).toHaveLength(1);
+      expect(duplicate[0]!.title).toContain("change");
+      // Points at `change: {}` inside the options object — the declaration to delete — not at the
+      // `defineEmits` line that wins.
+      expect(duplicate[0]!.loc.line).toBe(3);
+    });
+
+    it("leaves a component that declares events from a single source untouched", async () => {
+      const { component, diagnostics } = await parse(`
+        import { defineComponent, defineEmits } from "@inkline/core";
+        export default defineComponent(() => {
+          const emit = defineEmits<{ change: [value: string] }>();
+          return <button onClick={() => emit("change", "next")}>Go</button>;
+        });
+      `);
+      expect(component.events.map((e) => e.name)).toEqual(["change"]);
+      expect(diagnostics.filter((d) => d.code === "INK0046")).toHaveLength(0);
+    });
+
+    it("collapses a name repeated within defineEmits itself", async () => {
+      const { component, diagnostics } = await parse(`
+        import { defineComponent, defineEmits } from "@inkline/core";
+        export default defineComponent(() => {
+          const emit = defineEmits(["change", "change"]);
+          return <button onClick={() => emit("change")}>Go</button>;
+        });
+      `);
+      expect(component.events.map((e) => e.name)).toEqual(["change"]);
+      expect(diagnostics.filter((d) => d.code === "INK0046")).toHaveLength(1);
+    });
+  });
 });

--- a/core/compiler/src/pipeline/passes/02-parse/index.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/index.ts
@@ -5,13 +5,14 @@ import {
   type IRComponent,
   type IRContextDefinition,
   type IREffectDeclaration,
+  type IREventDeclaration,
   type IRExprNode,
   type IRModule,
   type IRProp,
   type PrimitiveUsage,
 } from "../../../ir/render/nodes.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
-import type { Pass } from "../../types.ts";
+import type { Pass, PassContext } from "../../types.ts";
 import type { TsProgramArtifact } from "../01-program.ts";
 import { bindPrimitives, type BindingTable } from "./bind-primitives.ts";
 import { extractDeps, extractDepsFromFunctionBody } from "./deps.ts";
@@ -65,7 +66,7 @@ export const parsePass: Pass<TsProgramArtifact, IRModule> = {
         }
       }
       const props = baseProps;
-      const events = [...baseEvents, ...setupResult.events];
+      const events = mergeEventDeclarations(baseEvents, setupResult.events, ctx);
 
       const slots = [...(optionsResult?.slots ?? []), ...setupResult.slotDeclarations];
 
@@ -132,6 +133,42 @@ export const parsePass: Pass<TsProgramArtifact, IRModule> = {
     };
   },
 };
+
+/**
+ * Merge the two places an event can be declared — the options `events` object and `defineEmits` —
+ * into one declaration per name. Concatenating them let a name declared in both emit a duplicate
+ * channel downstream (`defineEmits(["change", "change"])` on the Vue target).
+ *
+ * Precedence is **last declaration wins**, which makes `defineEmits` beat the options object since
+ * setup is parsed after options. That direction is the only lossless one: the options `events` map
+ * is `Record<string, Record<string, never>>` and declares names only, while `defineEmits<{…}>()`
+ * also carries the payload tuple that targets lower into typed signatures. The winner keeps the
+ * first declaration's **position**, so emitted event order still follows the options object's
+ * reading order. The losing declaration is reported as INK0046 (warning, like the INK0044
+ * model/prop collision above) — deduping keeps the output correct, the diagnostic tells the author
+ * which of the two to delete.
+ */
+function mergeEventDeclarations(
+  optionsEvents: readonly IREventDeclaration[],
+  setupEvents: readonly IREventDeclaration[],
+  ctx: PassContext,
+): IREventDeclaration[] {
+  const merged: IREventDeclaration[] = [];
+  const positionByName = new Map<string, number>();
+
+  for (const event of [...optionsEvents, ...setupEvents]) {
+    const position = positionByName.get(event.name);
+    if (position === undefined) {
+      positionByName.set(event.name, merged.length);
+      merged.push(event);
+      continue;
+    }
+    ctx.diagnostics.push("INK0046", merged[position]!.loc, { name: event.name });
+    merged[position] = event;
+  }
+
+  return merged;
+}
 
 function resolveDeps(
   component: IRComponent,

--- a/core/compiler/src/testing/codegen.ts
+++ b/core/compiler/src/testing/codegen.ts
@@ -121,6 +121,7 @@ export const NEW_FIXTURES = [
   "SlotInConditional",
   "ModelInput",
   "EmitButton",
+  "DuplicateEvent",
   "BoundField",
   "NativeBind",
   "MultiChildSlot",


### PR DESCRIPTION
## Summary

`02-parse` merged the options `events` object and the `defineEmits` declarations with a bare `[...baseEvents, ...setupResult.events]`. A name declared in both produced two IR entries and a duplicated channel in every target — `defineEmits(["change", "change"])` in Vue, two `onChange` callback props elsewhere. The two declarations now collapse into one, and the redundant one is reported as `INK0046`.

## Related issues

- UXF-174 (Multica). Live defect on `main`, independent of the UXF-90 / UXF-162 B2 work — surfaced while measuring B2, shipped on its own.

## Type of change

- [x] `fix` — bug fix

## Precedence rule

Last declaration wins, which makes `defineEmits` beat the options object since setup is parsed after options. That is the only lossless direction: `events?: Record<string, Record<string, never>>` declares names only, while `defineEmits<{ change: [value: string] }>()` also carries the payload tuple that `af6996e7d` just wired through to codegen. The winner keeps the **first** declaration's position, so emitted event order still follows the options object's reading order.

The redundant declaration is reported as `INK0046`, a **warning** (same shape as the existing `INK0044` model/prop collision: dedupe keeps the output correct, the diagnostic tells the author which of the two to delete). Warning, not error, so no existing build breaks. Documented in `core/compiler/README.md` → custom events.

## Failure-mode note

- **What breaks:** nothing new. A component that declared an event twice previously emitted a duplicate channel; it now emits one and warns. Components declaring events from a single source are byte-identical — `vp run -r build` regenerated all seven `ui/*` output packages with zero diff.
- **How it's detected:** `INK0046` at compile time, plus the IR-level assertions in `02-parse/index.test.ts` and the `DuplicateEvent` per-target snapshots.
- **How it recovers:** deleting either declaration clears the warning; the emitted output is already correct either way.

## Test plan

- [x] `vp run -r build` — 18/18 packages, no drift in generated `ui/*` output
- [x] `vp check` — 0 lint/type errors across 712 files; `vp fmt --check` clean
- [x] `core/compiler` — 3455/3455 across 223 files (baseline on `af6996e7d`: 3421 passed | 3 skipped)
- [x] `ui/components` — 212/212 across 25 files (matches baseline exactly)
- [x] New fixture `DuplicateEvent.ink.tsx` type-checks unexcluded, and its emitted output passes the emitted-typecheck, emitted-lint and conformance matrices (react/solid/vue/svelte)

Coverage added:
- `02-parse/index.test.ts` — collapse, payload-type precedence, `INK0046` location, single-source no-op, and a name repeated inside `defineEmits` itself
- `DuplicateEvent.ink.tsx` in `NEW_FIXTURES` → full output snapshots for all 7 targets
- `vue/__tests__/events.test.ts` — `defineEmits(["change", "close"])`, never `"change", "change"`
- `react/__tests__/events.test.ts` — one callback prop per name, `onChange?: (value: string) => void` proving the `defineEmits` declaration won

## Checklist

- [x] Added a changeset (`.changeset/dedupe-merged-event-declarations.md`, `@inkline/compiler: patch`)
- [x] Public-facing behavior documented in `core/compiler/README.md`
- [x] Conventional commit (`fix(compiler): …`)
