### PR TITLE
fix(website): mechanical cleanup pass on apps/website (UXF-169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,16 +133,24 @@ jobs:
         with:
           name: build-artifacts
 
+      # `generate`, not `build`: the site is statically hosted, and prerendering
+      # every route is what catches broken content, 404s and render errors — the
+      # class of defect a docs build should fail on.
       - name: Build website
-        run: pnpm --filter website run build
+        run: pnpm --filter website run generate
         env:
           NODE_ENV: production
 
+      # `nuxt generate` emits `.output/public`; `apps/website/dist` is only a
+      # symlink to it and was never produced by `nuxt build`, so this step used
+      # to log "No files were found with the provided path" and upload nothing.
+      # `include-hidden-files` is required because `.output` is a dot-directory.
       - name: Upload website build
         uses: actions/upload-artifact@v4
         with:
           name: website-build
-          path: apps/website/dist
+          path: apps/website/.output/public
+          include-hidden-files: true
           retention-days: 1
 
   lint:

--- a/apps/website/app/app.config.ts
+++ b/apps/website/app/app.config.ts
@@ -7,6 +7,11 @@ export default defineAppConfig({
    */
   seo: {
     title: "Inkline",
+    // @ts-expect-error the layer reads `seo.titleTemplate` in its `app.vue`, but
+    // its `AppConfig` augmentation only declares `title`/`description`. The key
+    // works; the type is incomplete upstream. (Latent until now: TypeScript
+    // skipped the excess-property check on this literal while every nested value
+    // was assignable.) Delete this directive once the layer widens the type.
     titleTemplate: "%s - Inkline",
     description:
       "Write-once, compile-everywhere UI components for React, Vue, Svelte, Solid, Angular, Qwik and Astro.",
@@ -32,6 +37,12 @@ export default defineAppConfig({
   github: {
     url: "https://github.com/inkline/inkline",
     branch: "main",
+    // Path from the repository root to this Nuxt app. The layer builds the
+    // "Edit this page" href as
+    // `{url}/edit/{branch}/{rootDir}/content/{stem}.{extension}`; with `rootDir`
+    // unset the segment is dropped and every link 404s, because the content
+    // lives at `apps/website/content/`, not `content/`.
+    rootDir: "apps/website",
   },
   footer: {
     credits: `Copyright © ${new Date().getFullYear()} Inkline`,
@@ -44,6 +55,25 @@ export default defineAppConfig({
       primary: "purple",
       neutral: "slate",
     },
+    // Nuxt UI's `UContentSearch` falls back to `t('contentSearch.title')` and
+    // `t('contentSearch.description')` for the search modal's accessible name
+    // and description, but its own catalogue (`@nuxt/ui/locale/en`) only ships
+    // `contentSearch.links|search|theme` — the two keys resolve to nothing and
+    // the raw key strings are what a screen reader announces. Supplying the
+    // props here is the fix: `useComponentProps` reads `defaultVariants` as
+    // app-config-level prop defaults, and the layer's `AppSearch` passes
+    // neither prop. (Not an i18n-registration problem — no Nuxt UI locale
+    // defines these keys, so `@nuxtjs/i18n` would not change this.)
+    contentSearch: {
+      defaultVariants: {
+        // @ts-expect-error Nuxt UI types `defaultVariants` as tailwind-variants
+        // keys only (`fullscreen`, `size`), but `useComponentProps` reads it for
+        // any prop at runtime. Verified in a browser — see the PR. Delete this
+        // directive once @nuxt/ui widens the type.
+        title: "Search documentation",
+        description: "Search the Inkline documentation by page title or content.",
+      },
+    },
   },
   // Consumer-declared framework list for the package's generalized
   // FrameworkSwitcher (UXF-13). Inkline compiles to these seven, in this order
@@ -52,8 +82,9 @@ export default defineAppConfig({
     frameworks: [
       { value: "react", label: "React", icon: "i-mdi-react" },
       { value: "vue", label: "Vue", icon: "i-mdi-vuejs" },
-      // MDI has no Svelte brand glyph; use the simple-icons set (both resolve
-      // via the Iconify API — no local @iconify-json/* collection is installed).
+      // MDI has no Svelte brand glyph; use the simple-icons set. Both sets are
+      // installed locally (see package.json), so `icon.serverBundle: "local"`
+      // resolves them at build time instead of via api.iconify.design.
       { value: "svelte", label: "Svelte", icon: "i-simple-icons-svelte" },
       { value: "solid", label: "Solid", icon: "i-mdi-atom" },
       { value: "angular", label: "Angular", icon: "i-mdi-angular" },

--- a/apps/website/app/assets/css/main.css
+++ b/apps/website/app/assets/css/main.css
@@ -1,6 +1,14 @@
 @import "@uxfront/layer-docs/app/assets/css/main.css";
 
 /*
+ * `@source` re-scans this app's own content + config for utility classes: the
+ * layer's `@source` paths are package-relative (they resolve inside
+ * node_modules), so they never see the consumer's markdown or app.config.
+ */
+@source "../../../content/**/*";
+@source "../../app.config.ts";
+
+/*
  * Inkline brand palette. The layer-docs package ships neutral (palette-free);
  * this consumer supplies the purple scale and maps it onto Nuxt UI's
  * --ui-primary. The base hue is derived from the committed brand mark

--- a/apps/website/content/docs/01.getting-started/01.installation.md
+++ b/apps/website/content/docs/01.getting-started/01.installation.md
@@ -5,8 +5,6 @@ navigation:
   title: Getting Started
 ---
 
-# Getting Started
-
 Inkline is **write-once, compile-everywhere**. You author a component once in a
 `.ink.tsx` file, and the compiler emits idiomatic output for React, Vue 3,
 Svelte 5, Solid, Angular, Qwik, and Astro. The generated components carry no

--- a/apps/website/content/docs/02.guide/01.architecture.md
+++ b/apps/website/content/docs/02.guide/01.architecture.md
@@ -5,8 +5,6 @@ navigation:
   title: Architecture
 ---
 
-# Architecture
-
 Inkline is a compiler, not a runtime. A single `.ink.tsx` source is parsed into a
 language-agnostic intermediate representation (IR), analyzed once, then emitted
 per target. The frameworks never share a runtime — each gets idiomatic,

--- a/apps/website/content/docs/03.components/01.button.md
+++ b/apps/website/content/docs/03.components/01.button.md
@@ -5,8 +5,6 @@ navigation:
   title: Button
 ---
 
-# Button
-
 The Button is an action element with color, variant and size options, plus
 `disabled`, `loading` and `block` states. It is authored once in `.ink.tsx` and
 compiled to all seven frameworks.

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -11,6 +11,9 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@iconify-json/lucide": "^1.2.121",
+    "@iconify-json/mdi": "^1.2.3",
+    "@iconify-json/simple-icons": "^1.2.93",
     "@nuxt/content": "^3.14.0",
     "@nuxt/image": "^1.11.0",
     "@nuxt/kit": "^4.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,15 @@ importers:
 
   apps/website:
     dependencies:
+      '@iconify-json/lucide':
+        specifier: ^1.2.121
+        version: 1.2.121
+      '@iconify-json/mdi':
+        specifier: ^1.2.3
+        version: 1.2.3
+      '@iconify-json/simple-icons':
+        specifier: ^1.2.93
+        version: 1.2.93
       '@nuxt/content':
         specifier: ^3.14.0
         version: 3.15.0(@farmfe/core@1.7.11(@types/node@26.1.1))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(better-sqlite3@12.11.1)(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.0.0-rc.17)(rollup@4.62.0)(valibot@1.4.1(@typescript/typescript6@6.0.2))(vite@8.0.10(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.99.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.19))
@@ -3193,6 +3202,15 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/lucide@1.2.121':
+    resolution: {integrity: sha512-zSoQQSmsyFaeTpSwURHJ9PIrsDcGFpDNhGlpiTrs+Ua4uFeH5UsE26L4OEBLrgLWoSK0UO+JhsO8yehSw0403g==}
+
+  '@iconify-json/mdi@1.2.3':
+    resolution: {integrity: sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==}
+
+  '@iconify-json/simple-icons@1.2.93':
+    resolution: {integrity: sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==}
 
   '@iconify/collections@1.0.711':
     resolution: {integrity: sha512-atGUurchVFc/O3fHhpDCrPAe30TLEbWBDkuM5ZXjr0720rLpVNTqydyvMxQS3lt5kvIwrYgHqLInZ1F26y9n5A==}
@@ -17609,6 +17627,18 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/lucide@1.2.121':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/mdi@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/simple-icons@1.2.93':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify/collections@1.0.711':
     dependencies:


### PR DESCRIPTION
> **Stacked on #565.** Base is `agent/signal/9c67ca6a`, not `main`. #565 is still open (UXF-168, @merge's to land), and item 3 below touches `apps/website/package.json` + `pnpm-lock.yaml` — the same lines. Rebase onto `main` and retarget once #565 merges. **Do not merge this before #565.**

## Summary

Six independent mechanical fixes to `apps/website`, one commit each, from @signal's gap audit on UXF-158 (items 8–12, 16). No new features, no content authoring, no deploy config.

| # | Fix | Commit |
| --- | --- | --- |
| 1 | Tailwind never scanned the app's own markdown or `app.config.ts` | `e06a3d27c` |
| 2 | Every "Edit this page" link 404'd | `a2f6dd2f7` |
| 3 | 43 icons fetched at runtime from `api.iconify.design` | `b99c80001` |
| 4 | Two `<h1>` per docs page | `e25b388ed` |
| 5 | CI uploaded an empty website artifact | `4818b6106` |
| 6 | Search modal announced `contentSearch.title` to screen readers | `a2f6dd2f7` |

### 1 — `@source` directives

The layer's own `@source` paths are package-relative, so they resolve inside `node_modules` and never see the consumer's content. Added `@source "../../../content/**/*"` and `@source "../../app.config.ts"`, matching styleframe's `apps/docs`. Any utility class written in markdown or in `app.config.ts` was being purged.

### 2 — `github.rootDir`

The layer builds the href as `{url}/edit/{branch}/{rootDir}/content/{stem}.{extension}`. With `rootDir` unset the segment is dropped, so links pointed at `.../edit/main/content/docs/...` while the content lives at `apps/website/content/`.

```
before  https://github.com/inkline/inkline/edit/main/content/docs/components/01.button.md   → 404
after   https://github.com/inkline/inkline/edit/main/apps/website/content/docs/components/01.button.md
```

**Per-consumer, not a layer default** — the layer cannot know a consumer's directory layout, and inferring it from the git root is a separate uxfront change. styleframe has the identical bug; fixed there in **styleframe-dev/styleframe#332**.

### 3 — Local icon collections

`@iconify-json/lucide`, `/mdi` and `/simple-icons` added to `dependencies`. The layer sets `icon.serverBundle: "local"`, but with no collection installed every icon fell through to the network.

```
[nuxt:icon] ✔ Nuxt Icon discovered local-installed 3 collections: lucide, mdi, simple-icons
[nuxt:icon] ℹ Nuxt Icon client bundle consist of 43 icons with 10.40KB (uncompressed)
```

43 matches the audit's count exactly. Browser network panel filtered on `iconify`: zero requests. `grep -c api.iconify.design` on the prerendered HTML: 0.

`lucide` is pinned to `^1.2.121`, not `^1.2.122`. 1.2.122 was published under the repo's 24h `minimumReleaseAge` threshold, and pnpm's response is to silently append an entry to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` — a supply-chain guard bypass landing in a docs PR. Pinning one patch back resolves cleanly with `pnpm-workspace.yaml` untouched.

### 4 — Duplicate `<h1>`

The layer's `UPageHeader` already renders frontmatter `title` as the page `<h1>`; each docs page then repeated it as a markdown `# Title`. Two `<h1>` is an SEO signal conflict and a screen-reader heading-outline defect. Removed from the three docs pages; `content/index.md` is deliberately untouched — the landing page renders through the layer's catch-all with a bare `<ContentRenderer>`, so its `# Inkline` is the only `<h1>` there.

Prerendered `<h1>` count is now exactly 1 on `installation`, `architecture`, `button` and `index`.

### 5 — CI artifact — confirmed before, then fixed

**Confirmed first.** `pnpm --filter website run build` locally produces `.output/` and no `dist` — that symlink is a `nuxt generate` artifact. On the last green `main` run (`31240854588`) the artifact list holds `build-artifacts`, `storybook-build` and the two visual-parity reports, and no `website-build`. The job log:

```
##[warning]No files were found with the provided path: apps/website/dist. No artifacts will be uploaded.
```

**Chose `generate` over repointing the path at `.output`.** The site is statically hosted, and prerendering every route is what catches broken content links, 404s and render errors — the class of defect a docs build should fail on. Repointing the path would have kept a green job that never renders a page. Upload now targets `.output/public` with `include-hidden-files: true`, required because `.output` is a dot-directory.

### 6 — Search modal accessible name

**The audit's root cause is wrong, and it matters.** This is not a missing `@nuxtjs/i18n` registration. Nuxt UI's `ContentSearch` resolves these keys through its *own* `useLocale()` catalogue:

```vue
:title="props.title || t('contentSearch.title')"
:description="props.description || t('contentSearch.description')"
```

and `@nuxt/ui/dist/runtime/locale/en.js` ships only `contentSearch.links | .search | .theme`. No Nuxt UI locale defines `title` or `description` — registering `@nuxtjs/i18n` would not have changed a character. The layer's `AppSearch` passes neither prop, so the raw key strings became the dialog's accessible name and description.

Fixed by supplying the props through app config: `useComponentProps` falls back to `appConfig.ui.<component>.defaultVariants[prop]` for any prop, not just tv variants.

Verified in a browser on the prerendered output, both directions:

```
before  {"title":"contentSearch.title","desc":"contentSearch.description"}
after   {"title":"Search documentation","desc":"Search the Inkline documentation by page title or content."}
```

Both strings sit on `DialogTitle`/`DialogDescription` behind a custom slot, so they are visually hidden — the DOM read is the proof, not a screenshot.

**Two `@ts-expect-error` directives ride along**, each documenting a real upstream type gap and each self-removing when upstream catches up:

- Nuxt UI types `defaultVariants` as tailwind-variants keys only, though `useComponentProps` reads it for any prop.
- The layer's `AppConfig` augmentation declares `seo` as `{ title, description }` though its own `app.vue` reads `seo.titleTemplate`. This one is pre-existing and was latent: TypeScript skips the excess-property check on the literal while every nested value is assignable, so the first genuine nested error made it visible.

`vp check` reports 652 errors on this branch and 652 on the base — **zero in `apps/website`** either way.

**Follow-up, not in this PR (S, ~1 day):** register `@nuxtjs/i18n` in the layer so `useDocusI18n` activates. That unlocks the layer's 30 shipped locales and the locale switcher, and lets consumers override Nuxt UI's own catalogue properly instead of per-component prop defaults. It belongs in the uxfront repo, touches routing (`[[lang]]` prefix strategy) and the per-locale content collections, and needs its own visual pass — genuinely separate work.

## Related issues

- Closes UXF-169
- Blocked by #565 (UXF-168)
- Cross-repo companion: styleframe-dev/styleframe#332

## Type of change

- [ ] `feat` — new user-facing capability or public API
- [x] `fix` — bug fix
- [ ] `refactor` — internal change, no behavior change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `chore` / `ci` — tooling, dependencies, or CI

## Test plan

- [x] `pnpm --filter website generate` — exit 0, 24 routes prerendered, no errors
- [x] `npx vp check --no-fmt --no-lint` — 652 errors, identical to base, none in `apps/website`
- [x] `vp check --fix` (lint-staged pre-commit) passes on every commit
- [x] Prerendered `<h1>` count is 1 on all three docs pages and on `index`
- [x] Edit link resolves to a real file path on GitHub
- [x] Zero `api.iconify.design` requests, verified in the browser network panel and by grep over the prerendered HTML
- [x] Search dialog accessible name and description read as English, verified in a browser before and after

## Checklist

- [x] No changeset — `apps/website` is private and unpublished; nothing here changes a published package's behavior, API or types.
- [x] No `AGENTS.md` / `docs/*.md` update needed — no change to public API, build flow, conventions or repo structure. The CI change fixes an upload path that was never documented.
- [x] Commit messages follow the conventional format.
