### PR TITLE
test(website): guard the single Tailwind pass, take the fixed layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,18 @@ jobs:
         env:
           NODE_ENV: production
 
+      # Consumes the artifact the step above produced, which is why it lives
+      # here and not in the `test` job — that job never builds the website.
+      #
+      # Guards the single-Tailwind-pass invariant: the layer's base CSS and the
+      # app's brand CSS must reach the bundle as ONE entry. Two entries emit a
+      # duplicate of every utility (437,170 B raw / 55,295 B gzip against
+      # 224,261 B / 28,573 B when this last shipped here — UXF-118); zero
+      # entries ship no utilities at all. The guard asserts exactly one, so it
+      # catches both.
+      - name: Guard compiled CSS (single Tailwind pass)
+        run: pnpm --filter website run test:build
+
       - name: Upload website build
         uses: actions/upload-artifact@v4
         with:

--- a/apps/website/app/assets/css/main.css
+++ b/apps/website/app/assets/css/main.css
@@ -1,3 +1,25 @@
+/*
+ * Single Tailwind entry for the website.
+ *
+ * The brand `@theme` below only compiles into real `:root` custom properties
+ * when it lives inside a Tailwind pass, so this file imports the layer's
+ * palette-free base — which owns the one `@import "tailwindcss"` — rather than
+ * starting a pass of its own.
+ *
+ * This must stay the ONLY registered CSS entry. A second one — a bare
+ * `@import "tailwindcss"` here, or a layer registering its own base in `css:`
+ * alongside this file — opens a second Tailwind pass that re-emits every
+ * utility. That shipped here until `@uxfront/layer-docs@0.3.0`: `entry.css`
+ * measured 437,170 B raw / 55,295 B gzip against 224,261 B / 28,573 B for the
+ * single-pass build, on a render-blocking stylesheet, on every page for every
+ * visitor (UXF-118). The cost is payload, not layout — the duplicate pass was
+ * a superset of the first and emitted wholly after it, so the cascade survived
+ * by accident.
+ *
+ * Both halves — this file being a Tailwind entry, and there being exactly one
+ * of them — are asserted by `test/brand-palette-*.test.ts` against the layer's
+ * shared preset.
+ */
 @import "@uxfront/layer-docs/app/assets/css/main.css";
 
 /*

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -8,6 +8,8 @@
     "build": "nuxt build",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
+    "test": "vp test",
+    "test:build": "vp test --config vite.build.config.ts",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {

--- a/apps/website/test/brand-palette-compiled.build.test.ts
+++ b/apps/website/test/brand-palette-compiled.build.test.ts
@@ -1,0 +1,28 @@
+import { describeSingleTailwindPass } from "@uxfront/layer-docs/test";
+
+/**
+ * Compiled-output half of the brand-palette guard: exactly one Tailwind pass in
+ * the shipped stylesheet, and the purple palette present in it.
+ *
+ * This repo is where the regression it guards actually shipped. Until
+ * `@uxfront/layer-docs@0.3.0` the layer registered its own base CSS in `css:`
+ * while this app's `main.css` imported that same base, giving the build two
+ * Tailwind entries and a byte-for-byte duplicate of every utility:
+ * `entry.css` measured 437,170 B raw / 55,295 B gzip against 224,261 B /
+ * 28,573 B for the single-pass build — +94% on a render-blocking stylesheet,
+ * on every page for every visitor (UXF-118, UXF-121).
+ *
+ * The cost is payload, not layout: the duplicate pass was a complete superset
+ * of the first and emitted wholly after it, so the last `sm:`/`lg:` variant
+ * still won by source order and a computed-style A/B across 4 pages x 4
+ * viewports found zero rendering difference. Incidental, not designed — hence
+ * the guard.
+ *
+ * Requires a prior `nuxt build`. Excluded from the default `vp test` run (see
+ * `vitest.config.ts`); runs via `test:build` in the Build Website CI job,
+ * against the artifact that job just produced.
+ */
+describeSingleTailwindPass({
+  output: new URL("../.output/public/_nuxt", import.meta.url),
+  scale: "purple",
+});

--- a/apps/website/test/brand-palette-css.test.ts
+++ b/apps/website/test/brand-palette-css.test.ts
@@ -1,0 +1,20 @@
+import { describeBrandPaletteCss } from "@uxfront/layer-docs/test";
+
+/**
+ * Source-level half of the brand-palette guard, from the layer's shared preset
+ * so all three of its consumers assert the same invariant the same way.
+ *
+ * What it guards: a Tailwind `@theme` block only compiles into real `:root`
+ * custom properties when it lives in a file that is part of a Tailwind pass. If
+ * `app/assets/css/main.css` stops importing the layer's base, the
+ * `@theme static { --color-purple … }` block ships to the browser verbatim,
+ * browsers discard the unknown at-rule, and every `*-primary` utility falls
+ * back to black/transparent site-wide.
+ *
+ * Cheap — reads one file, so it runs in the default `vp test`. The
+ * compiled-output half is `brand-palette-compiled.build.test.ts`.
+ */
+describeBrandPaletteCss({
+  entry: new URL("../app/assets/css/main.css", import.meta.url),
+  scale: "purple",
+});

--- a/apps/website/vite.build.config.ts
+++ b/apps/website/vite.build.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite-plus";
+
+// Compiled-output guards. Separate from the default `vp test` run because they
+// read `.output/` off disk and so need a prior `nuxt build`; invoked via the
+// `test:build` script from the Build Website job, against the artifact that job
+// just produced.
+//
+// `root` is pinned here so the run resolves the same way whether it is invoked
+// from this directory or from the workspace root with `--config`.
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  test: {
+    include: ["test/**/*.build.test.ts"],
+  },
+});

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite-plus";
+
+// Test config only. Nuxt does not read `vite.config.ts` — its Vite options live
+// under the `vite` key in `nuxt.config.ts` — so this file is `vp test`'s alone.
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    // Compiled-output guards read `.output/` off disk, so they fail — correctly
+    // — in a run that never built anything. They run via the `test:build`
+    // script (see `vite.build.config.ts`) from the Build Website CI job.
+    exclude: ["**/node_modules/**", "**/.output/**", "**/.nuxt/**", "test/**/*.build.test.ts"],
+  },
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ catalog:
   "@types/react": ^19.2.17
   "@types/react-dom": ^19.2.3
   "@typescript-eslint/parser": ^8.61.0
-  "@uxfront/layer-docs": ^0.1.0
+  "@uxfront/layer-docs": ^0.3.0
   "@vitejs/plugin-react": ^6.0.2
   "@vitejs/plugin-vue": ^6.0.7
   "@vitest/coverage-v8": ^4.1.8


### PR DESCRIPTION
## Summary

Consumer half of UXF-121. **Draft — blocked on `@uxfront/layer-docs@0.3.0` publishing** ([uxfront-com/uxfront#58](https://github.com/uxfront-com/uxfront/pull/58)). The catalog references `^0.3.0` and the lockfile cannot be regenerated until that version exists on npm, so CI will fail install until then.

This repo is where the double-Tailwind-pass regression actually shipped. Until 0.3.0 the layer registered its own base CSS in `css:` while `apps/website/app/assets/css/main.css` imported that same base — two Tailwind entries, and the second re-emits every utility.

## What it cost, and what it buys

| | raw | gzip |
|---|---|---|
| shipped (double pass) | 437,170 B | 55,295 B |
| fixed (single pass) | 224,593 B | 29,016 B |

−48% on a **render-blocking** stylesheet, on every page for every visitor.

The 224,593 / 29,016 figures are my own local rebuild against a packed build of the fixed layer; @filter measured 224,261 / 28,573 for the hook-fixed equivalent in UXF-118. The ~450 B gap is layer content drift — @filter measured against published `0.1.0`, this takes `0.3.0`.

Every asserted utility counts exactly 1 where the shipped build had 2 — including the `@media`-wrapped ones (`.lg\:hidden`, `.lg\:block`, `.max-lg\:hidden`), which duplicate independently of the base ones.

## Changes

- `pnpm-workspace.yaml` catalog: `@uxfront/layer-docs` `^0.1.0` → `^0.3.0`
- `apps/website/test/brand-palette-css.test.ts` — source-level guard from the layer's shared preset, purple scale. Runs in the default `vp test`; reads one file, no build.
- `apps/website/test/brand-palette-compiled.build.test.ts` — compiled-output guard. Reads `.output/`, so it runs from the `Build Website` job against the artifact that job just produced.
- `vite.config.ts` / `vite.build.config.ts` — the two runs, split. Nuxt does not read `vite.config.ts` (its Vite options live under the `vite` key in `nuxt.config.ts`), so these belong to `vp test` alone.
- CI: `Guard compiled CSS (single Tailwind pass)` step in `Build Website`.
- A docblock on `main.css` recording the single-entry contract and what breaking it cost here.

## Why `=== 1` and not `<= 1`

The same assertion catches the opposite failure — an app that never registered a CSS entry importing the layer base, and so ships no utilities at all. Since 0.3.0 makes the app solely responsible for registering the entry, that failure mode is now reachable, and it is worth catching in the same line.

## Test plan

- [x] `vp test` — 3 tests pass (verified against a packed tarball install, not a workspace symlink)
- [x] `nuxt build` clean, then `vp test --config vite.build.config.ts` — 2 tests pass
- [x] `entry.css` 437,170 → 224,593 B raw, 56,117 → 29,016 B gzip
- [x] `vp fmt` clean
- [ ] Re-run `pnpm install` to refresh the lockfile once `@uxfront/layer-docs@0.3.0` is published, then un-draft
- [ ] Visual parity job on the un-drafted PR — the payload halves but the cascade is expected unchanged; CI should confirm rather than my assertion

Refs UXF-121, UXF-118
