### PR TITLE
feat(core): add the type-only models declaration channel with INK0094 drift diagnostic

### DIFF
--- a/.changeset/declared-models-channel.md
+++ b/.changeset/declared-models-channel.md
@@ -1,0 +1,19 @@
+---
+"@inkline/core": minor
+"@inkline/compiler": minor
+---
+
+feat(core): add the type-only `models` declaration channel with INK0094 drift diagnostic
+
+`ComponentOptions` now accepts `models?: Record<string, PropDeclaration>`, so a parent's type-checker
+can see the two-way models a component's setup body creates with `defineModel` at JSX attribute
+position (`open`, `$bind:open`) without the child having to hand-write props.
+
+The key is a **type-only channel**: the compiler emits models from the setup body's `defineModel`
+calls alone, so declaring it changes no emitted output on any of the seven targets — asserted by
+compiling the same body with and without the key and requiring byte-identical files.
+
+Because nothing downstream reads it, a drifted entry would compile clean on both sides while teaching
+a parent a shape the compiler never emits. The new `INK0094` warning reports that disagreement: a
+name declared but never created, a name created but never declared, or a declared type that
+contradicts the `defineModel` type argument.

--- a/core/compiler/README.md
+++ b/core/compiler/README.md
@@ -919,6 +919,7 @@ The codes below are the ones most authors hit. For the complete, always-current 
 | INK0085 | error    | Unknown target. Lists the valid targets and suggests the closest match.                                                                 |
 | INK0086 | error    | Target is not present in the configured registry.                                                                                       |
 | INK0090 | error    | A plugin threw an exception.                                                                                                            |
+| INK0094 | warning  | The options object's type-only `models` map disagrees with the setup body's `defineModel` calls.                                        |
 | INK0100 | error    | Parse failure in a component. That component is skipped; the others in the module still compile.                                        |
 
 Run `inkline check <file>` to check without producing output.

--- a/core/compiler/src/__fixtures__/DeclaredModels.ink.tsx
+++ b/core/compiler/src/__fixtures__/DeclaredModels.ink.tsx
@@ -1,0 +1,17 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+// The type-only `models` key, agreeing with the setup body. It exists so a parent's checker sees
+// `open` / `$bind:open` at JSX attribute position; the compiler never reads it, so the emitted
+// output is identical with or without the key on every target.
+export default defineComponent({ models: { open: Boolean } }, () => {
+  const [open, setOpen] = defineModel<boolean>("open");
+  return (
+    <button
+      type="button"
+      aria-expanded={open() ? "true" : "false"}
+      onClick={() => setOpen(!open())}
+    >
+      Toggle
+    </button>
+  );
+});

--- a/core/compiler/src/__fixtures__/Diag_ModelDeclaredOnly.ink.tsx
+++ b/core/compiler/src/__fixtures__/Diag_ModelDeclaredOnly.ink.tsx
@@ -1,0 +1,16 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+// `expanded` is declared in the type-only `models` map but no defineModel call creates it: a parent
+// would see `$bind:expanded` at JSX attribute position and bind to a prop no target emits — INK0094.
+export default defineComponent({ models: { open: Boolean, expanded: Boolean } }, () => {
+  const [open, setOpen] = defineModel<boolean>("open");
+  return (
+    <button
+      type="button"
+      aria-expanded={open() ? "true" : "false"}
+      onClick={() => setOpen(!open())}
+    >
+      Toggle
+    </button>
+  );
+});

--- a/core/compiler/src/__fixtures__/Diag_ModelSetupOnly.ink.tsx
+++ b/core/compiler/src/__fixtures__/Diag_ModelSetupOnly.ink.tsx
@@ -1,0 +1,21 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+// The setup body creates a second model, `size`, that the `models` map does not declare: the compiler
+// emits the prop and its update event, but a parent's checker never learns about it — INK0094.
+export default defineComponent({ models: { open: Boolean } }, () => {
+  const [open, setOpen] = defineModel<boolean>("open");
+  const [size, setSize] = defineModel<string>("size");
+  return (
+    <button
+      type="button"
+      data-size={size()}
+      aria-expanded={open() ? "true" : "false"}
+      onClick={() => {
+        setOpen(!open());
+        setSize("lg");
+      }}
+    >
+      Toggle
+    </button>
+  );
+});

--- a/core/compiler/src/__fixtures__/Diag_ModelTypeDrift.ink.tsx
+++ b/core/compiler/src/__fixtures__/Diag_ModelTypeDrift.ink.tsx
@@ -1,0 +1,12 @@
+import { defineComponent, defineModel } from "@inkline/core";
+
+// Both sides name `count`, but the type-only declaration says `String` where defineModel says
+// `number`: a parent binding to it type-checks against a shape the compiler never emits — INK0094.
+export default defineComponent({ models: { count: String } }, () => {
+  const [count, setCount] = defineModel<number>("count");
+  return (
+    <button type="button" onClick={() => setCount(count() + 1)}>
+      {count()}
+    </button>
+  );
+});

--- a/core/compiler/src/__fixtures__/scenarios.ts
+++ b/core/compiler/src/__fixtures__/scenarios.ts
@@ -146,6 +146,25 @@ export const scenarios: Readonly<Record<string, readonly Scenario[]>> = {
   Diag_SetupLocalDrop: [
     { name: "triggers INK0121", asserts: { expectedDiagnostics: ["INK0121"] } },
   ],
+  // The three ways the type-only `models` map can drift from the setup body's defineModel calls.
+  Diag_ModelDeclaredOnly: [
+    {
+      name: "triggers INK0094 (declared, never created)",
+      asserts: { expectedDiagnostics: ["INK0094"] },
+    },
+  ],
+  Diag_ModelSetupOnly: [
+    {
+      name: "triggers INK0094 (created, never declared)",
+      asserts: { expectedDiagnostics: ["INK0094"] },
+    },
+  ],
+  Diag_ModelTypeDrift: [
+    {
+      name: "triggers INK0094 (declared type disagrees)",
+      asserts: { expectedDiagnostics: ["INK0094"] },
+    },
+  ],
   Diag_ComponentRef: [{ name: "compiles without error (ref forwarding supported)", asserts: {} }],
 
   // ── v1: Component refs ──

--- a/core/compiler/src/core/diagnostics/codes.test.ts
+++ b/core/compiler/src/core/diagnostics/codes.test.ts
@@ -39,6 +39,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0086",
       "INK0087",
       "INK0090",
+      "INK0094",
       "INK0100",
       "INK0110",
       "INK0111",
@@ -85,7 +86,7 @@ describe("DIAGNOSTICS catalog", () => {
     }
   });
 
-  it("codes with title placeholders: INK0030, INK0044, INK0072, INK0073, INK0080, INK0081, INK0082, INK0083, INK0085, INK0086, INK0087, INK0090, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
+  it("codes with title placeholders: INK0030, INK0044, INK0072, INK0073, INK0080, INK0081, INK0082, INK0083, INK0085, INK0086, INK0087, INK0090, INK0094, INK0100, INK0110, INK0111, INK0120, INK0121", () => {
     const withPlaceholders = codes.filter((c) => /\{\w+\}/.test(DIAGNOSTICS[c].title));
     expect(withPlaceholders.sort()).toEqual([
       "INK0030",
@@ -100,6 +101,7 @@ describe("DIAGNOSTICS catalog", () => {
       "INK0086",
       "INK0087",
       "INK0090",
+      "INK0094",
       "INK0100",
       "INK0110",
       "INK0111",

--- a/core/compiler/src/core/diagnostics/codes.ts
+++ b/core/compiler/src/core/diagnostics/codes.ts
@@ -215,6 +215,12 @@ export const DIAGNOSTICS = {
     help: "The hook is skipped and compilation continues without its contribution. Re-run with --verbose for the stack trace; a plugin should report recoverable problems with ctx.pushDiagnostic(diagnostic) rather than throwing." as const,
     url: "https://docs.inkline.dev/diagnostics/INK0090" as const,
   },
+  INK0094: {
+    severity: "warning" as const,
+    title: "Declared model '{name}' does not match the setup body: {reason}" as const,
+    help: "options.models is a type-only channel — the compiler emits models from the setup body's defineModel calls alone, so a drifted entry misleads a parent's type-checker while changing no output. Make the entry agree with its defineModel call, or drop it." as const,
+    url: "https://docs.inkline.dev/diagnostics/INK0094" as const,
+  },
   INK0100: {
     severity: "error" as const,
     title: "Parse failure in component '{name}': {message}" as const,

--- a/core/compiler/src/ir/render/nodes.ts
+++ b/core/compiler/src/ir/render/nodes.ts
@@ -276,6 +276,22 @@ export interface IRModelDeclaration {
   readonly loc: SourceLocation;
 }
 
+/**
+ * One entry of the options object's `models` map — the type-only channel that lets a parent's
+ * checker see what the setup body's `defineModel` creates. Deliberately plain data: it is compared
+ * against {@link IRModelDeclaration} and never emitted.
+ */
+export interface IRDeclaredModel {
+  /** The model's prop name — the map key, which the `defineModel` argument must match. */
+  readonly name: string;
+  /**
+   * The declared type, resolved through the same constructor table as props (`Number` → `number`).
+   * `undefined` when the declaration carries no type the compiler can name.
+   */
+  readonly typeText?: string;
+  readonly loc: SourceLocation;
+}
+
 export interface IRStateDeclaration {
   readonly name: string;
   readonly setterName: string;
@@ -385,6 +401,13 @@ export interface IRComponent {
   readonly slots: readonly IRSlotDeclaration[];
   readonly events: readonly IREventDeclaration[];
   readonly models: readonly IRModelDeclaration[];
+  /**
+   * The options object's `models` key, when the author wrote one. It exists so a parent's
+   * type-checker can see the setup body's models; **no target reads it and none may start** —
+   * `models` above stays the only source codegen consumes. Carried here solely so P4 can report
+   * drift between the two (INK0094).
+   */
+  readonly declaredModels?: readonly IRDeclaredModel[];
   /** Local name bound to the `defineEmits()` result, so codegen can rewrite `emit(name, …)` calls. */
   readonly emitName?: string;
   readonly state: readonly IRStateDeclaration[];

--- a/core/compiler/src/pipeline/compile.test.ts
+++ b/core/compiler/src/pipeline/compile.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "./compile.ts";
 import type { Plugin } from "../plugin/types.ts";
-import type { GeneratedFile, Target } from "../codegen/context.ts";
+import { ALL_TARGETS, type GeneratedFile, type Target } from "../codegen/context.ts";
 import { createRegistry } from "../codegen/registry.ts";
 import { InklineConfigError } from "../core/diagnostics/error.ts";
 import { UNKNOWN_LOCATION } from "../ir/types.ts";
@@ -875,5 +875,85 @@ describe("named type imports from .ink files", () => {
       );
       expect(main!.contents, `${target} should not contain .ink`).not.toMatch(/\.ink[."']/);
     }
+  });
+});
+
+// `options.models` is a type-only channel: it teaches a parent's checker what `defineModel` creates
+// and nothing else. Nothing downstream of P4 may start reading it, so the guarantee is asserted the
+// only way that cannot rot — compile the same body twice, once with the key and once without, and
+// require byte-identical output on every target.
+describe("options.models is emit-invariant", () => {
+  const body = `() => {
+      const [open, setOpen] = defineModel<boolean>("open");
+      return <button type="button" onClick={() => setOpen(!open())}>{open() ? "on" : "off"}</button>;
+    }`;
+  const sourceFor = (options: string): string => `
+    import { defineComponent, defineModel } from "@inkline/core";
+    export default defineComponent(${options}${body});
+  `;
+
+  it("emits byte-identical files with and without the key on every target", async () => {
+    const withKey = await compile(
+      { fileName: "T.ink.tsx", source: sourceFor(`{ models: { open: Boolean } }, `) },
+      { targets: ALL_TARGETS },
+    );
+    const without = await compile(
+      { fileName: "T.ink.tsx", source: sourceFor("") },
+      { targets: ALL_TARGETS },
+    );
+
+    for (const target of ALL_TARGETS) {
+      const a = withKey.files[target]!;
+      const b = without.files[target]!;
+      expect(a.length, `${target} file count`).toBe(b.length);
+      for (const [i, file] of a.entries()) {
+        expect(file.path, `${target} file ${i} path`).toBe(b[i]!.path);
+        expect(file.contents, `${target} file ${i} contents`).toBe(b[i]!.contents);
+      }
+    }
+  });
+
+  it("an agreeing declaration adds no diagnostics", async () => {
+    const result = await compile(
+      { fileName: "T.ink.tsx", source: sourceFor(`{ models: { open: Boolean } }, `) },
+      { targets: ["react"] },
+    );
+    expect(result.diagnostics.map((d) => d.code)).not.toContain("INK0094");
+  });
+
+  it("reports INK0094 on drift without changing what is emitted", async () => {
+    const drifted = await compile(
+      {
+        fileName: "T.ink.tsx",
+        source: sourceFor(`{ models: { open: Boolean, expanded: Boolean } }, `),
+      },
+      { targets: ["react"] },
+    );
+    const clean = await compile(
+      { fileName: "T.ink.tsx", source: sourceFor("") },
+      {
+        targets: ["react"],
+      },
+    );
+
+    expect(drifted.diagnostics.map((d) => d.code)).toContain("INK0094");
+    expect(drifted.files.react![0]!.contents).toBe(clean.files.react![0]!.contents);
+  });
+
+  it("leaves INK0044 alone — a prop collision still reports, and only once", async () => {
+    const source = `
+      import { defineComponent, defineModel } from "@inkline/core";
+      export default defineComponent(
+        { models: { value: String } },
+        (props: { value?: string }) => {
+          const [value, setValue] = defineModel<string>("value");
+          return <input value={value()} onInput={() => setValue(props.value ?? "")} />;
+        },
+      );
+    `;
+    const result = await compile({ fileName: "T.ink.tsx", source }, { targets: ["react"] });
+    const codes = result.diagnostics.map((d) => d.code);
+    expect(codes.filter((c) => c === "INK0044")).toHaveLength(1);
+    expect(codes).not.toContain("INK0094");
   });
 });

--- a/core/compiler/src/pipeline/passes/02-parse/index.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/index.ts
@@ -94,6 +94,9 @@ export const parsePass: Pass<TsProgramArtifact, IRModule> = {
         slots,
         events,
         models: setupResult.models,
+        // Type-only: carried for the P4 drift check (INK0094), read by nothing else. `models` above
+        // stays the single source every target emits from.
+        declaredModels: optionsResult?.declaredModels,
         emitName: setupResult.emitName,
         state: setupResult.state,
         refs: setupResult.refs,

--- a/core/compiler/src/pipeline/passes/02-parse/model-emit.test.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/model-emit.test.ts
@@ -76,6 +76,68 @@ describe("defineModel parsing", () => {
     );
     expect(ctx.diagnostics.freeze().some((d) => d.code === "INK0044")).toBe(true);
   });
+
+  // The type-only `models` key is parsed in the same pass as INK0044's prop-collision check and must
+  // not interact with it — the collision is still the author's problem either way.
+  it("still warns (INK0044) when the collision is also declared in options.models", async () => {
+    const ctx = makeCtx();
+    await parse(
+      `
+        import { defineComponent, defineModel } from "@inkline/core";
+        export default defineComponent(
+          { models: { value: String } },
+          (props: { value?: string }) => {
+            const [value, setValue] = defineModel<string>("value");
+            return <input value={value()} onInput={(e) => setValue(props.value ?? "")} />;
+          },
+        );
+      `,
+      ctx,
+    );
+    expect(ctx.diagnostics.freeze().some((d) => d.code === "INK0044")).toBe(true);
+  });
+});
+
+describe("options.models parsing", () => {
+  it("records the declared entries without touching component.models", async () => {
+    const comp = (
+      await parse(`
+        import { defineComponent, defineModel } from "@inkline/core";
+        export default defineComponent({ models: { open: Boolean } }, () => {
+          const [open, setOpen] = defineModel<boolean>("open");
+          return <button onClick={() => setOpen(!open())}>{open() ? "on" : "off"}</button>;
+        });
+      `)
+    ).components[0]!;
+    expect(comp.declaredModels).toEqual([
+      expect.objectContaining({ name: "open", typeText: "boolean" }),
+    ]);
+    // The setup body stays the single source every target emits from.
+    expect(comp.models.map((m) => m.propName)).toEqual(["open"]);
+  });
+
+  it("leaves declaredModels undefined when the author wrote no models key", async () => {
+    const comp = (await parse(MODEL_SOURCE)).components[0]!;
+    expect(comp.declaredModels).toBeUndefined();
+  });
+
+  it("reads the type off a full { type, … } declaration", async () => {
+    const comp = (
+      await parse(`
+        import { defineComponent, defineModel } from "@inkline/core";
+        export default defineComponent(
+          { models: { count: { type: Number, required: true } } },
+          () => {
+            const [count, setCount] = defineModel<number>("count");
+            return <button onClick={() => setCount(count() + 1)}>{count()}</button>;
+          },
+        );
+      `)
+    ).components[0]!;
+    expect(comp.declaredModels![0]).toEqual(
+      expect.objectContaining({ name: "count", typeText: "number" }),
+    );
+  });
 });
 
 describe("defineEmits parsing", () => {

--- a/core/compiler/src/pipeline/passes/02-parse/options.ts
+++ b/core/compiler/src/pipeline/passes/02-parse/options.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { DYNAMIC_DEPS } from "../../../ir/reactivity.ts";
 import type {
+  IRDeclaredModel,
   IREventDeclaration,
   IRExprNode,
   IRProp,
@@ -13,6 +14,8 @@ import { toLoc } from "./loc.ts";
 
 export interface ParsedOptions {
   readonly props?: IRProp[];
+  /** `undefined` when the author wrote no `models` key — absent is not the same as empty here. */
+  readonly declaredModels?: IRDeclaredModel[];
   readonly slots: IRSlotDeclaration[];
   readonly events: IREventDeclaration[];
   readonly styles: IRStyleBlock[];
@@ -40,6 +43,7 @@ export function parseOptions(
   ctx: PassContext,
 ): ParsedOptions {
   let props: IRProp[] | undefined;
+  let declaredModels: IRDeclaredModel[] | undefined;
   const slots: IRSlotDeclaration[] = [];
   const events: IREventDeclaration[] = [];
   const styles: IRStyleBlock[] = [];
@@ -52,6 +56,9 @@ export function parseOptions(
     switch (prop.name.text) {
       case "props":
         props = parsePropsFromObject(prop.initializer, componentId, sourceFile, ctx);
+        break;
+      case "models":
+        declaredModels = parseDeclaredModelsFromObject(prop.initializer, sourceFile);
         break;
       case "slots":
         slots.push(...parseSlotsFromObject(prop.initializer, sourceFile));
@@ -87,7 +94,44 @@ export function parseOptions(
     }
   }
 
-  return { props, slots, events, styles, runtime, headless };
+  return { props, declaredModels, slots, events, styles, runtime, headless };
+}
+
+/**
+ * Reads the type-only `models` map. Nothing downstream of this emits it — the entries exist only to
+ * be compared against the setup body's `defineModel` calls by P4 (INK0094).
+ */
+function parseDeclaredModelsFromObject(
+  value: ts.Expression,
+  sourceFile: ts.SourceFile,
+): IRDeclaredModel[] {
+  if (!ts.isObjectLiteralExpression(value)) return [];
+
+  const declared: IRDeclaredModel[] = [];
+
+  for (const member of value.properties) {
+    if (!ts.isPropertyAssignment(member) || !ts.isIdentifier(member.name)) continue;
+
+    const init = member.initializer;
+    // Same three forms as a prop declaration: a constructor reference, a full `{ type, … }` shape,
+    // or a bare default value.
+    const typeText = ts.isObjectLiteralExpression(init)
+      ? declaredShapeType(init)
+      : inferPropType(init);
+
+    declared.push({ name: member.name.text, typeText, loc: toLoc(member, sourceFile) });
+  }
+
+  return declared;
+}
+
+/** The `type:` of a full prop shape, resolved through the constructor table. */
+function declaredShapeType(obj: ts.ObjectLiteralExpression): string | undefined {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+    if (prop.name.text === "type") return inferPropType(prop.initializer);
+  }
+  return undefined;
 }
 
 function parseStyleFromValue(
@@ -202,7 +246,7 @@ function isConstructorRef(node: ts.Expression): boolean {
   );
 }
 
-const CONSTRUCTOR_TYPES: Readonly<Record<string, string>> = {
+export const CONSTRUCTOR_TYPES: Readonly<Record<string, string>> = {
   String: "string",
   Number: "number",
   Boolean: "boolean",

--- a/core/compiler/src/pipeline/passes/04-analyze/index.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/index.ts
@@ -5,6 +5,7 @@ import {
   diagnoseCycles,
   validateAttrFallthrough,
   validateComponent,
+  validateDeclaredModels,
   validateSetupLocals,
 } from "./validate.ts";
 
@@ -26,6 +27,7 @@ export const analyzePass: Pass<IRModule, AnalyzedModule> = {
       validateComponent(component, ctx);
       validateAttrFallthrough(component, localComponents, ctx);
       validateSetupLocals(component, ctx);
+      validateDeclaredModels(component, ctx);
       diagnoseCycles(component, graph, ctx);
     }
 
@@ -38,5 +40,6 @@ export {
   validateComponent,
   validateAttrFallthrough,
   validateSetupLocals,
+  validateDeclaredModels,
   diagnoseCycles,
 } from "./validate.ts";

--- a/core/compiler/src/pipeline/passes/04-analyze/validate.test.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/validate.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
 import { UNKNOWN_LOCATION } from "../../../ir/types.ts";
 import { DYNAMIC_DEPS, SymbolTable, type SymbolId } from "../../../ir/reactivity.ts";
-import type { IRComponent, IRExprNode, IRMemoDeclaration } from "../../../ir/render/nodes.ts";
+import type {
+  IRComponent,
+  IRExprNode,
+  IRMemoDeclaration,
+  IRModelDeclaration,
+} from "../../../ir/render/nodes.ts";
 import { createDiagnosticCollector } from "../../../core/diagnostics/collector.ts";
 import { resolveOptions } from "../../../core/options.ts";
 import { builtinRegistry } from "../../../codegen/registry.ts";
@@ -16,7 +21,12 @@ import {
   createText,
 } from "../../../ir/render/builders.ts";
 import { buildReactivityGraph } from "./graph.ts";
-import { diagnoseCycles, validateAttrFallthrough, validateComponent } from "./validate.ts";
+import {
+  diagnoseCycles,
+  validateAttrFallthrough,
+  validateComponent,
+  validateDeclaredModels,
+} from "./validate.ts";
 
 function mockExpr(code = "x"): ts.Expression {
   const sf = ts.createSourceFile("t.ts", code, ts.ScriptTarget.Latest, true);
@@ -401,5 +411,134 @@ describe("diagnoseCycles", () => {
     const graph = buildReactivityGraph(comp);
     diagnoseCycles(comp, graph, ctx);
     expect(ctx.diagnostics.freeze()).toHaveLength(0);
+  });
+});
+
+describe("validateDeclaredModels", () => {
+  function typeNode(text: string): ts.TypeNode {
+    const sf = ts.createSourceFile(`t.ts`, `let x: ${text};`, ts.ScriptTarget.Latest, true);
+    const decl = (sf.statements[0] as ts.VariableStatement).declarationList.declarations[0]!;
+    return decl.type!;
+  }
+
+  function model(propName: string, type?: string): IRModelDeclaration {
+    return {
+      name: propName,
+      setterName: `set${propName}`,
+      propName,
+      getterSymbolId: `${propName}-get` as SymbolId,
+      setterSymbolId: `${propName}-set` as SymbolId,
+      typeNode: type ? typeNode(type) : undefined,
+      loc: UNKNOWN_LOCATION,
+    };
+  }
+
+  function declared(name: string, typeText?: string) {
+    return { name, typeText, loc: UNKNOWN_LOCATION };
+  }
+
+  it("is silent when the author wrote no models key", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(makeComp({ models: [model("open", "boolean")] }), ctx);
+    expect(ctx.diagnostics.freeze()).toHaveLength(0);
+  });
+
+  it("is silent when both sides agree", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("open", "boolean")],
+        declaredModels: [declared("open", "boolean")],
+      }),
+      ctx,
+    );
+    expect(ctx.diagnostics.freeze()).toHaveLength(0);
+  });
+
+  it("pushes INK0094 for a name declared but never created", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("open", "boolean")],
+        declaredModels: [declared("open", "boolean"), declared("expanded", "boolean")],
+      }),
+      ctx,
+    );
+    const diags = ctx.diagnostics.freeze();
+    expect(diags).toHaveLength(1);
+    expect(diags[0]!.code).toBe("INK0094");
+    expect(diags[0]!.title).toContain("expanded");
+    expect(diags[0]!.title).toContain("no defineModel");
+  });
+
+  it("pushes INK0094 for a name created but never declared", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("open", "boolean"), model("size", "string")],
+        declaredModels: [declared("open", "boolean")],
+      }),
+      ctx,
+    );
+    const diags = ctx.diagnostics.freeze();
+    expect(diags).toHaveLength(1);
+    expect(diags[0]!.code).toBe("INK0094");
+    expect(diags[0]!.title).toContain("size");
+    expect(diags[0]!.title).toContain("does not declare it");
+  });
+
+  it("pushes INK0094 when the declared type disagrees", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("count", "number")],
+        declaredModels: [declared("count", "string")],
+      }),
+      ctx,
+    );
+    const diags = ctx.diagnostics.freeze();
+    expect(diags).toHaveLength(1);
+    expect(diags[0]!.code).toBe("INK0094");
+    expect(diags[0]!.title).toContain("declared as string");
+    expect(diags[0]!.title).toContain("types it as number");
+  });
+
+  // `options.models` can only spell constructor-derived types, so `Object` is the closest available
+  // declaration for a model typed `MyShape`. Flagging that would make the channel unusable.
+  it("does not flag a type options.models cannot express", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("value", "MyShape")],
+        declaredModels: [declared("value", "Record<string, any>")],
+      }),
+      ctx,
+    );
+    expect(ctx.diagnostics.freeze()).toHaveLength(0);
+  });
+
+  it("does not flag an untyped declaration or an untyped defineModel", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("a"), model("b", "number")],
+        declaredModels: [declared("a", "string"), declared("b")],
+      }),
+      ctx,
+    );
+    expect(ctx.diagnostics.freeze()).toHaveLength(0);
+  });
+
+  it("reports every drifted entry, not just the first", () => {
+    const ctx = makeCtx();
+    validateDeclaredModels(
+      makeComp({
+        models: [model("count", "number"), model("size", "string")],
+        declaredModels: [declared("count", "string"), declared("expanded", "boolean")],
+      }),
+      ctx,
+    );
+    const diags = ctx.diagnostics.freeze();
+    expect(diags.map((d) => d.code)).toEqual(["INK0094", "INK0094", "INK0094"]);
   });
 });

--- a/core/compiler/src/pipeline/passes/04-analyze/validate.ts
+++ b/core/compiler/src/pipeline/passes/04-analyze/validate.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 import type { IRComponent, IRExprNode } from "../../../ir/render/nodes.ts";
 import { walkRenderTree } from "../../../ir/render/visit.ts";
 import { emittedSetupNames, setupLocalDefs } from "../../../ir/setup.ts";
+import { CONSTRUCTOR_TYPES } from "../02-parse/options.ts";
 import type { PassContext } from "../../types.ts";
 import type { ReactivityGraph } from "./graph.ts";
 
@@ -149,6 +150,63 @@ export function validateSetupLocals(component: IRComponent, ctx: PassContext): v
       if (!emitted.has(name) && referenced.has(name)) {
         ctx.diagnostics.push("INK0121", s.loc, { name });
       }
+    }
+  }
+}
+
+/**
+ * The type spellings `options.models` is able to express, so a disagreement with one of them is a
+ * real one. A model typed `MyShape` or `"a" | "b"` in the setup body has no `PropDeclaration` that
+ * says the same thing — `Object` is the closest available and is not wrong — so those are left
+ * alone rather than reported as drift.
+ */
+const COMPARABLE_TYPES: ReadonlySet<string> = new Set(Object.values(CONSTRUCTOR_TYPES));
+
+/**
+ * INK0094: the options object's `models` map disagrees with the `defineModel` calls in the setup
+ * body. `options.models` is a type-only channel — no target reads it — so nothing else would ever
+ * notice: a drifted entry teaches a parent's type-checker a shape the compiler will not emit, and
+ * compiles clean on both sides. Only components that opted into the channel are checked; a setup
+ * body with no `models` key is declaring nothing and is not drift.
+ */
+export function validateDeclaredModels(component: IRComponent, ctx: PassContext): void {
+  const declared = component.declaredModels;
+  if (!declared) return;
+
+  const actual = new Map(component.models.map((m) => [m.propName, m]));
+
+  for (const entry of declared) {
+    const model = actual.get(entry.name);
+    if (!model) {
+      ctx.diagnostics.push("INK0094", entry.loc, {
+        name: entry.name,
+        reason: `no defineModel("${entry.name}") call in the setup body creates it`,
+      });
+      continue;
+    }
+
+    const actualType = model.typeNode?.getText();
+    if (
+      entry.typeText &&
+      actualType &&
+      COMPARABLE_TYPES.has(entry.typeText) &&
+      COMPARABLE_TYPES.has(actualType) &&
+      entry.typeText !== actualType
+    ) {
+      ctx.diagnostics.push("INK0094", entry.loc, {
+        name: entry.name,
+        reason: `declared as ${entry.typeText}, but defineModel types it as ${actualType}`,
+      });
+    }
+  }
+
+  const declaredNames = new Set(declared.map((d) => d.name));
+  for (const model of component.models) {
+    if (!declaredNames.has(model.propName)) {
+      ctx.diagnostics.push("INK0094", model.loc, {
+        name: model.propName,
+        reason: "the setup body creates it, but options.models does not declare it",
+      });
     }
   }
 }

--- a/core/core/src/index.ts
+++ b/core/core/src/index.ts
@@ -106,6 +106,16 @@ export interface ComponentOptions {
    * The setup parameter's type is inferred from this map, so it must not be annotated.
    */
   props?: Record<string, PropDeclaration>;
+  /**
+   * Declares the two-way models the setup body creates with `defineModel`, so a parent's
+   * type-checker can see them at JSX attribute position.
+   *
+   * **Type-only channel.** The compiler never reads this key — models are emitted from the setup
+   * body's `defineModel` calls alone — so declaring it changes no output on any target. That also
+   * means an entry can drift from what the setup body actually declares; the compiler reports the
+   * disagreement as `INK0094` rather than trusting either side.
+   */
+  models?: Record<string, PropDeclaration>;
   slots?: Record<string, { scoped?: boolean; required?: boolean }>;
   events?: Record<string, Record<string, never>>;
   /** Scoped CSS for the component, as a plain string or template literal. */


### PR DESCRIPTION
## Summary

Adds `models?: Record<string, PropDeclaration>` to `ComponentOptions` so a parent's type-checker can see the two-way models a child creates with `defineModel` at JSX attribute position (`open`, `$bind:open`), and adds `INK0094` to report when that declaration drifts from what the setup body actually declares.

Step 1 of 3 in the ADR-006 / UXF-162 B2 rollout. No components are migrated here (UXF-177) and `InkComponent`'s index signature is untouched (UXF-178).

## Related issues

- Refs UXF-176, parent UXF-90, ADR-006

## Type of change

- [x] `feat` — new user-facing capability or public API

## Design

**The key is type-only by construction.** `component.models` still comes solely from `setupResult.models` — the setup body's `defineModel` calls — and nothing in lowering, codegen, or any of the seven targets reads the declaration. It is carried to P4 as a plain-data `IRComponent.declaredModels` (no `ts` nodes beyond a `SourceLocation`, optional and additive, so no `IR_VERSION` bump) purely so the drift check has something to compare against.

That guarantee is **asserted, not assumed**: `compile.test.ts` compiles the same body twice — once with the key, once without — across all seven targets and requires byte-identical file paths and contents.

**INK0094** (P4, `warning`, same shape as INK0044) reports the three ways the two sides can disagree:

| Drift | Message |
| --- | --- |
| declared, never created | `no defineModel("expanded") call in the setup body creates it` |
| created, never declared | `the setup body creates it, but options.models does not declare it` |
| type disagreement | `declared as string, but defineModel types it as number` |

Types are compared **only** when both sides spell something `options.models` is capable of expressing (the constructor table's values). A model typed `MyShape` or `"a" \| "b"` has no `PropDeclaration` that says the same thing — `Object` is the closest available and is not wrong — so those are left alone rather than reported as false drift.

Components that wrote no `models` key are skipped entirely, so the un-migrated corpus stays silent.

## Failure modes

- **A future pass starts reading `options.models`.** Caught by the byte-identical emit test across all seven targets, which fails the moment output diverges.
- **Over-eager type comparison.** Guarded by `COMPARABLE_TYPES` plus a unit test asserting `Record<string, any>` declared against a `MyShape` model is silent.
- **INK0094 crowding out INK0044.** Regression-asserted at both parse level and full-pipeline level: a model colliding with a hand-declared prop still reports INK0044 exactly once, and adds no INK0094.
- **Diagnostic ships an unresolved `{placeholder}`.** Covered by the existing corpus-wide gate in `conformance.test.ts`, which now runs over the three new drift fixtures.

## Test plan

- [x] `core/compiler` — **3496 passed / 223 files** (baseline 3421 + 3 skipped; the 3 skipped now run after the `@inkline/core` rebuild)
- [x] `core/core` — 52/52 · `ui/components` — 212/212
- [x] `core/compiler` type check — **14 errors in 435 files** (baseline 14 in 431; all four new fixtures are type-clean and need no `typecheck-exclusions.ts` entry)
- [x] `core/core` type check — 0 errors
- [x] `vp fmt` / `vp lint` — no new findings
- [x] Fixtures: `DeclaredModels` (agreeing, clean, runs the full per-target conformance matrix) + `Diag_ModelDeclaredOnly` / `Diag_ModelSetupOnly` / `Diag_ModelTypeDrift` (registered in `scenarios.ts` with `expectedDiagnostics: ["INK0094"]`)

## Checklist

- [x] Added a changeset (`.changeset/declared-models-channel.md`, minor for `@inkline/core` + `@inkline/compiler`)
- [x] `core/compiler/README.md` diagnostics table updated with INK0094
- [x] Commit message follows the conventional format
