### PR TITLE
feat(website): ship apps/website as a static Vercel deploy (UXF-170)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,16 +133,25 @@ jobs:
         with:
           name: build-artifacts
 
+      # `generate`, not `build`: the site ships as a fully prerendered static
+      # bundle (docs/adrs/007-website-ships-as-a-static-site.md). Only `generate`
+      # emits robots.txt, sitemap.xml, 200.html and 404.html, so building the
+      # other way would leave CI green while the deploy artifact is missing
+      # exactly the files the deploy needs.
       - name: Build website
-        run: pnpm --filter website run build
+        run: pnpm --filter website run generate
         env:
           NODE_ENV: production
 
+      # `.output/public` is `generate`'s real output. The previous path,
+      # `apps/website/dist`, is an untracked symlink Nuxt only creates on
+      # `generate` — under `build` it never existed and this artifact uploaded
+      # nothing.
       - name: Upload website build
         uses: actions/upload-artifact@v4
         with:
           name: website-build
-          path: apps/website/dist
+          path: apps/website/.output/public
           retention-days: 1
 
   lint:

--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -1,0 +1,53 @@
+# apps/website — public runtime config.
+#
+# The site is deployed fully static (ADR-007), so every NUXT_PUBLIC_* value below
+# is baked into the prerendered HTML at BUILD time. Setting one only at runtime
+# does nothing — it must be present when `nuxt generate` runs, which on Vercel
+# means a Project Environment Variable, not a runtime secret.
+#
+# Copy to `.env` for local development.
+
+#
+# Site
+#
+
+# Canonical origin. Feeds sitemap.xml, robots.txt, og tags and llms.txt.
+# Defaults to `site.url` in nuxt.config.ts (https://inkline.io) when unset.
+NUXT_PUBLIC_SITE_URL=http://localhost:3000
+
+#
+# Storybook embeds
+#
+
+# Host template for the per-framework Storybook iframes rendered by
+# StorybookEmbed.vue. `{framework}` is replaced with the framework key
+# (react, vue, svelte, solid, angular, qwik, astro).
+# Empty → falls back to the convention in app/constants/storybook.ts
+# (https://{framework}.storybook.inkline.io), which is NOT live yet — see
+# UXF-170 for the hosting plan. Point it at a deployed Storybook to light the
+# embeds up without a code change.
+NUXT_PUBLIC_STORYBOOK_BASE_URL=
+
+#
+# Analytics (PostHog) — off by default
+#
+
+# @uxfront/layer-docs ships a PostHog client plugin that stays inert unless
+# `analytics.enabled` is true in app/app.config.ts AND a key is set here.
+# inkline sets neither and does not install the optional `posthog-js` peer, so
+# analytics is currently a no-op. Provision these only alongside that decision.
+# NUXT_PUBLIC_POSTHOG_KEY=
+# NUXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+# NUXT_PUBLIC_POSTHOG_DEFAULTS=2025-05-24
+
+#
+# Build
+#
+
+# Nitro output preset. `vercel_static` emits the Build Output API v3 static
+# bundle (.vercel/output) with zero serverless functions — set by vercel.json's
+# buildCommand in CI/Vercel. Unset locally; `nuxt generate` then writes to
+# .output/public instead.
+# NITRO_PRESET=vercel_static
+
+NUXT_TELEMETRY_DISABLED=1

--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -8,6 +8,14 @@ dist
 dist-ssr
 *.local
 
+# Vercel: build output (.vercel/output) and CLI project link (.vercel/project.json)
+.vercel
+
+# Local env files — .env.example is the committed template
+.env
+.env.*
+!.env.example
+
 # Node dependencies
 node_modules
 

--- a/apps/website/AGENTS.md
+++ b/apps/website/AGENTS.md
@@ -1,6 +1,6 @@
 # website
 
-The documentation and marketing site for Inkline. Private (`"private": true` in [`package.json`](./package.json)) — never published to npm. Deployed as a static site (deploy target out of scope here).
+The documentation and marketing site for Inkline. Private (`"private": true` in [`package.json`](./package.json)) — never published to npm. Deployed as a fully prerendered static site on Vercel, with zero serverless functions — see [ADR-007](../../docs/adrs/007-website-ships-as-a-static-site.md) and [`vercel.json`](./vercel.json).
 
 A Nuxt 4 + Nuxt Content app that **extends** the published [`@uxfront/layer-docs`](https://www.npmjs.com/package/@uxfront/layer-docs) layer. The theme supplies the shell (layout, left-nav, TOC, search, dark mode, mobile menu, i18n, content components); this app supplies only Inkline's brand, its section topology, and its markdown.
 
@@ -64,6 +64,14 @@ pnpm --filter website preview    # serve the built output locally
 ```
 
 The acceptance gate for this app is a clean `nitro prerender`: `nuxt generate` must finish with no errors.
+
+`generate` is the build that ships. `build` (node-server) is a local convenience only — it does not emit `robots.txt`, `sitemap.xml`, `200.html` or `404.html`, all of which the deploy needs.
+
+## Deploy
+
+Vercel, fully static. `vercel.json` sets `NITRO_PRESET=vercel_static`, which writes the Build Output API bundle to `.vercel/output` — `static/` only, no `functions/`. Copy `.env.example` to `.env` for local dev; every `NUXT_PUBLIC_*` is baked into the HTML at build time, so changing one on Vercel requires a rebuild, not a restart.
+
+The layer's `/` → `/llms.txt` content negotiation is a Nitro server plugin and cannot run here. It is re-expressed as edge rules in `nitro.vercel.config.routes` in [`nuxt.config.ts`](./nuxt.config.ts) — **not** in `vercel.json`, whose `routes`/`redirects` Vercel ignores once `.vercel/output/config.json` exists. Any future server-only behaviour the layer ships needs the same treatment or it silently no-ops; ADR-007 records this as a standing cost.
 
 ## Conventions
 

--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -36,4 +36,42 @@ export default defineNuxtConfig({
       storybookBaseUrl: "",
     },
   },
+  nitro: {
+    vercel: {
+      config: {
+        // The layer ships `/` → `/llms.txt` content negotiation as a Nitro
+        // *request* plugin (server/plugins/llms-redirect.ts). A fully static
+        // deploy (ADR-007) has no Nitro runtime, so that plugin never executes.
+        // These two rules restore the same behaviour at the CDN edge: agents
+        // asking for markdown, and curl, get the llms.txt entry point; browsers
+        // get the rendered homepage. `(?i)` makes the match case-insensitive.
+        //
+        // Build Output API v3 routes must be declared here, not in vercel.json —
+        // once .vercel/output/config.json exists, Vercel ignores vercel.json's
+        // own routes/redirects entirely.
+        //
+        // Nitro types `routes` as a narrow 3-variant union that predates `has`
+        // and redirect routes; the Build Output API accepts both, and the
+        // emitted .vercel/output/config.json carries these two entries verbatim
+        // as routes[0] and routes[1]. Drop the directives below when nitropack
+        // widens the type — ts-expect-error errors once it is unnecessary.
+        routes: [
+          {
+            src: "/",
+            has: [{ type: "header", key: "accept", value: "(?i).*text/markdown.*" }],
+            status: 302,
+            // @ts-expect-error -- nitropack's route type allows only cache-control here
+            headers: { Location: "/llms.txt" },
+          },
+          {
+            src: "/",
+            has: [{ type: "header", key: "user-agent", value: "(?i)curl/.*" }],
+            status: 302,
+            // @ts-expect-error -- nitropack's route type allows only cache-control here
+            headers: { Location: "/llms.txt" },
+          },
+        ],
+      },
+    },
+  },
 });

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nuxtjs",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile --filter website...",
+  "buildCommand": "cd ../.. && NITRO_PRESET=vercel_static pnpm --filter website run generate"
+}

--- a/docs/adrs/007-website-ships-as-a-static-site.md
+++ b/docs/adrs/007-website-ships-as-a-static-site.md
@@ -1,0 +1,138 @@
+# ADR-007: `apps/website` ships as a fully static site on Vercel
+
+Date: 2026-08-08 · Status: Accepted
+Deciders: Release/infra · Informed by: internal tracker UXF-170, UXF-158 (gap audit items 5 and 6)
+Supersedes: — · Superseded by: —
+
+## Context
+
+`apps/website` had **no deploy path at all** — no `vercel.json`, no `Dockerfile`, no `nixpacks.toml`,
+no `.env.example`. The reference implementation, styleframe `apps/docs`, ships all four and runs the
+Nuxt **node-server** output behind Nixpacks. Copying that set wholesale was the obvious move and is
+the one this ADR declines.
+
+**The host was never actually open.** inkline already runs on Vercel, verified 2026-08-08:
+`www.inkline.io` and `storybook.inkline.io` both answer with `server: Vercel`, and three Vercel
+projects are wired to this repo through the GitHub integration, posting checks on every PR
+(`inkline-io-next-storybook` → `apps/storybook`, `inkline-io-next-storybook-react` → `ui/react`,
+`inkline-io-next-storybook-vue` → `ui/vue`). So the real question was not "which host" but "which
+Nitro preset on the host we are already on."
+
+**What each mode actually emits**, measured on this app at `@uxfront/layer-docs@0.2.1`, not inferred:
+
+| artifact                         | `nuxt build` (node-server) | `nuxt generate` (static) |
+| -------------------------------- | -------------------------- | ------------------------ |
+| `index.html`, 4 docs pages       | prerendered file           | prerendered file         |
+| `llms.txt`, `llms-full.txt`      | prerendered file           | prerendered file         |
+| `/raw/**.md` (4 agent endpoints) | prerendered file           | prerendered file         |
+| `robots.txt`                     | runtime handler            | **static file**          |
+| `sitemap.xml`                    | runtime handler            | **static file**          |
+| `200.html`, `404.html`           | **absent**                 | static file              |
+
+This corrects the gap audit, which recorded that plain `build` emits none of the sitemap/robots/llms
+set. It emits most of it: `llms.txt`, `llms-full.txt` and the `/raw/**.md` endpoints are prerendered
+under both modes. The genuine delta is four files — `robots.txt`, `sitemap.xml`, `200.html`,
+`404.html` — plus two behaviours that only exist with a running Nitro:
+
+1. `/raw/<path>.md` for any path **not** prerendered at build time. Nothing in the app links to
+   `/raw/*`, and the content set is fully known at build time, so today this is reachable only by
+   typing a URL that does not correspond to a page.
+2. The layer's `/` → `/llms.txt` content negotiation
+   (`server/plugins/llms-redirect.ts`), which fires on Nitro's `request` hook.
+
+**The cost of keeping a server, priced on Vercel.** Building with `NITRO_PRESET=vercel` produced
+**41 MB across 11 serverless functions** — `__fallback`, `__nuxt_error`, `robots.txt`, `sitemap.xml`,
+`raw`, `[lang]`, `_ipx` and more — each a 36 MB copy of the same Nitro bundle, each embedding two
+native binaries: `better-sqlite3` (Nuxt Content's database driver) and `sharp`. `NITRO_PRESET=vercel_static`
+produced **4.8 MB and zero functions**: 8.5× smaller, with no native module in the request path.
+
+Native SQLite inside a serverless function is the fragile part. It is the configuration Nuxt Content
+warns about for serverless targets, and it exists here to serve a docs site with **zero request-time
+data** — every byte is derivable from markdown in the repo at build time.
+
+**The steelman for node-server, which is real.** styleframe already runs it, so a second mode means
+two deploy shapes across two repos, and the `@uxfront/layer-docs` maintainers write server code (the
+`llms-redirect` plugin's own docblock says "we deploy the node-server output"). Divergence means the
+layer can ship a runtime feature that silently no-ops for inkline. That risk is accepted below, with
+a revisit trigger, because the alternative is paying for a runtime that this site's content model
+does not need.
+
+## Decision
+
+`apps/website` deploys as a **fully static, prerendered site on Vercel**, built with
+`nuxt generate` under `NITRO_PRESET=vercel_static`. No `Dockerfile` and no `nixpacks.toml` are added
+— they describe a container runtime this app will not have.
+
+Landed with it:
+
+- **`apps/website/vercel.json`** — `framework: nuxtjs`, install and build commands run from the
+  monorepo root so pnpm resolves the single root lockfile.
+- **`apps/website/.env.example`** — the `NUXT_PUBLIC_*` surface, documenting that in static mode
+  these are **build-time** values baked into the prerendered HTML, not runtime configuration.
+- **`nitro.vercel.config.routes` in `nuxt.config.ts`** — restores the `/` → `/llms.txt` content
+  negotiation as two Build Output API edge rules, matching `Accept: text/markdown` and `curl/*`.
+  These must live in `nuxt.config.ts`: once `.vercel/output/config.json` exists, Vercel ignores
+  `vercel.json`'s own `routes`/`redirects` entirely.
+- **CI** — `build-website` now runs `generate` and uploads `.output/public`. It previously ran
+  `build` and uploaded `apps/website/dist`, a symlink only `generate` creates, so the artifact was
+  empty.
+
+The sitemap/robots/llms gap in the audit is closed **by this decision**, not by separate work: all
+four files fall out of `generate`.
+
+## Consequences
+
+**Good.**
+
+- Zero serverless functions, so zero cold starts, zero function invocations to pay for, and no
+  native `better-sqlite3` or `sharp` in the request path. The whole site is CDN-cacheable.
+- A broken deploy cannot be a runtime failure. If the content is wrong the build fails; nothing that
+  passed the build can fail in production for a request-shaped reason.
+- `robots.txt`, `sitemap.xml` and `404.html` are files in the artifact, greppable in CI, and
+  identical in preview and production — not the output of a handler that could behave differently
+  per environment.
+- Rollback is a Vercel instant rollback to a previous immutable static deployment. Nothing to drain,
+  no state to reconcile.
+- The deploy artifact is inspectable before it ships: `.vercel/output/static` is exactly what serves.
+
+**Bad.**
+
+- **The layer can ship server behaviour that silently no-ops here.** `llms-redirect.ts` is already an
+  instance; we caught it and replaced it with edge rules, but the next one will not announce itself.
+  Nothing in CI detects "the layer added a server route and inkline is static." That is a standing
+  divergence cost between this app and styleframe, paid on every layer upgrade.
+- **`/raw/<path>.md` is now closed-world.** Only prerendered paths resolve; anything else 404s. If a
+  future consumer expects to construct those URLs for arbitrary content paths, this decision breaks
+  it, and the fix is a mode change rather than a config tweak.
+- **Build time grows with page count and every deploy is a full rebuild.** At the audit's 4 content
+  files this is 4 seconds for 22 routes. At styleframe's 200 files it is minutes, and there is no
+  incremental path without moving to ISR — which means functions, which means reopening this ADR.
+- **Two deploy shapes across two repos.** styleframe on node-server, inkline on static. Anyone
+  debugging "why does it work there and not here" now has one more axis to check, and the shared
+  layer's docs describe the other one.
+- **Content search depends on the client-side SQLite WASM path**, not a server query. That is Nuxt
+  Content's supported static mode and it works, but it ships the content index to the browser — a
+  payload that grows with the corpus and has no server-side fallback to degrade to.
+
+**Neutral.**
+
+- `apps/website/AGENTS.md` already described the app as "Deployed as a static site (deploy target out
+  of scope here)." This ADR makes that stated intent real and names the target; it does not reverse a
+  prior decision.
+- `posthog-js` stays uninstalled and analytics stays off. Static vs node-server does not bear on it —
+  the layer's plugin is client-side either way.
+
+## Revisit triggers
+
+Written now, before the first deploy:
+
+- **The docs need any request-time data** — auth, a form endpoint, per-user content, or a search
+  backend that cannot ship its index to the client. That is the boundary this decision is drawn at,
+  and crossing it is a supersede, not an exception.
+- **A full rebuild exceeds ~10 minutes**, or the content corpus passes roughly 500 pages. Then the
+  "every deploy is a full rebuild" cost above has arrived and ISR/hybrid rendering needs pricing.
+- **`@uxfront/layer-docs` ships a second server-only feature** that matters to inkline. One
+  (`llms-redirect`) was worth an edge-rule workaround; a pattern of them means the layer assumes a
+  runtime and inkline should stop fighting that.
+- **Vercel stops being inkline's host.** The static artifact is portable to any static host, but the
+  `nitro.vercel.config` edge rules are not, and they would need re-expressing.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -14,6 +14,7 @@ pays for the same lesson twice.
 | [004](./004-inkline-check-does-not-type-check.md)                     | `inkline check` does not type-check; `tsc` owns types                   | 2026-07-28 | Accepted   | cli, types, dx            |
 | [005](./005-generated-component-authoring-types.md)                   | Keep `InkComponent`'s index signature; generate authoring types         | 2026-08-06 | Superseded | core, compiler, authoring |
 | [006](./006-inferred-component-authoring-types.md)                    | Authoring types are inferred from `defineComponent`, not generated      | 2026-08-08 | Accepted   | core, compiler, authoring |
+| [007](./007-website-ships-as-a-static-site.md)                        | `apps/website` ships as a fully static site on Vercel                   | 2026-08-08 | Accepted   | website, deploy, infra    |
 
 ## Rules
 


### PR DESCRIPTION
Closes UXF-170.

`apps/website` had **no deploy path at all** — no `vercel.json`, no `.env.example`, and a CI job
uploading `apps/website/dist`, a symlink only `generate` creates, so that artifact was always empty.

The obvious move was to copy styleframe `apps/docs`'s artifact set (Dockerfile + nixpacks.toml +
vercel.json, node-server behind Nixpacks). This PR declines that, and the reason is measured, not
asserted.

## The host was never open

inkline already runs on Vercel. `www.inkline.io` and `storybook.inkline.io` both answer with
`server: Vercel`, and three Vercel projects are wired to this repo through the GitHub integration
and post checks on every PR (`inkline-io-next-storybook` → `apps/storybook`,
`inkline-io-next-storybook-react` → `ui/react`, `inkline-io-next-storybook-vue` → `ui/vue`). The
real question was which Nitro preset, not which host.

## What each mode actually emits

Measured on this app at `@uxfront/layer-docs@0.2.1`:

| artifact | `nuxt build` (node-server) | `nuxt generate` (static) |
| --- | --- | --- |
| `index.html`, 4 docs pages | prerendered file | prerendered file |
| `llms.txt`, `llms-full.txt` | prerendered file | prerendered file |
| `/raw/**.md` (4 agent endpoints) | prerendered file | prerendered file |
| `robots.txt` | runtime handler | **static file** |
| `sitemap.xml` | runtime handler | **static file** |
| `200.html`, `404.html` | **absent** | static file |

This corrects the gap audit on UXF-158, which recorded that plain `build` emits none of the
sitemap/robots/llms set. It emits most of it. The genuine delta is four files plus two runtime-only
behaviours.

## The cost of keeping a server, priced

| | `NITRO_PRESET=vercel` | `NITRO_PRESET=vercel_static` |
| --- | --- | --- |
| total size | 41 MB | **4.8 MB** |
| serverless functions | 11 × 36 MB | **0** |
| native modules in request path | `better-sqlite3`, `sharp` | none |

Eleven functions — `__fallback`, `__nuxt_error`, `robots.txt`, `sitemap.xml`, `raw`, `[lang]`,
`_ipx` and more — each a copy of the same Nitro bundle with two native binaries, to serve a docs
site with **zero request-time data**. Every byte is derivable from markdown in the repo at build
time.

## What landed

- **`apps/website/vercel.json`** — `framework: nuxtjs`; install and build run from the monorepo
  root so pnpm resolves the single root lockfile.
- **`apps/website/.env.example`** — the `NUXT_PUBLIC_*` surface, documenting that in static mode
  these are **build-time** values baked into the HTML, not runtime config.
- **`nitro.vercel.config.routes` in `nuxt.config.ts`** — restores the layer's `/` → `/llms.txt`
  content negotiation (a Nitro *request* plugin, which a static deploy cannot run) as two Build
  Output API edge rules. These must live here: once `.vercel/output/config.json` exists, Vercel
  ignores `vercel.json`'s own `routes`/`redirects` entirely.
- **`apps/website/.gitignore`** — `.vercel` and `.env*` were ignored **nowhere** in this repo
  (`git check-ignore` returned nothing), which made committing `.env.example` a secret-leak
  footgun. Fixed.
- **CI `build-website`** — now runs `generate` and uploads `.output/public`.
- **ADR-007** — the decision, the measurements, and the costs accepted.

No `Dockerfile`, no `nixpacks.toml`: they describe a container runtime this app will not have.

## Verification

```
$ NITRO_PRESET=vercel_static pnpm --filter website run generate
Prerendered 24 routes in 4.335 seconds
✔ Generated public .vercel/output/static

$ du -sh .vercel/output              →  4.8M
$ ls .vercel/output/functions        →  No such file or directory
$ ls .vercel/output/static           →  200.html 404.html robots.txt sitemap.xml
                                        llms.txt llms-full.txt raw/ docs/ index.html …
```

Served locally, every route 200s: `/`, `/robots.txt`, `/sitemap.xml`, `/llms.txt`,
`/docs/components/button`, `/raw/docs/components/button.md`. `robots.txt` carries
`Sitemap: https://inkline.io/sitemap.xml`; `sitemap.xml` is valid XML.

The two edge rules emit as `routes[0]` and `routes[1]` in `config.json`, ahead of the cache
handlers, with `functions/` absent.

Browser check on the served bundle: pages render and hydrate, the framework switcher is
interactive, and there are **no hydration errors** — `grep -rl 'Could not resolve "posthog-js"'
.output/public/_nuxt/` returns nothing, confirming the layer 0.2.1 fix. The only console errors are
the Storybook embed 404s (audit item 6, reported separately, not in scope here).

## Notes for review

- **Depends on #565** (`@uxfront/layer-docs@^0.2.1` lockfile bump) landing first. This branch is
  based on `main` for a clean diff, but the build above was verified at 0.2.1. The two PRs touch
  disjoint files.
- **Overlaps UXF-169 item 5.** The `build-website` CI fix is also on @palette's cleanup list —
  whichever lands second should drop it.
- The `@ts-expect-error` pair in `nuxt.config.ts` is deliberate: nitropack types
  `VercelBuildConfigV3["routes"]` as a narrow 3-variant union that predates `has` and redirect
  routes. The directives are self-cleaning — they will error once nitropack widens the type.
- **This does not point `inkline.io` at anything.** Cutover is UXF-173.
